### PR TITLE
refactor: remove sortBy parameter from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Lightweight API to parse NHL fantasy league (FFHL) team stats and print combined
    - Report type can be provided as a path segment:
       - `/seasons/regular` or `/seasons/playoffs` (default: `regular` when omitted)
 
-`/players/season/:reportType/:season/:sortBy` - Get player stats for a single season
+`/players/season/:reportType/:season` - Get player stats for a single season
 
-`/players/combined/:reportType/:sortBy` - Get player stats combined (repository data starting from 12-13 season). Includes a 'seasons' array with individual season stats, each of which also has its own per-season `score`, `scoreAdjustedByGames`, and `scores` metadata.
+`/players/combined/:reportType` - Get player stats combined (repository data starting from 12-13 season). Includes a 'seasons' array with individual season stats, each of which also has its own per-season `score`, `scoreAdjustedByGames`, and `scores` metadata.
 
-`/goalies/season/:reportType/:season/:sortBy` - Get goalie stats for a single season
+`/goalies/season/:reportType/:season` - Get goalie stats for a single season
 
-`/goalies/combined/:reportType/:sortBy` - Get goalie stats combined (repository data starting from 12-13 season, goal against average and save percentage NOT included as combined!). Includes a 'seasons' array with individual season stats, each of which also has its own per-season `score`, `scoreAdjustedByGames`, and `scores` metadata (including per-season `gaa` and `savePercent` when available).
+`/goalies/combined/:reportType` - Get goalie stats combined (repository data starting from 12-13 season, goal against average and save percentage NOT included as combined!). Includes a 'seasons' array with individual season stats, each of which also has its own per-season `score`, `scoreAdjustedByGames`, and `scores` metadata (including per-season `gaa` and `savePercent` when available).
 
 Every API except `/teams` have optional query params:
 `teamId` (default: `1`) - if provided, check other than this repo maintainers data. teamId's are defined in `constants.ts` file `TEAMS` definition.
@@ -329,8 +329,6 @@ curl -H "Authorization: Bearer <your-key>" http://localhost:3000/seasons
 `teamId` - Optional query param. Selects which team dataset to use (CSV folder `csv/<teamId>/`). If missing or unknown, defaults to `DEFAULT_TEAM_ID`.
 
 `season` - Optional. Needed only in single season endpoint. Starting year of the season want to check. If not specified, latest available season will show.
-
-`sortBy` - Optional. Sort results by specific stats field. Currently available options: games, goals, assists, points, penalties, ppp, shp for both. shots, plusMinus, hits, blocks for players only and wins, saves, shutouts for goalies only. If not specified, sort by points (players) and by wins (goalies).
 
 ## Caching
 

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -168,20 +168,6 @@ describe("helpers", () => {
       },
     ];
 
-    test("sorts players by specified field (goals) descending", () => {
-      const result = sortItemsByStatField([...players], "players", "goals") as Player[];
-      expect(result[0].name).toBe("Player B");
-      expect(result[1].name).toBe("Player C");
-      expect(result[2].name).toBe("Player A");
-    });
-
-    test("returns players unsorted when sortBy is name", () => {
-      const result = sortItemsByStatField([...players], "players", "name") as Player[];
-      expect(result[0].name).toBe("Player A");
-      expect(result[1].name).toBe("Player B");
-      expect(result[2].name).toBe("Player C");
-    });
-
     test("sorts players by default (points desc, then goals desc)", () => {
       const playersWithTie: Player[] = [
         { ...players[0], points: 80, goals: 25 },
@@ -192,20 +178,6 @@ describe("helpers", () => {
       expect(result[0].name).toBe("Player C"); // 100 points
       expect(result[1].name).toBe("Player B"); // 80 points, 35 goals
       expect(result[2].name).toBe("Player A"); // 80 points, 25 goals
-    });
-
-    test("sorts goalies by specified field (saves) descending", () => {
-      const result = sortItemsByStatField([...goalies], "goalies", "saves") as Goalie[];
-      expect(result[0].name).toBe("Goalie B");
-      expect(result[1].name).toBe("Goalie C");
-      expect(result[2].name).toBe("Goalie A");
-    });
-
-    test("returns goalies unsorted when sortBy is name", () => {
-      const result = sortItemsByStatField([...goalies], "goalies", "name") as Goalie[];
-      expect(result[0].name).toBe("Goalie A");
-      expect(result[1].name).toBe("Goalie B");
-      expect(result[2].name).toBe("Goalie C");
     });
 
     test("sorts goalies by default (wins desc, then games desc)", () => {

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -317,7 +317,6 @@ describe("routes", () => {
         params: {
           reportType: "regular",
           season: "2024",
-          sortBy: "goals",
         },
       });
       const res = createResponse();
@@ -326,7 +325,7 @@ describe("routes", () => {
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
-      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, "goals", "1");
+      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
     });
 
@@ -388,7 +387,7 @@ describe("routes", () => {
 
       await getPlayersSeason(req, res);
 
-      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, undefined, "1");
+      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
     });
   });
@@ -400,14 +399,14 @@ describe("routes", () => {
       (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
 
       const req = createRequest({
-        params: { reportType: "regular", sortBy: "points" },
+        params: { reportType: "regular" },
       });
       const res = createResponse();
 
       await getPlayersCombined(req, res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "points", "1");
+      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
     });
 
@@ -439,21 +438,6 @@ describe("routes", () => {
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
 
-    test("passes sortBy to service correctly", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
-
-      const req = createRequest({
-        params: { reportType: "playoffs", sortBy: "goals" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(req, res);
-
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("playoffs", "goals", "1");
-    });
-
     test("works without sortBy parameter", async () => {
       const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
       (reportTypeAvailable as jest.Mock).mockReturnValue(true);
@@ -466,7 +450,7 @@ describe("routes", () => {
 
       await getPlayersCombined(req, res);
 
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", undefined, "1");
+      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1");
     });
   });
 
@@ -479,7 +463,7 @@ describe("routes", () => {
       (getGoaliesStatsSeason as jest.Mock).mockResolvedValue(mockGoalies);
 
       const req = createRequest({
-        params: { reportType: "regular", season: "2024", sortBy: "wins" },
+        params: { reportType: "regular", season: "2024" },
       });
       const res = createResponse();
 
@@ -487,7 +471,7 @@ describe("routes", () => {
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
-      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, "wins", "1");
+      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
     });
 
@@ -549,7 +533,7 @@ describe("routes", () => {
 
       await getGoaliesSeason(req, res);
 
-      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, undefined, "1");
+      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
     });
   });
 
@@ -560,14 +544,14 @@ describe("routes", () => {
       (getGoaliesStatsCombined as jest.Mock).mockResolvedValue(mockGoalies);
 
       const req = createRequest({
-        params: { reportType: "regular", sortBy: "wins" },
+        params: { reportType: "regular" },
       });
       const res = createResponse();
 
       await getGoaliesCombined(req, res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "wins", "1");
+      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
     });
 
@@ -611,7 +595,7 @@ describe("routes", () => {
 
       await getGoaliesCombined(req, res);
 
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", undefined, "1");
+      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1");
     });
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -67,15 +67,15 @@ describe("services", () => {
     });
 
     test("fetches player stats and sorts by specified field", async () => {
-      const result = await getPlayersStatsSeason("regular", 2024, "goals");
+      const result = await getPlayersStatsSeason("regular", 2024);
 
       expect(mapPlayerData).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players", "goals");
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
       expect(result).toEqual([mockPlayer]);
     });
 
     test("uses max season when season is undefined", async () => {
-      await getPlayersStatsSeason("regular", undefined, "goals");
+      await getPlayersStatsSeason("regular", undefined);
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledWith(
@@ -89,7 +89,7 @@ describe("services", () => {
       (applyPlayerScores as jest.Mock).mockImplementation((data) => data);
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
 
-      const result = await getPlayersStatsSeason("regular", undefined, "goals");
+      const result = await getPlayersStatsSeason("regular", undefined);
 
       expect(result).toEqual([]);
       expect((csv as unknown as jest.Mock)).toHaveBeenCalledTimes(0);
@@ -98,12 +98,12 @@ describe("services", () => {
     test("works without sortBy parameter", async () => {
       const result = await getPlayersStatsSeason("regular", 2024);
 
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players", undefined);
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
       expect(result).toEqual([mockPlayer]);
     });
 
     test("constructs correct CSV file path", async () => {
-      await getPlayersStatsSeason("playoffs", 2023, "points");
+      await getPlayersStatsSeason("playoffs", 2023);
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledWith(
@@ -125,15 +125,15 @@ describe("services", () => {
     });
 
     test("fetches goalie stats and sorts by specified field", async () => {
-      const result = await getGoaliesStatsSeason("regular", 2024, "wins");
+      const result = await getGoaliesStatsSeason("regular", 2024);
 
       expect(mapGoalieData).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies", "wins");
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
       expect(result).toEqual([mockGoalie]);
     });
 
     test("uses max season when season is undefined", async () => {
-      await getGoaliesStatsSeason("regular", undefined, "wins");
+      await getGoaliesStatsSeason("regular", undefined);
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledWith(
@@ -144,7 +144,7 @@ describe("services", () => {
     test("works without sortBy parameter", async () => {
       const result = await getGoaliesStatsSeason("regular", 2024);
 
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies", undefined);
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
       expect(result).toEqual([mockGoalie]);
     });
   });
@@ -162,16 +162,16 @@ describe("services", () => {
     });
 
     test("fetches player stats for all available seasons", async () => {
-      const result = await getPlayersStatsCombined("regular", "points");
+      const result = await getPlayersStatsCombined("regular");
 
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(mapCombinedPlayerData).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players", "points");
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
       expect(result).toEqual([mockPlayer]);
     });
 
     test("reads CSV files for all seasons", async () => {
-      await getPlayersStatsCombined("regular", "points");
+      await getPlayersStatsCombined("regular");
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledTimes(3);
@@ -183,7 +183,7 @@ describe("services", () => {
       (applyPlayerScores as jest.Mock).mockImplementation((data) => data);
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
 
-      const result = await getPlayersStatsCombined("regular", "points");
+      const result = await getPlayersStatsCombined("regular");
 
       expect(result).toEqual([]);
       expect((csv as unknown as jest.Mock)).toHaveBeenCalledTimes(0);
@@ -192,7 +192,7 @@ describe("services", () => {
     test("works without sortBy parameter", async () => {
       const result = await getPlayersStatsCombined("regular");
 
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players", undefined);
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
       expect(result).toEqual([mockPlayer]);
     });
   });
@@ -210,16 +210,16 @@ describe("services", () => {
     });
 
     test("fetches goalie stats for all available seasons", async () => {
-      const result = await getGoaliesStatsCombined("regular", "wins");
+      const result = await getGoaliesStatsCombined("regular");
 
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(mapCombinedGoalieData).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies", "wins");
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
       expect(result).toEqual([mockGoalie]);
     });
 
     test("reads CSV files for all seasons", async () => {
-      await getGoaliesStatsCombined("regular", "wins");
+      await getGoaliesStatsCombined("regular");
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledTimes(3);
@@ -228,7 +228,7 @@ describe("services", () => {
     test("works without sortBy parameter", async () => {
       const result = await getGoaliesStatsCombined("regular");
 
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies", undefined);
+      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
       expect(result).toEqual([mockGoalie]);
     });
   });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { Player, PlayerFields, Goalie, GoalieFields, Report, GoalieScoreField } from "./types";
+import { Player, PlayerFields, Goalie, Report, GoalieScoreField } from "./types";
 import {
   REPORT_TYPES,
   PLAYER_SCORE_FIELDS,
@@ -240,28 +240,14 @@ const applyScoresInternal = <T extends { score?: number }, K extends keyof T>(
 
 export const sortItemsByStatField = (
   data: Player[] | Goalie[],
-  kind: "players" | "goalies",
-  sortBy?: PlayerFields | GoalieFields
+  kind: "players" | "goalies"
 ): Player[] | Goalie[] => {
-  if (sortBy === "name") {
-    return data;
-  }
-
   if (kind === "players") {
-    return (data as Player[]).sort((a, b) =>
-      sortBy
-        ? (b[sortBy as PlayerFields] as number) - (a[sortBy as PlayerFields] as number)
-        : defaultSortPlayers(a, b)
-    );
+    return (data as Player[]).sort(defaultSortPlayers);
   } else if (kind === "goalies") {
-    return (data as Goalie[]).sort((a, b) =>
-      sortBy
-        ? (b[sortBy as GoalieFields] as number) - (a[sortBy as GoalieFields] as number)
-        : defaultSortGoalies(a, b)
-    );
-  } else {
-    return data;
+    return (data as Goalie[]).sort(defaultSortGoalies);
   }
+  return data;
 };
 
 const applyPlayerScoresByGames = (players: Player[]): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,11 @@ module.exports = cors(
     get("/teams", protectedRoute(getTeams)),
     get("/seasons", protectedRoute(getSeasons)),
     get("/seasons/:reportType", protectedRoute(getSeasons)),
-    get("/players/season/:reportType/:season/:sortBy", protectedRoute(getPlayersSeason)),
     get("/players/season/:reportType/:season", protectedRoute(getPlayersSeason)),
     get("/players/season/:reportType", protectedRoute(getPlayersSeason)),
-    get("/players/combined/:reportType/:sortBy", protectedRoute(getPlayersCombined)),
     get("/players/combined/:reportType", protectedRoute(getPlayersCombined)),
-    get("/goalies/season/:reportType/:season/:sortBy", protectedRoute(getGoaliesSeason)),
     get("/goalies/season/:reportType/:season", protectedRoute(getGoaliesSeason)),
     get("/goalies/season/:reportType", protectedRoute(getGoaliesSeason)),
-    get("/goalies/combined/:reportType/:sortBy", protectedRoute(getGoaliesCombined)),
     get("/goalies/combined/:reportType", protectedRoute(getGoaliesCombined)),
     get("/*", notFound)
   )

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,7 +8,7 @@ import {
   getGoaliesStatsSeason,
   getGoaliesStatsCombined,
 } from "./services";
-import { PlayerFields, GoalieFields, Report } from "./types";
+import { Report } from "./types";
 import {
   reportTypeAvailable,
   seasonAvailable,
@@ -118,7 +118,6 @@ export const getSeasons: AugmentedRequestHandler = async (req, res) => {
 export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const report = req.params.reportType as Report;
-  const sortBy = req.params.sortBy as PlayerFields | undefined;
   const season = parseSeasonParam(req.params.season);
 
   if (!reportTypeAvailable(report)) {
@@ -131,26 +130,24 @@ export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getPlayersStatsSeason(report, season, sortBy, teamId));
+  await withErrorHandlingCached(req, res, () => getPlayersStatsSeason(report, season, teamId));
 };
 
 export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const report = req.params.reportType as Report;
-  const sortBy = req.params.sortBy as PlayerFields | undefined;
 
   if (!reportTypeAvailable(report)) {
     sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getPlayersStatsCombined(report, sortBy, teamId));
+  await withErrorHandlingCached(req, res, () => getPlayersStatsCombined(report, teamId));
 };
 
 export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const report = req.params.reportType as Report;
-  const sortBy = req.params.sortBy as GoalieFields | undefined;
   const season = parseSeasonParam(req.params.season);
 
   if (!reportTypeAvailable(report)) {
@@ -163,18 +160,17 @@ export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getGoaliesStatsSeason(report, season, sortBy, teamId));
+  await withErrorHandlingCached(req, res, () => getGoaliesStatsSeason(report, season, teamId));
 };
 
 export const getGoaliesCombined: AugmentedRequestHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const report = req.params.reportType as Report;
-  const sortBy = req.params.sortBy as GoalieFields | undefined;
 
   if (!reportTypeAvailable(report)) {
     sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getGoaliesStatsCombined(report, sortBy, teamId));
+  await withErrorHandlingCached(req, res, () => getGoaliesStatsCombined(report, teamId));
 };

--- a/src/services.ts
+++ b/src/services.ts
@@ -16,7 +16,7 @@ import {
   mapCombinedPlayerData,
   mapCombinedGoalieData,
 } from "./mappings";
-import { PlayerFields, GoalieFields, RawData, Report, Player, Goalie } from "./types";
+import { RawData, Report, Player, Goalie } from "./types";
 import { DEFAULT_TEAM_ID } from "./constants";
 
 // Parser wants seasons as an array even in one-season cases
@@ -71,32 +71,29 @@ export const getAvailableSeasons = async (
 export const getPlayersStatsSeason = async (
   report: Report,
   season?: number,
-  sortBy?: PlayerFields,
   teamId: string = DEFAULT_TEAM_ID
 ) => {
   const rawData = await getRawDataFromFiles(teamId, report, getSeasonParam(teamId, report, season));
   const mappedData = mapPlayerData(rawData);
   const scoredData = applyPlayerScores(mappedData);
-  return sortItemsByStatField(scoredData, "players", sortBy);
+  return sortItemsByStatField(scoredData, "players");
 };
 
 export const getGoaliesStatsSeason = async (
   report: Report,
   season?: number,
-  sortBy?: GoalieFields,
   teamId: string = DEFAULT_TEAM_ID
 ) => {
   const rawData = await getRawDataFromFiles(teamId, report, getSeasonParam(teamId, report, season));
   const mappedData = mapGoalieData(rawData);
   const scoredData = applyGoalieScores(mappedData);
-  return sortItemsByStatField(scoredData, "goalies", sortBy);
+  return sortItemsByStatField(scoredData, "goalies");
 };
 
 const getCombinedStats = async (
   report: Report,
   mapper: (data: RawData[]) => Player[] | Goalie[],
   kind: "players" | "goalies",
-  sortBy?: PlayerFields | GoalieFields,
   teamId: string = DEFAULT_TEAM_ID
 ) => {
   const seasons = availableSeasons(teamId, report);
@@ -106,17 +103,15 @@ const getCombinedStats = async (
     kind === "players"
       ? applyPlayerScores(mappedData as Player[])
       : applyGoalieScores(mappedData as Goalie[]);
-  return sortItemsByStatField(scoredData, kind, sortBy);
+  return sortItemsByStatField(scoredData, kind);
 };
 
 export const getPlayersStatsCombined = async (
   report: Report,
-  sortBy?: PlayerFields,
   teamId: string = DEFAULT_TEAM_ID
-) => getCombinedStats(report, mapCombinedPlayerData, "players", sortBy, teamId);
+) => getCombinedStats(report, mapCombinedPlayerData, "players", teamId);
 
 export const getGoaliesStatsCombined = async (
   report: Report,
-  sortBy?: GoalieFields,
   teamId: string = DEFAULT_TEAM_ID
-) => getCombinedStats(report, mapCombinedGoalieData, "goalies", sortBy, teamId);
+) => getCombinedStats(report, mapCombinedGoalieData, "goalies", teamId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,6 @@ export type Report = "regular" | "playoffs";
 
 export type QueryParams = {
   reportType: Report;
-  sortBy?: PlayerFields | GoalieFields;
   season?: number;
 };
 


### PR DESCRIPTION
Remove sortBy parameter from all API endpoints as sorting is now handled on the UI side. All responses now use default sorting:
- Players: by score → points → goals (descending)
- Goalies: by score → wins → games (descending)

Changes:
- Removed sortBy routes from API endpoints
- Simplified sortItemsByStatField to use default sorting only
- Updated all service functions to remove sortBy parameter
- Removed sortBy from QueryParams type
- Updated README to reflect API changes
- Updated tests to match new behavior