### PR TITLE
Add parseAndUploadCsv script and auto-cleanup temp files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "r2:download": "tsx scripts/download-from-r2.ts",
     "r2:download:dry": "tsx scripts/download-from-r2.ts --dry-run",
     "r2:download:force": "tsx scripts/download-from-r2.ts --force",
+    "parseAndUploadCsv": "set -a && source .env && set +a && ./scripts/import-temp-csv.sh",
     "start": "npm run build && node lib/server.js",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/import-temp-csv.sh
+++ b/scripts/import-temp-csv.sh
@@ -114,7 +114,14 @@ if [[ "$IMPORTED_COUNT" -gt 0 ]]; then
   if [[ "${USE_R2_STORAGE:-false}" == "true" ]]; then
     echo ""
     echo "📤 Uploading to R2..."
-    npm run r2:upload:current
+    if npm run r2:upload:current; then
+      echo ""
+      echo "🧹 Cleaning up temp files..."
+      rm -f "$TEMP_DIR"/*.csv
+      echo "Removed CSV files from csv/temp/"
+    else
+      echo "⚠️  R2 upload failed, keeping temp files" >&2
+    fi
   fi
 fi
 


### PR DESCRIPTION
- Add npm script that sources .env and runs import-temp-csv.sh
- Clean up csv/temp/*.csv after successful R2 upload
- Keep temp files if upload fails for safety