### PR TITLE
Add apperances field into playoff leaderboard API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/teams
 # Deep route example
 curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/players/combined/playoffs?teamId=1"
 
+# Leaderboards
+curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/leaderboard/playoffs
+curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/leaderboard/regular
+
 # Filter by season (startFrom parameter)
 curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/seasons?startFrom=2020"
 curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/players/combined/regular?startFrom=2020"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -266,6 +266,7 @@ components:
       required:
         - teamId
         - teamName
+        - appearances
         - championships
         - finals
         - conferenceFinals
@@ -277,6 +278,9 @@ components:
           type: string
         teamName:
           type: string
+        appearances:
+          type: integer
+          description: Total playoff appearances (sum of championships, finals, conferenceFinals, secondRound, and firstRound).
         championships:
           type: integer
         finals:

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -811,6 +811,7 @@ describe("routes", () => {
         {
           teamId: "1",
           teamName: "Colorado Avalanche",
+          appearances: 13,
           championships: 3,
           finals: 2,
           conferenceFinals: 2,
@@ -980,6 +981,7 @@ describe("routes", () => {
     const validPlayoffEntry = {
       teamId: "1",
       teamName: "Colorado Avalanche",
+      appearances: 13,
       championships: 3,
       finals: 2,
       conferenceFinals: 2,

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -427,11 +427,13 @@ describe("services", () => {
       expect(result[0]).toMatchObject({
         teamId: "1",
         teamName: "Colorado Avalanche",
+        appearances: 13,
         tieRank: false,
       });
       expect(result[1]).toMatchObject({
         teamId: "4",
         teamName: "Vancouver Canucks",
+        appearances: 13,
         tieRank: false,
       });
     });
@@ -444,6 +446,8 @@ describe("services", () => {
 
       const result = await getPlayoffLeaderboardData();
 
+      expect(result[0].appearances).toBe(4);
+      expect(result[1].appearances).toBe(4);
       expect(result[0].tieRank).toBe(false);
       expect(result[1].tieRank).toBe(true);
     });
@@ -455,6 +459,7 @@ describe("services", () => {
 
       const result = await getPlayoffLeaderboardData();
 
+      expect(result[0].appearances).toBe(5);
       expect(result[0].tieRank).toBe(false);
     });
 
@@ -463,6 +468,7 @@ describe("services", () => {
       const result = await getPlayoffLeaderboardData();
       expect(result).toHaveLength(TEAMS.length);
       for (const entry of result) {
+        expect(entry.appearances).toBe(0);
         expect(entry.championships).toBe(0);
         expect(entry.finals).toBe(0);
         expect(entry.conferenceFinals).toBe(0);
@@ -481,6 +487,7 @@ describe("services", () => {
       expect(result).toHaveLength(TEAMS.length);
       const missing = result.filter((r) => r.teamId !== "1");
       for (const entry of missing) {
+        expect(entry.appearances).toBe(0);
         expect(entry.championships).toBe(0);
         expect(entry.finals).toBe(0);
         expect(entry.conferenceFinals).toBe(0);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -156,7 +156,7 @@ interface PlayoffLeaderboardRow {
 
 type PlayoffLeaderboardDbEntry = Omit<
   import("../types").PlayoffLeaderboardEntry,
-  "teamName" | "tieRank"
+  "teamName" | "appearances" | "tieRank"
 >;
 
 const mapLeaderboardRow = (row: PlayoffLeaderboardRow): PlayoffLeaderboardDbEntry => ({

--- a/src/services.ts
+++ b/src/services.ts
@@ -295,6 +295,13 @@ export const getPlayoffLeaderboardData = async (): Promise<
     const team = TEAMS.find((t) => t.id === row.teamId);
     const teamName = team?.presentName ?? row.teamId;
 
+    const appearances =
+      row.championships +
+      row.finals +
+      row.conferenceFinals +
+      row.secondRound +
+      row.firstRound;
+
     const prev = i > 0 ? allRows[i - 1] : null;
     const tieRank =
       prev !== null &&
@@ -304,7 +311,7 @@ export const getPlayoffLeaderboardData = async (): Promise<
       prev.secondRound === row.secondRound &&
       prev.firstRound === row.firstRound;
 
-    return { ...row, teamName, tieRank };
+    return { ...row, teamName, appearances, tieRank };
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,7 @@ export type Team = {
 export type PlayoffLeaderboardEntry = {
   teamId: string;
   teamName: string;
+  appearances: number;
   championships: number;
   finals: number;
   conferenceFinals: number;


### PR DESCRIPTION
## Summary

Adds a new `appearances` field to playoff leaderboard entries.

`appearances` is derived in service logic as:

championships + finals + conferenceFinals + secondRound + firstRound

No database schema/query change was required.

## What changed

- Added `appearances` to playoff leaderboard response type.
- Computed `appearances` in playoff leaderboard service output.
- Kept DB leaderboard query shape unchanged (only adjusted query-layer type omit for derived field).
- Updated OpenAPI schema for `PlayoffLeaderboardEntry` to include required `appearances`.
- Updated tests to cover and validate the new field:
  - services tests
  - routes tests
  - schema conformance tests
- Updated README examples to include leaderboard curl endpoints (without extra response-field commentary).

## Validation

- npm test
- npm run verify

Both pass.

## Notes

- Tie ranking behavior is unchanged (still based on championships/finals/conferenceFinals/secondRound/firstRound tuple).
- `appearances` is deterministic and derived from existing aggregate fields.