### PR TITLE
Polishments: Clean up implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         run: npm ci
 
       - name: Validate Pull Request (lint, build, test coverage)
-        run: npm run verify:coverage
+        run: npm run verify

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repository runs a GitHub Actions workflow on:
 The CI check runs the full verification command:
 
 ```
-npm run verify:coverage
+npm run verify
 ```
 
 That command runs lint, TypeScript build, and Jest with the enforced global coverage thresholds. The workflow definition is in `.github/workflows/ci.yml`.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "verify": "npm run lint:check && npm run build && npm test",
-    "verify:coverage": "npm run lint:check && npm run build && npm run test:coverage"
+    "verify": "npm run lint:check && npm run build && npm run test:coverage"
   },
   "dependencies": {
     "csvtojson": "^2.0.14",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "node": ">=24 <25"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "rimraf lib && tsc -p tsconfig.build.json",
     "dev": "npm run build && concurrently \"tsc --watch\" \"nodemon --watch lib --ext js --exec node lib/server.js\"",
     "dev-start": "npm run build && node lib/server.js",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "lint:check": "eslint src/**/*.ts --max-warnings 0",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "playwright:login": "tsx src/playwright/login.ts",
     "playwright:sync:leagues": "tsx src/playwright/sync-leagues.ts",
     "playwright:sync:playoffs": "tsx src/playwright/sync-playoffs.ts",
@@ -27,7 +28,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "verify": "npm run lint:check && npm run build && npm run test:coverage"
+    "verify": "npm run lint:check && npm run typecheck && npm run build && npm run test:coverage"
   },
   "dependencies": {
     "csvtojson": "^2.0.14",

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -77,13 +77,13 @@ describe("auth", () => {
     });
 
     test("reads configured header from array form", () => {
-      const req = createRequest({ headers: { "x-api-key": ["key1", "key2"] } });
+      const req = createRequest({ headers: { "x-api-key": ["key1", "key2"] as unknown as string } });
       expect(extractApiKey(req, "x-api-key", true)).toBe("key1");
     });
 
     test("falls back to Bearer token when array header is empty", () => {
       const req = createRequest({
-        headers: { "x-api-key": [""], authorization: "Bearer token123" },
+        headers: { "x-api-key": [""] as unknown as string, authorization: "Bearer token123" },
       });
       expect(extractApiKey(req, "x-api-key", true)).toBe("token123");
     });
@@ -94,7 +94,7 @@ describe("auth", () => {
     });
 
     test("returns undefined when authorization header is not a string", () => {
-      const req = createRequest({ headers: { authorization: ["Bearer token123"] } });
+      const req = createRequest({ headers: { authorization: ["Bearer token123"] as unknown as string } });
       expect(extractApiKey(req, "x-api-key", true)).toBeUndefined();
     });
 
@@ -120,7 +120,7 @@ describe("auth", () => {
     test("passes through when auth not required", async () => {
       const handler = jest.fn();
       const wrapped = withApiKeyAuth(handler, { requireAuth: false });
-      const req = createRequest();
+      const req = createRequest({ headers: {} });
       const res = createResponse();
 
       await wrapped(req, res);
@@ -132,7 +132,7 @@ describe("auth", () => {
     test("allows OPTIONS preflight even when auth required", async () => {
       const handler = jest.fn();
       const wrapped = withApiKeyAuth(handler, { requireAuth: true, validKeys: ["k1"] });
-      const req = createRequest({ method: "OPTIONS" });
+      const req = createRequest({ method: "OPTIONS", headers: {} });
       const res = createResponse();
 
       await wrapped(req, res);

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -409,24 +409,6 @@ describe("routes", () => {
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
-
-    test("works without sortBy parameter", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 50 }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockReturnValue(true);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2024);
-      (getPlayersStatsSeason as jest.Mock).mockResolvedValue(mockPlayers);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2024" },
-      });
-      const res = createResponse();
-
-      await getPlayersSeason(req, res);
-
-      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
-    });
   });
 
   describe("getPlayersCombined", () => {
@@ -473,21 +455,6 @@ describe("routes", () => {
       await getPlayersCombined(req, res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
-    });
-
-    test("works without sortBy parameter", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(req, res);
-
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
     });
 
     test("passes startFrom to service correctly", async () => {
@@ -594,23 +561,6 @@ describe("routes", () => {
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
-
-    test("works without sortBy parameter", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 40 }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockReturnValue(true);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2024);
-      (getGoaliesStatsSeason as jest.Mock).mockResolvedValue(mockGoalies);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2024" },
-      });
-      const res = createResponse();
-
-      await getGoaliesSeason(req, res);
-
-      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
-    });
   });
 
   describe("getGoaliesCombined", () => {
@@ -657,21 +607,6 @@ describe("routes", () => {
       await getGoaliesCombined(req, res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
-    });
-
-    test("works without sortBy parameter", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue(mockGoalies);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(req, res);
-
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
     });
 
     test("passes startFrom to service correctly", async () => {

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -32,6 +32,9 @@ jest.mock("micro");
 jest.mock("../services");
 jest.mock("../helpers");
 
+type RouteReq = Parameters<typeof getSeasons>[0];
+const asRouteReq = (req: unknown): RouteReq => req as RouteReq;
+
 describe("routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,7 +49,7 @@ describe("routes", () => {
       const req = createRequest();
       const res = createResponse();
 
-      await getHealthcheck(req, res);
+      await getHealthcheck(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(
         res,
@@ -68,7 +71,7 @@ describe("routes", () => {
       const req = createRequest();
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -84,7 +87,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "playoffs", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -97,7 +100,7 @@ describe("routes", () => {
       const req = createRequest();
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
@@ -111,7 +114,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     });
@@ -122,7 +125,7 @@ describe("routes", () => {
 
       const res = createResponse();
 
-      await getSeasons({} as unknown as ReturnType<typeof createRequest>, res);
+      await getSeasons(asRouteReq({} as unknown as ReturnType<typeof createRequest>), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -135,7 +138,7 @@ describe("routes", () => {
       const req = { url: 123 } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -154,7 +157,7 @@ describe("routes", () => {
       } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -167,7 +170,7 @@ describe("routes", () => {
       const req = createRequest();
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, 422, error);
     });
@@ -180,7 +183,7 @@ describe("routes", () => {
       const req = createRequest({ url: "/seasons", headers: { host: "localhost" } });
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(resolveTeamId).toHaveBeenCalledWith(undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -197,7 +200,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(parseSeasonParam).toHaveBeenCalledWith("2020");
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", 2020);
@@ -216,7 +219,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getSeasons(req, res);
+      await getSeasons(asRouteReq(req), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "playoffs", 2018);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -231,7 +234,7 @@ describe("routes", () => {
       const req = createRequest();
       const res = createResponse();
 
-      await getTeams(req, res);
+      await getTeams(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, filteredTeams);
     });
@@ -242,12 +245,12 @@ describe("routes", () => {
 
       const req1 = createRequest({ url: "/teams" });
       const res1 = createResponse();
-      await getTeams(req1, res1);
+      await getTeams(asRouteReq(req1), res1);
 
       (send as jest.Mock).mockClear();
       const req2 = createRequest({ url: "/teams" });
       const res2 = createResponse();
-      await getTeams(req2, res2);
+      await getTeams(asRouteReq(req2), res2);
 
       expect(getTeamsWithCsvFolders).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledWith(res2, HTTP_STATUS.OK, filteredTeams);
@@ -259,7 +262,7 @@ describe("routes", () => {
 
       const req1 = createRequest({ url: "/teams", method: "GET" });
       const res1 = createResponse();
-      await getTeams(req1, res1);
+      await getTeams(asRouteReq(req1), res1);
 
       (send as jest.Mock).mockClear();
       const etag = makeEtagForJson(filteredTeams);
@@ -270,7 +273,7 @@ describe("routes", () => {
       } as unknown as ReturnType<typeof createRequest>;
       const res2 = createResponse();
       const endSpy = jest.spyOn(res2, "end");
-      await getTeams(req2, res2);
+      await getTeams(asRouteReq(req2), res2);
 
       expect(getTeamsWithCsvFolders).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledTimes(0);
@@ -288,7 +291,7 @@ describe("routes", () => {
         headers: { host: "localhost" },
       } as unknown as ReturnType<typeof createRequest>;
       const primeRes = createResponse();
-      await getTeams(primeReq, primeRes);
+      await getTeams(asRouteReq(primeReq), primeRes);
 
       (send as jest.Mock).mockClear();
 
@@ -301,7 +304,7 @@ describe("routes", () => {
       const cachedRes = createResponse();
       const endSpy = jest.spyOn(cachedRes, "end");
 
-      await getTeams(cachedReq, cachedRes);
+  await getTeams(asRouteReq(cachedReq), cachedRes);
 
       expect(getTeamsWithCsvFolders).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledTimes(0);
@@ -322,7 +325,7 @@ describe("routes", () => {
       const res = createResponse();
       const endSpy = jest.spyOn(res, "end");
 
-      await getTeams(req, res);
+      await getTeams(asRouteReq(req), res);
 
       expect(getTeamsWithCsvFolders).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledTimes(0);
@@ -335,7 +338,7 @@ describe("routes", () => {
       (getTeamsWithCsvFolders as jest.Mock).mockReturnValue(filteredTeams);
 
       const res = createResponse();
-      await getTeams(undefined as unknown as ReturnType<typeof createRequest>, res);
+      await getTeams(undefined as unknown as RouteReq, res);
 
       expect(getTeamsWithCsvFolders).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, filteredTeams);
@@ -358,7 +361,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersSeason(req, res);
+      await getPlayersSeason(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
@@ -375,7 +378,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersSeason(req, res);
+      await getPlayersSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     });
@@ -389,7 +392,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersSeason(req, res);
+      await getPlayersSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
     });
@@ -405,7 +408,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersSeason(req, res);
+      await getPlayersSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
@@ -422,7 +425,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersCombined(req, res);
+      await getPlayersCombined(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
@@ -437,7 +440,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersCombined(req, res);
+      await getPlayersCombined(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     });
@@ -452,7 +455,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersCombined(req, res);
+      await getPlayersCombined(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
@@ -470,7 +473,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersCombined(req, res);
+      await getPlayersCombined(asRouteReq(req), res);
 
       expect(parseSeasonParam).toHaveBeenCalledWith("2020");
       expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1", 2020);
@@ -490,7 +493,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getPlayersCombined(req, res);
+      await getPlayersCombined(asRouteReq(req), res);
 
       expect(getPlayersStatsCombined).toHaveBeenCalledWith("playoffs", "1", 2018);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
@@ -510,7 +513,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesSeason(req, res);
+      await getGoaliesSeason(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
@@ -527,7 +530,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesSeason(req, res);
+      await getGoaliesSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     });
@@ -541,7 +544,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesSeason(req, res);
+      await getGoaliesSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
     });
@@ -557,7 +560,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesSeason(req, res);
+      await getGoaliesSeason(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
@@ -574,7 +577,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesCombined(req, res);
+      await getGoaliesCombined(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
       expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
@@ -589,7 +592,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesCombined(req, res);
+      await getGoaliesCombined(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
     });
@@ -604,7 +607,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesCombined(req, res);
+      await getGoaliesCombined(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
     });
@@ -622,7 +625,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesCombined(req, res);
+      await getGoaliesCombined(asRouteReq(req), res);
 
       expect(parseSeasonParam).toHaveBeenCalledWith("2020");
       expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1", 2020);
@@ -642,7 +645,7 @@ describe("routes", () => {
       });
       const res = createResponse();
 
-      await getGoaliesCombined(req, res);
+      await getGoaliesCombined(asRouteReq(req), res);
 
       expect(getGoaliesStatsCombined).toHaveBeenCalledWith("playoffs", "1", 2018);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -81,7 +81,7 @@ describe("services", () => {
     });
 
     test("returns empty array when startFrom is after all available seasons", async () => {
-      const mockSeasons = [];
+      const mockSeasons: Array<{ season: number; text: string }> = [];
       (availableSeasons as jest.Mock).mockReturnValue([2012, 2013]);
       (mapAvailableSeasons as jest.Mock).mockReturnValue(mockSeasons);
 

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -134,13 +134,6 @@ describe("services", () => {
       expect((csv as unknown as jest.Mock)).toHaveBeenCalledTimes(0);
     });
 
-    test("works without sortBy parameter", async () => {
-      const result = await getPlayersStatsSeason("regular", 2024);
-
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
-      expect(result).toEqual([mockPlayer]);
-    });
-
     test("constructs correct CSV file path", async () => {
       await getPlayersStatsSeason("playoffs", 2023);
 
@@ -178,13 +171,6 @@ describe("services", () => {
       expect(csvMock.fromFile).toHaveBeenCalledWith(
         expect.stringContaining("regular-2024-2025.csv")
       );
-    });
-
-    test("works without sortBy parameter", async () => {
-      const result = await getGoaliesStatsSeason("regular", 2024);
-
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
-      expect(result).toEqual([mockGoalie]);
     });
   });
 
@@ -226,13 +212,6 @@ describe("services", () => {
 
       expect(result).toEqual([]);
       expect((csv as unknown as jest.Mock)).toHaveBeenCalledTimes(0);
-    });
-
-    test("works without sortBy parameter", async () => {
-      const result = await getPlayersStatsCombined("regular");
-
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
-      expect(result).toEqual([mockPlayer]);
     });
 
     test("filters seasons when startFrom is provided", async () => {
@@ -292,13 +271,6 @@ describe("services", () => {
 
       const csvMock = (csv as unknown as jest.Mock).mock.results[0].value;
       expect(csvMock.fromFile).toHaveBeenCalledTimes(3);
-    });
-
-    test("works without sortBy parameter", async () => {
-      const result = await getGoaliesStatsCombined("regular");
-
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
-      expect(result).toEqual([mockGoalie]);
     });
 
     test("filters seasons when startFrom is provided", async () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./node_modules",
+    "./src/**/*.test.ts",
+    "./src/__tests__",
+    "./lib",
+    "./coverage"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
   ],
   "exclude": [
     "./node_modules",
-    "./src/**/*.test.ts",
-    "./src/__tests__"
+    "./lib",
+    "./coverage"
   ]
 }


### PR DESCRIPTION
- Remove unused sortBy tests
- Rename npm run verify:coverage -> npm run verify and remove verify:coverage script
- Fix all TypeScript errors in tests and require tests be also type-safe until verification passes