### PR TITLE
Feature: Add leaderboard season breakdowns for regular and playoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/teams
 curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/players/combined/playoffs?teamId=1"
 
 # Leaderboards
-curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/leaderboard/playoffs
 curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/leaderboard/regular
+curl -H "x-api-key: <your-key>" https://ffhl-stats-api.vercel.app/leaderboard/playoffs
 
 # Filter by season (startFrom parameter)
 curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/seasons?startFrom=2020"
@@ -361,6 +361,15 @@ curl -H "x-api-key: <your-key>" "https://ffhl-stats-api.vercel.app/goalies/combi
 curl https://ffhl-stats-api.vercel.app/api/health
 curl https://ffhl-stats-api.vercel.app/api/seasons
 ```
+
+### Leaderboard response notes
+
+- `GET /leaderboard/regular` returns all-time aggregate stats plus:
+  - `seasons`: per-season regular results (includes `season`, W/L/T, points, division record, and per-season percentages)
+- `GET /leaderboard/playoffs` returns all-time aggregate playoff rounds plus:
+  - `seasons`: one item per season year
+  - each item has `season`, `round`, and `key`
+  - if a season has no DB row for that team, it is returned as `round: 0` and `key: "notQualified"`
 
 ## Cloud Storage (Cloudflare R2)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -272,6 +272,7 @@ components:
         - conferenceFinals
         - secondRound
         - firstRound
+        - seasons
         - tieRank
       properties:
         teamId:
@@ -291,9 +292,35 @@ components:
           type: integer
         firstRound:
           type: integer
+        seasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayoffLeaderboardSeason"
         tieRank:
           type: boolean
           description: True when this entry's record matches the previous entry's record.
+
+    PlayoffLeaderboardSeason:
+      type: object
+      required:
+        - season
+        - round
+        - key
+      properties:
+        season:
+          type: integer
+        round:
+          type: integer
+          description: "Playoff round reached: 0=not qualified, 1-4=round reached, 5=championship."
+        key:
+          type: string
+          enum:
+            - championship
+            - final
+            - conferenceFinal
+            - secondRound
+            - firstRound
+            - notQualified
 
     RegularLeaderboardEntry:
       type: object
@@ -319,7 +346,9 @@ components:
         teamName:
           type: string
         seasons:
-          type: integer
+          type: array
+          items:
+            $ref: "#/components/schemas/RegularLeaderboardSeason"
         wins:
           type: integer
         losses:
@@ -347,6 +376,44 @@ components:
         tieRank:
           type: boolean
           description: True when this entry's record matches the previous entry's record.
+
+    RegularLeaderboardSeason:
+      type: object
+      required:
+        - season
+        - wins
+        - losses
+        - ties
+        - points
+        - divWins
+        - divLosses
+        - divTies
+        - winPercent
+        - divWinPercent
+        - pointsPercent
+      properties:
+        season:
+          type: integer
+        wins:
+          type: integer
+        losses:
+          type: integer
+        ties:
+          type: integer
+        points:
+          type: integer
+        divWins:
+          type: integer
+        divLosses:
+          type: integer
+        divTies:
+          type: integer
+        winPercent:
+          type: number
+        divWinPercent:
+          type: number
+        pointsPercent:
+          type: number
 
 security:
   - apiKey: []

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "db:import:regular-results": "tsx scripts/db-import-regular-results.ts",
     "parseAndUploadCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; USE_R2_STORAGE=${USE_R2_STORAGE:-false} USE_REMOTE_DB=${USE_REMOTE_DB:-false} ./scripts/import-temp-csv.sh",
     "start": "npm run build && node lib/server.js",
-    "test": "jest",
+    "test": "jest --watchman=false",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --coverage --watchman=false",
     "verify": "npm run lint:check && npm run typecheck && npm run build && npm run test:coverage"
   },
   "dependencies": {

--- a/src/__tests__/queries.test.ts
+++ b/src/__tests__/queries.test.ts
@@ -13,7 +13,9 @@ import {
   getTeamIdsWithData,
   getLastModifiedFromDb,
   getPlayoffLeaderboard,
+  getPlayoffSeasons,
   getRegularLeaderboard,
+  getRegularSeasons,
 } from "../db/queries";
 import type { PlayerWithSeason, GoalieWithSeason } from "../types";
 
@@ -314,6 +316,33 @@ describe("db/queries", () => {
     });
   });
 
+  describe("getPlayoffSeasons", () => {
+    test("returns per-team playoff seasons", async () => {
+      mockExecute.mockResolvedValue({
+        rows: [
+          { team_id: "1", season: 2023, round: 2 },
+          { team_id: "1", season: 2024, round: 5 },
+        ],
+      });
+
+      const result = await getPlayoffSeasons();
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        expect.stringContaining("FROM playoff_results"),
+      );
+      expect(result).toEqual([
+        { teamId: "1", season: 2023, round: 2 },
+        { teamId: "1", season: 2024, round: 5 },
+      ]);
+    });
+
+    test("returns empty array when no playoff season rows exist", async () => {
+      mockExecute.mockResolvedValue({ rows: [] });
+      const result = await getPlayoffSeasons();
+      expect(result).toEqual([]);
+    });
+  });
+
   describe("getRegularLeaderboard", () => {
     test("returns mapped leaderboard rows sorted by SQL order", async () => {
       mockExecute.mockResolvedValue({
@@ -356,7 +385,6 @@ describe("db/queries", () => {
       expect(result).toEqual([
         {
           teamId: "1",
-          seasons: 10,
           wins: 355,
           losses: 79,
           ties: 46,
@@ -368,7 +396,6 @@ describe("db/queries", () => {
         },
         {
           teamId: "4",
-          seasons: 10,
           wins: 319,
           losses: 105,
           ties: 56,
@@ -384,6 +411,51 @@ describe("db/queries", () => {
     test("returns empty array when no regular results exist", async () => {
       mockExecute.mockResolvedValue({ rows: [] });
       const result = await getRegularLeaderboard();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getRegularSeasons", () => {
+    test("returns mapped regular season rows", async () => {
+      mockExecute.mockResolvedValue({
+        rows: [
+          {
+            team_id: "1",
+            season: 2024,
+            wins: 35,
+            losses: 7,
+            ties: 6,
+            points: 76,
+            div_wins: 8,
+            div_losses: 2,
+            div_ties: 2,
+          },
+        ],
+      });
+
+      const result = await getRegularSeasons();
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        expect.stringContaining("FROM regular_results"),
+      );
+      expect(result).toEqual([
+        {
+          teamId: "1",
+          season: 2024,
+          wins: 35,
+          losses: 7,
+          ties: 6,
+          points: 76,
+          divWins: 8,
+          divLosses: 2,
+          divTies: 2,
+        },
+      ]);
+    });
+
+    test("returns empty array when no regular season rows exist", async () => {
+      mockExecute.mockResolvedValue({ rows: [] });
+      const result = await getRegularSeasons();
       expect(result).toEqual([]);
     });
   });

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -817,6 +817,7 @@ describe("routes", () => {
           conferenceFinals: 2,
           secondRound: 4,
           firstRound: 2,
+          seasons: [{ season: 2024, round: 5, key: "championship" }],
           tieRank: false,
         },
       ];
@@ -865,7 +866,6 @@ describe("routes", () => {
         {
           teamId: "1",
           teamName: "Colorado Avalanche",
-          seasons: 10,
           wins: 355,
           losses: 79,
           ties: 46,
@@ -877,6 +877,21 @@ describe("routes", () => {
           divWinPercent: 0.717,
           pointsPercent: 0.788,
           regularTrophies: 2,
+          seasons: [
+            {
+              season: 2024,
+              wins: 35,
+              losses: 7,
+              ties: 6,
+              points: 76,
+              divWins: 8,
+              divLosses: 2,
+              divTies: 2,
+              winPercent: 0.729,
+              divWinPercent: 0.667,
+              pointsPercent: 0.792,
+            },
+          ],
           tieRank: false,
         },
       ];
@@ -987,13 +1002,13 @@ describe("routes", () => {
       conferenceFinals: 2,
       secondRound: 4,
       firstRound: 2,
+      seasons: [{ season: 2024, round: 5, key: "championship" }],
       tieRank: false,
     };
 
     const validRegularEntry = {
       teamId: "1",
       teamName: "Colorado Avalanche",
-      seasons: 10,
       wins: 355,
       losses: 79,
       ties: 46,
@@ -1005,6 +1020,21 @@ describe("routes", () => {
       divWinPercent: 0.717,
       pointsPercent: 0.788,
       regularTrophies: 2,
+      seasons: [
+        {
+          season: 2024,
+          wins: 35,
+          losses: 7,
+          ties: 6,
+          points: 76,
+          divWins: 8,
+          divLosses: 2,
+          divTies: 2,
+          winPercent: 0.729,
+          divWinPercent: 0.667,
+          pointsPercent: 0.792,
+        },
+      ],
       tieRank: false,
     };
 

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -19,7 +19,14 @@ import {
   mapCombinedPlayerDataFromPlayersWithSeason,
   mapCombinedGoalieDataFromGoaliesWithSeason,
 } from "../mappings";
-import { getPlayersFromDb, getGoaliesFromDb, getPlayoffLeaderboard, getRegularLeaderboard } from "../db/queries";
+import {
+  getPlayersFromDb,
+  getGoaliesFromDb,
+  getPlayoffLeaderboard,
+  getPlayoffSeasons,
+  getRegularLeaderboard,
+  getRegularSeasons,
+} from "../db/queries";
 import { mockPlayer, mockGoalie, mockPlayerWithSeason, mockGoalieWithSeason } from "./fixtures";
 import { TEAMS } from "../constants";
 
@@ -415,6 +422,13 @@ describe("services", () => {
     const mockGetPlayoffLeaderboard = getPlayoffLeaderboard as jest.MockedFunction<
       typeof getPlayoffLeaderboard
     >;
+    const mockGetPlayoffSeasons = getPlayoffSeasons as jest.MockedFunction<
+      typeof getPlayoffSeasons
+    >;
+
+    beforeEach(() => {
+      mockGetPlayoffSeasons.mockResolvedValue([]);
+    });
 
     test("resolves teamName from TEAMS and sets tieRank false for non-tied entries", async () => {
       mockGetPlayoffLeaderboard.mockResolvedValue([
@@ -428,6 +442,7 @@ describe("services", () => {
         teamId: "1",
         teamName: "Colorado Avalanche",
         appearances: 13,
+        seasons: expect.any(Array),
         tieRank: false,
       });
       expect(result[1]).toMatchObject({
@@ -504,16 +519,70 @@ describe("services", () => {
       const result = await getPlayoffLeaderboardData();
       expect(result[0].teamName).toBe("999");
     });
+
+    test("adds season breakdown with notQualified defaults within latest playoff season", async () => {
+      mockGetPlayoffLeaderboard.mockResolvedValue([
+        { teamId: "1", championships: 1, finals: 0, conferenceFinals: 0, secondRound: 0, firstRound: 0 },
+      ]);
+      mockGetPlayoffSeasons.mockResolvedValue([
+        { teamId: "1", season: 2012, round: 1 },
+        { teamId: "1", season: 2013, round: 5 },
+      ]);
+
+      const result = await getPlayoffLeaderboardData();
+      const colorado = result.find((entry) => entry.teamId === "1");
+
+      expect(colorado).toBeDefined();
+      expect(colorado?.seasons[0]).toEqual({ season: 2012, round: 1, key: "firstRound" });
+      expect(colorado?.seasons[1]).toEqual({ season: 2013, round: 5, key: "championship" });
+      expect(colorado?.seasons).toHaveLength(2);
+    });
+
+    test("uses team firstSeason for playoff season breakdown", async () => {
+      mockGetPlayoffLeaderboard.mockResolvedValue([
+        { teamId: "32", championships: 0, finals: 0, conferenceFinals: 0, secondRound: 0, firstRound: 1 },
+      ]);
+      mockGetPlayoffSeasons.mockResolvedValue([{ teamId: "32", season: 2018, round: 1 }]);
+
+      const result = await getPlayoffLeaderboardData();
+      const vegas = result.find((entry) => entry.teamId === "32");
+
+      expect(vegas).toBeDefined();
+      expect(vegas?.seasons[0].season).toBe(2017);
+      expect(vegas?.seasons[0].key).toBe("notQualified");
+      expect(vegas?.seasons[1]).toEqual({ season: 2018, round: 1, key: "firstRound" });
+    });
+
+    test("maps playoff round keys for final, conferenceFinal and secondRound", async () => {
+      mockGetPlayoffLeaderboard.mockResolvedValue([
+        { teamId: "1", championships: 0, finals: 1, conferenceFinals: 1, secondRound: 1, firstRound: 0 },
+      ]);
+      mockGetPlayoffSeasons.mockResolvedValue([
+        { teamId: "1", season: 2012, round: 4 },
+        { teamId: "1", season: 2013, round: 3 },
+        { teamId: "1", season: 2014, round: 2 },
+      ]);
+
+      const result = await getPlayoffLeaderboardData();
+      const colorado = result.find((entry) => entry.teamId === "1");
+
+      expect(colorado).toBeDefined();
+      expect(colorado?.seasons[0]).toEqual({ season: 2012, round: 4, key: "final" });
+      expect(colorado?.seasons[1]).toEqual({ season: 2013, round: 3, key: "conferenceFinal" });
+      expect(colorado?.seasons[2]).toEqual({ season: 2014, round: 2, key: "secondRound" });
+    });
   });
 
   describe("getRegularLeaderboardData", () => {
     const mockGetRegularLeaderboard = getRegularLeaderboard as jest.MockedFunction<
       typeof getRegularLeaderboard
     >;
+    const mockGetRegularSeasons = getRegularSeasons as jest.MockedFunction<
+      typeof getRegularSeasons
+    >;
 
     const baseRow = {
       teamId: "1",
-      seasons: 10,
       wins: 355,
       losses: 79,
       ties: 46,
@@ -524,6 +593,10 @@ describe("services", () => {
       regularTrophies: 2,
     };
 
+    beforeEach(() => {
+      mockGetRegularSeasons.mockResolvedValue([]);
+    });
+
     test("resolves teamName from TEAMS and sets tieRank false for first entry", async () => {
       mockGetRegularLeaderboard.mockResolvedValue([baseRow]);
 
@@ -532,6 +605,7 @@ describe("services", () => {
       expect(result[0]).toMatchObject({
         teamId: "1",
         teamName: "Colorado Avalanche",
+        seasons: [],
         tieRank: false,
       });
     });
@@ -652,6 +726,75 @@ describe("services", () => {
       const result = await getRegularLeaderboardData();
 
       expect(result[0].pointsPercent).toBe(0);
+    });
+
+    test("adds per-season breakdown with computed percents", async () => {
+      mockGetRegularLeaderboard.mockResolvedValue([baseRow]);
+      mockGetRegularSeasons.mockResolvedValue([
+        {
+          teamId: "1",
+          season: 2024,
+          wins: 35,
+          losses: 7,
+          ties: 6,
+          points: 76,
+          divWins: 8,
+          divLosses: 2,
+          divTies: 2,
+        },
+      ]);
+
+      const result = await getRegularLeaderboardData();
+
+      expect(result[0].seasons).toEqual([
+        {
+          season: 2024,
+          wins: 35,
+          losses: 7,
+          ties: 6,
+          points: 76,
+          divWins: 8,
+          divLosses: 2,
+          divTies: 2,
+          winPercent: Math.round((35 / (35 + 7 + 6)) * 1000) / 1000,
+          divWinPercent: Math.round((8 / (8 + 2 + 2)) * 1000) / 1000,
+          pointsPercent: Math.round((76 / ((35 + 7 + 6) * 2)) * 1000) / 1000,
+        },
+      ]);
+    });
+
+    test("includes multiple per-season rows for same team", async () => {
+      mockGetRegularLeaderboard.mockResolvedValue([baseRow]);
+      mockGetRegularSeasons.mockResolvedValue([
+        {
+          teamId: "1",
+          season: 2023,
+          wins: 30,
+          losses: 10,
+          ties: 8,
+          points: 68,
+          divWins: 7,
+          divLosses: 3,
+          divTies: 2,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          wins: 35,
+          losses: 7,
+          ties: 6,
+          points: 76,
+          divWins: 8,
+          divLosses: 2,
+          divTies: 2,
+        },
+      ]);
+
+      const result = await getRegularLeaderboardData();
+
+      expect(result[0].seasons).toHaveLength(2);
+      expect(result[0].seasons[0].season).toBe(2023);
+      expect(result[0].seasons[1].season).toBe(2024);
     });
   });
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -156,7 +156,7 @@ interface PlayoffLeaderboardRow {
 
 type PlayoffLeaderboardDbEntry = Omit<
   import("../types").PlayoffLeaderboardEntry,
-  "teamName" | "appearances" | "tieRank"
+  "teamName" | "appearances" | "tieRank" | "seasons"
 >;
 
 const mapLeaderboardRow = (row: PlayoffLeaderboardRow): PlayoffLeaderboardDbEntry => ({
@@ -192,9 +192,34 @@ export const getPlayoffLeaderboard = async (): Promise<
   return castRows<PlayoffLeaderboardRow>(result.rows).map(mapLeaderboardRow);
 };
 
+interface PlayoffSeasonRow {
+  team_id: string;
+  season: number;
+  round: number;
+}
+
+export type PlayoffSeasonDbEntry = {
+  teamId: string;
+  season: number;
+  round: number;
+};
+
+export const getPlayoffSeasons = async (): Promise<PlayoffSeasonDbEntry[]> => {
+  const db = getDbClient();
+  const result = await db.execute(
+    `SELECT team_id, season, round
+     FROM playoff_results
+     ORDER BY team_id, season`,
+  );
+  return castRows<PlayoffSeasonRow>(result.rows).map((row) => ({
+    teamId: row.team_id,
+    season: row.season,
+    round: row.round,
+  }));
+};
+
 interface RegularLeaderboardRow {
   team_id: string;
-  seasons: number;
   wins: number;
   losses: number;
   ties: number;
@@ -207,12 +232,16 @@ interface RegularLeaderboardRow {
 
 type RegularLeaderboardDbEntry = Omit<
   import("../types").RegularLeaderboardEntry,
-  "teamName" | "tieRank" | "winPercent" | "divWinPercent" | "pointsPercent"
+  | "teamName"
+  | "tieRank"
+  | "winPercent"
+  | "divWinPercent"
+  | "pointsPercent"
+  | "seasons"
 >;
 
 const mapRegularLeaderboardRow = (row: RegularLeaderboardRow): RegularLeaderboardDbEntry => ({
   teamId: row.team_id,
-  seasons: row.seasons,
   wins: row.wins,
   losses: row.losses,
   ties: row.ties,
@@ -230,7 +259,6 @@ export const getRegularLeaderboard = async (): Promise<
   const result = await db.execute(
     `SELECT
        team_id,
-       COUNT(*) AS seasons,
        SUM(wins) AS wins,
        SUM(losses) AS losses,
        SUM(ties) AS ties,
@@ -246,4 +274,57 @@ export const getRegularLeaderboard = async (): Promise<
        SUM(wins) DESC`,
   );
   return castRows<RegularLeaderboardRow>(result.rows).map(mapRegularLeaderboardRow);
+};
+
+interface RegularSeasonRow {
+  team_id: string;
+  season: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  points: number;
+  div_wins: number;
+  div_losses: number;
+  div_ties: number;
+}
+
+export type RegularSeasonDbEntry = {
+  teamId: string;
+  season: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  points: number;
+  divWins: number;
+  divLosses: number;
+  divTies: number;
+};
+
+export const getRegularSeasons = async (): Promise<RegularSeasonDbEntry[]> => {
+  const db = getDbClient();
+  const result = await db.execute(
+    `SELECT
+       team_id,
+       season,
+       wins,
+       losses,
+       ties,
+       points,
+       div_wins,
+       div_losses,
+       div_ties
+     FROM regular_results
+     ORDER BY team_id, season`,
+  );
+  return castRows<RegularSeasonRow>(result.rows).map((row) => ({
+    teamId: row.team_id,
+    season: row.season,
+    wins: row.wins,
+    losses: row.losses,
+    ties: row.ties,
+    points: row.points,
+    divWins: row.div_wins,
+    divLosses: row.div_losses,
+    divTies: row.div_ties,
+  }));
 };

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,9 +11,24 @@ import {
   mapCombinedGoalieDataFromGoaliesWithSeason,
 } from "./mappings";
 import { Report, CsvReport, PlayerWithSeason, GoalieWithSeason } from "./types";
-import { DEFAULT_TEAM_ID, TEAMS } from "./constants";
-import { getPlayersFromDb, getGoaliesFromDb, getPlayoffLeaderboard, getRegularLeaderboard } from "./db/queries";
-import type { PlayoffLeaderboardEntry, RegularLeaderboardEntry } from "./types";
+import { CURRENT_SEASON, DEFAULT_TEAM_ID, START_SEASON, TEAMS } from "./constants";
+import {
+  getPlayersFromDb,
+  getGoaliesFromDb,
+  getPlayoffLeaderboard,
+  getPlayoffSeasons,
+  getRegularLeaderboard,
+  getRegularSeasons,
+  type PlayoffSeasonDbEntry,
+  type RegularSeasonDbEntry,
+} from "./db/queries";
+import type {
+  PlayoffLeaderboardEntry,
+  PlayoffLeaderboardSeason,
+  PlayoffRoundKey,
+  RegularLeaderboardEntry,
+  RegularLeaderboardSeason,
+} from "./types";
 
 // Parser wants seasons as an array even in one-season cases
 const getSeasonParam = async (teamId: string, report: Report, season?: number): Promise<number[]> => {
@@ -277,6 +292,11 @@ export const getPlayoffLeaderboardData = async (): Promise<
   PlayoffLeaderboardEntry[]
 > => {
   const rows = await getPlayoffLeaderboard();
+  const seasonsByTeam = await getPlayoffSeasons();
+  const latestPlayoffSeason =
+    seasonsByTeam.length > 0
+      ? Math.max(...seasonsByTeam.map((entry) => entry.season))
+      : CURRENT_SEASON;
 
   const missingTeams = TEAMS.filter((t) => !rows.some((r) => r.teamId === t.id));
   const allRows = [
@@ -290,6 +310,46 @@ export const getPlayoffLeaderboardData = async (): Promise<
       firstRound: 0,
     })),
   ];
+
+  const seasonsByTeamId = new Map<string, PlayoffSeasonDbEntry[]>();
+  for (const seasonEntry of seasonsByTeam) {
+    const list = seasonsByTeamId.get(seasonEntry.teamId);
+    if (list) {
+      list.push(seasonEntry);
+    } else {
+      seasonsByTeamId.set(seasonEntry.teamId, [seasonEntry]);
+    }
+  }
+
+  const getFirstSeasonForTeam = (teamId: string): number => {
+    const team = TEAMS.find((entry) => entry.id === teamId);
+    return team?.firstSeason ?? START_SEASON;
+  };
+
+  const toRoundKey = (round: number): PlayoffRoundKey => {
+    if (round === 5) return "championship";
+    if (round === 4) return "final";
+    if (round === 3) return "conferenceFinal";
+    if (round === 2) return "secondRound";
+    if (round === 1) return "firstRound";
+    return "notQualified";
+  };
+
+  const buildPlayoffSeasons = (teamId: string): PlayoffLeaderboardSeason[] => {
+    const bySeason = new Map<number, number>();
+    const rowsForTeam = seasonsByTeamId.get(teamId) ?? [];
+    for (const row of rowsForTeam) {
+      bySeason.set(row.season, row.round);
+    }
+
+    const firstSeason = getFirstSeasonForTeam(teamId);
+    const seasons: PlayoffLeaderboardSeason[] = [];
+    for (let season = firstSeason; season <= latestPlayoffSeason; season++) {
+      const round = bySeason.get(season) ?? 0;
+      seasons.push({ season, round, key: toRoundKey(round) });
+    }
+    return seasons;
+  };
 
   return allRows.map((row, i) => {
     const team = TEAMS.find((t) => t.id === row.teamId);
@@ -311,14 +371,61 @@ export const getPlayoffLeaderboardData = async (): Promise<
       prev.secondRound === row.secondRound &&
       prev.firstRound === row.firstRound;
 
-    return { ...row, teamName, appearances, tieRank };
+    return {
+      ...row,
+      teamName,
+      appearances,
+      seasons: buildPlayoffSeasons(row.teamId),
+      tieRank,
+    };
   });
+};
+
+const computeRegularSeasonPercents = (
+  row: Pick<
+    RegularSeasonDbEntry,
+    "wins" | "losses" | "ties" | "points" | "divWins" | "divLosses" | "divTies"
+  >,
+): Pick<RegularLeaderboardSeason, "winPercent" | "divWinPercent" | "pointsPercent"> => {
+  const total = row.wins + row.losses + row.ties;
+  const divTotal = row.divWins + row.divLosses + row.divTies;
+  const winPercent = total > 0 ? Math.round((row.wins / total) * 1000) / 1000 : 0;
+  const divWinPercent = divTotal > 0 ? Math.round((row.divWins / divTotal) * 1000) / 1000 : 0;
+  const pointsPercent = total > 0 ? Math.round((row.points / (total * 2)) * 1000) / 1000 : 0;
+  return { winPercent, divWinPercent, pointsPercent };
 };
 
 export const getRegularLeaderboardData = async (): Promise<
   RegularLeaderboardEntry[]
 > => {
   const rows = await getRegularLeaderboard();
+  const seasonsByTeam = await getRegularSeasons();
+
+  const seasonsByTeamId = new Map<string, RegularSeasonDbEntry[]>();
+  for (const seasonEntry of seasonsByTeam) {
+    const list = seasonsByTeamId.get(seasonEntry.teamId);
+    if (list) {
+      list.push(seasonEntry);
+    } else {
+      seasonsByTeamId.set(seasonEntry.teamId, [seasonEntry]);
+    }
+  }
+
+  const buildRegularSeasons = (teamId: string): RegularLeaderboardSeason[] => {
+    const teamRows = seasonsByTeamId.get(teamId) ?? [];
+    return teamRows.map((row) => ({
+      season: row.season,
+      wins: row.wins,
+      losses: row.losses,
+      ties: row.ties,
+      points: row.points,
+      divWins: row.divWins,
+      divLosses: row.divLosses,
+      divTies: row.divTies,
+      ...computeRegularSeasonPercents(row),
+    }));
+  };
+
   return rows.map((row, i) => {
     const team = TEAMS.find((t) => t.id === row.teamId);
     const teamName = team?.presentName ?? row.teamId;
@@ -329,12 +436,16 @@ export const getRegularLeaderboardData = async (): Promise<
       prev.points === row.points &&
       prev.wins === row.wins;
 
-    const total = row.wins + row.losses + row.ties;
-    const divTotal = row.divWins + row.divLosses + row.divTies;
-    const winPercent = total > 0 ? Math.round((row.wins / total) * 1000) / 1000 : 0;
-    const divWinPercent = divTotal > 0 ? Math.round((row.divWins / divTotal) * 1000) / 1000 : 0;
-    const pointsPercent = total > 0 ? Math.round((row.points / (total * 2)) * 1000) / 1000 : 0;
+    const { winPercent, divWinPercent, pointsPercent } = computeRegularSeasonPercents(row);
 
-    return { ...row, teamName, tieRank, winPercent, divWinPercent, pointsPercent };
+    return {
+      ...row,
+      teamName,
+      tieRank,
+      winPercent,
+      divWinPercent,
+      pointsPercent,
+      seasons: buildRegularSeasons(row.teamId),
+    };
   });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,13 +156,41 @@ export type PlayoffLeaderboardEntry = {
   conferenceFinals: number;
   secondRound: number;
   firstRound: number;
+  seasons: PlayoffLeaderboardSeason[];
   tieRank: boolean;
+};
+
+export type RegularLeaderboardSeason = {
+  season: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  points: number;
+  divWins: number;
+  divLosses: number;
+  divTies: number;
+  winPercent: number;
+  divWinPercent: number;
+  pointsPercent: number;
+};
+
+export type PlayoffRoundKey =
+  | "championship"
+  | "final"
+  | "conferenceFinal"
+  | "secondRound"
+  | "firstRound"
+  | "notQualified";
+
+export type PlayoffLeaderboardSeason = {
+  season: number;
+  round: number;
+  key: PlayoffRoundKey;
 };
 
 export type RegularLeaderboardEntry = {
   teamId: string;
   teamName: string;
-  seasons: number;
   wins: number;
   losses: number;
   ties: number;
@@ -174,5 +202,6 @@ export type RegularLeaderboardEntry = {
   divWinPercent: number;
   pointsPercent: number;
   regularTrophies: number;
+  seasons: RegularLeaderboardSeason[];
   tieRank: boolean;
 };


### PR DESCRIPTION
## Summary

This PR adds season-level breakdowns to team leaderboard endpoints and updates docs/spec/tests accordingly.

### API changes

- `GET /leaderboard/regular`
  - Adds `seasons` array with per-season regular results:
    - `season`, `wins`, `losses`, `ties`, `points`
    - `divWins`, `divLosses`, `divTies`
    - `winPercent`, `divWinPercent`, `pointsPercent`
  - Keeps existing root-level aggregate fields (no `seasonCount` field).

- `GET /leaderboard/playoffs`
  - Adds `seasons` array with per-season playoff status:
    - `season`, `round`, `key`
  - `key` values:
    - `championship`, `final`, `conferenceFinal`, `secondRound`, `firstRound`, `notQualified`
  - Missing team-season playoff row is represented as:
    - `round: 0`, `key: "notQualified"`
  - Season range now ends at latest playoff season found in DB (global max playoff season), so future seasons are not incorrectly shown as `notQualified`.

### Internal changes

- Added new leaderboard season-related types in `src/types.ts`.
- Added DB query functions:
  - `getPlayoffSeasons()`
  - `getRegularSeasons()`
- Updated leaderboard service composition in `src/services.ts` to merge aggregate + season arrays.
- Updated OpenAPI schemas in `openapi.yaml`.
- Updated tests in:
  - `src/__tests__/queries.test.ts`
  - `src/__tests__/services.test.ts`
  - `src/__tests__/routes.test.ts`
- Updated README with leaderboard endpoint examples and response notes.

### Tooling adjustment

- Updated `package.json` test scripts to pass `--watchman=false` for non-watch runs:
  - `test`
  - `test:coverage`
- Reason: avoid watchman permission failures in restricted environments while keeping test behavior unchanged.

## Validation

- `npm run verify` passes (lint, typecheck, build, tests, 100% coverage).
