### PR TITLE
Refactor: eliminate as-unknown-as casts in helpers and routes

### DIFF
--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -133,7 +133,7 @@ describe("routes", () => {
 
       const res = createResponse();
 
-      await getSeasons(asRouteReq({} as unknown as ReturnType<typeof createRequest>), res);
+      await getSeasons(asRouteReq({ params: {} } as unknown as ReturnType<typeof createRequest>), res);
 
       expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
@@ -143,7 +143,7 @@ describe("routes", () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
 
-      const req = { url: 123 } as unknown as ReturnType<typeof createRequest>;
+      const req = { url: 123, params: {} } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);
@@ -162,6 +162,7 @@ describe("routes", () => {
       const req = {
         url: "/seasons?teamId=1",
         headers: { host: 123 },
+        params: {},
       } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
@@ -178,7 +179,7 @@ describe("routes", () => {
         typeof raw === "string" && raw ? raw : "1"
       );
 
-      const req = { url: "/seasons?teamId=1" } as unknown as ReturnType<typeof createRequest>;
+      const req = { url: "/seasons?teamId=1", params: {} } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -108,8 +108,9 @@ export const getTeams: AugmentedRequestHandler = async (req, res) => {
 
 export const getSeasons: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
-  const report = (req.params.reportType || "regular") as Report;
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
+
+  const report = (req.params.reportType || "regular") as Report;
 
   if (!reportTypeAvailable(report)) {
     sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -108,8 +108,7 @@ export const getTeams: AugmentedRequestHandler = async (req, res) => {
 
 export const getSeasons: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
-  const reportRaw = (req as unknown as { params?: { reportType?: unknown } }).params?.reportType;
-  const report = (typeof reportRaw === "string" ? reportRaw : "regular") as Report;
+  const report = (req.params.reportType || "regular") as Report;
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
 
   if (!reportTypeAvailable(report)) {


### PR DESCRIPTION
- Tighten getMaxByField/getMinByField constraints to T extends Record<K, number>, allowing direct item[field] access without escape casts
- Tighten applyScoresInternal constraint to include Record<K, number> and scores?: Record<string, number>, removing three separate casts
- Remove casts from applyPlayerScoresByGames and applyPositionScoresForGroup — PlayerScoreField fields are all number on Player, so player[field] is typed
- Remove casts from applyGoalieScores — GoalieScoreField fields are all number on Goalie, and scores is already on Common; use goalie.scores! after init
- Replace getSeasons two-line escape cast with req.params.reportType || "regular" since microrouter types params as Record<string, string> already
- Update four route tests to include params: {} reflecting real microrouter behaviour