### PR TITLE
Feature: Add snapshot-backed API responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,15 @@ R2_ACCESS_KEY_ID=your_access_key_id
 R2_SECRET_ACCESS_KEY=your_secret_access_key
 R2_BUCKET_NAME=ffhl-stats-csv
 
+# Optional runtime snapshot storage
+# When true, snapshot generation also uploads JSON payloads to R2 and
+# the API can read them at request time if local generated files are absent.
+USE_R2_SNAPSHOTS=false
+# R2_SNAPSHOT_BUCKET_NAME=ffhl-stats-snapshots  # Optional; defaults to R2_BUCKET_NAME
+# R2_SNAPSHOT_PREFIX=snapshots                  # Optional object prefix inside the bucket
+# SNAPSHOT_DIR=generated/snapshots             # Optional local snapshot directory
+# SNAPSHOT_CACHE_TTL_MS=60000                  # Optional in-memory snapshot cache ttl
+
 # Playwright imports post-process command when output dir is csv/temp
 # false: parseAndUploadCsv (clean/move/import pipeline)
 # true:  parseAndUploadRawCsv (upload raw temp CSVs to R2 rawFiles/ + cleanup temp)

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ csv/
 # Local-only Fantrax Playwright artifacts
 src/playwright/.fantrax/
 
+# Generated API snapshots
+generated/
+
 # Git worktrees
 .worktrees/
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Lightweight API to serve NHL fantasy league (FFHL) team stats as JSON. Data is s
 8. Go to endpoints mentioned below
 ```
 
-**Note:** The API reads all data from the database. CSV files are only needed as the import source.
+**Note:** CSV files are only the import source. The API reads live data from Turso and can also serve generated JSON snapshots for read-mostly endpoints.
 
 ## Endpoints
 
@@ -48,6 +48,7 @@ The spec is hand-crafted in `openapi.yaml` at the repo root — there is no code
 3. Restart the dev server and visit `/api-docs` to preview the changes
 
 **Key files:**
+
 - `openapi.yaml` — the spec source
 - `src/openapi.ts` — route handlers that serve `/openapi.json` and `/api-docs`
 - `src/index.ts` — registers the two public routes
@@ -292,7 +293,7 @@ It will:
   - `csv/<teamId>/{regular|playoffs}-YYYY-YYYY.csv`
 - Create `csv/<teamId>/` if it doesn't exist
 - Upload to R2 if `USE_R2_STORAGE=true` (CSV backup)
-- Import into database (`npm run db:import:stats`)
+- Import into database (`npm run db:import:stats`) and regenerate API snapshots
 - Clean up temp files after successful DB import, unless `--keep-temp` is used
 - If `--season` is omitted, all matched seasons are uploaded/imported
 - If `--report-type` is omitted, `both` is the default and all matched report types are uploaded/imported
@@ -354,7 +355,7 @@ Required environment variables: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, and AP
 
 **Local development:** The API reads from a local SQLite file (`local.db`), created by running `npm run db:migrate` and `npm run db:import:stats`.
 
-**CSV files** are the import source. They can be stored locally in `csv/<teamId>/` and optionally backed up to Cloudflare R2. CSV files are NOT used at runtime by the API.
+**CSV files** are the import source. They can be stored locally in `csv/<teamId>/` and optionally backed up to Cloudflare R2. Runtime responses come from Turso or generated JSON snapshots, not from CSV files.
 
 Multi-team CSV layout (local or R2):
 
@@ -408,7 +409,10 @@ curl https://ffhl-stats-api.vercel.app/api/seasons
 
 ## Cloud Storage (Cloudflare R2)
 
-CSV files can be backed up to Cloudflare R2 for team sharing and archival. R2 is **not** used at runtime by the API — it's purely for managing CSV files.
+Cloudflare R2 can be used for two separate purposes:
+
+- CSV backup and sharing
+- generated API snapshot storage for read-mostly endpoints
 
 ### Configuration (environment variables for R2 scripts)
 
@@ -417,6 +421,11 @@ R2_ENDPOINT=https://[account-id].r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your_access_key_id
 R2_SECRET_ACCESS_KEY=your_secret_access_key
 R2_BUCKET_NAME=ffhl-stats-csv
+USE_R2_SNAPSHOTS=false
+# R2_SNAPSHOT_BUCKET_NAME=ffhl-stats-snapshots  # Optional; defaults to R2_BUCKET_NAME
+# R2_SNAPSHOT_PREFIX=snapshots                  # Optional object prefix
+# SNAPSHOT_DIR=generated/snapshots              # Optional local snapshot directory
+# SNAPSHOT_CACHE_TTL_MS=60000                   # Optional in-memory snapshot cache ttl
 ```
 
 ### Managing R2 Data
@@ -451,6 +460,8 @@ npm run r2:download -- --team=1       # Download only team 1
 npm run r2:download -- --force        # Force overwrite existing files
 ```
 
+`npm run r2:download` skips runtime snapshot objects under the configured snapshot prefix.
+
 **Download raw temp CSV files from `rawFiles/` in R2 to `csv/temp/`:**
 
 ```bash
@@ -466,6 +477,32 @@ When `USE_R2_STORAGE=true`, the import pipeline automatically uploads to R2 and 
 ```bash
 npm run parseAndUploadCsv  # Loads .env, cleans CSVs, uploads to R2, imports to DB
 npm run parseAndUploadRawCsv # Loads .env, uploads raw csv/temp files to rawFiles/, removes uploaded temp files
+```
+
+## API snapshots
+
+Read-mostly endpoints can be served from generated JSON snapshots. This is intended to cut Turso traffic and reduce response time for historical payloads.
+
+Currently snapshotted response families are:
+
+- `/career/players`
+- `/career/goalies`
+- `/leaderboard/regular`
+- `/leaderboard/playoffs`
+- `/players/combined/{reportType}?teamId=<id>` when `startFrom` is omitted
+- `/goalies/combined/{reportType}?teamId=<id>` when `startFrom` is omitted
+
+Behavior:
+
+- Successful `db:import:*` scripts refresh `import_metadata.last_modified` and then run `npm run snapshot:generate`
+- snapshots are written locally to `generated/snapshots/`
+- if `USE_R2_SNAPSHOTS=true`, the same generation step also uploads JSON snapshots to R2
+- at runtime the API tries local snapshots first, then R2, and finally falls back to live DB queries
+
+Manual generation:
+
+```bash
+npm run snapshot:generate
 ```
 
 ## Database (Turso/SQLite)
@@ -512,6 +549,8 @@ npm run db:import:stats:current # Import only current season into remote Turso
 npm run db:import:stats -- --season=2018 # Import only 2018-2019 into remote Turso
 npm run db:import:stats -- --season=2018 --report-type=regular # Import only regular from one season
 ```
+
+All successful `db:import:*` commands regenerate API snapshots after the database update completes.
 
 Get credentials from the [Turso dashboard](https://turso.tech).
 
@@ -570,13 +609,13 @@ Consumer applications can poll the `/last-modified` endpoint to detect when data
 let lastKnownTimestamp: string | null = null;
 
 async function checkForUpdates() {
-  const response = await fetch('https://your-api.com/last-modified', {
-    headers: { 'X-API-Key': 'your-api-key' }
+  const response = await fetch("https://your-api.com/last-modified", {
+    headers: { "X-API-Key": "your-api-key" },
   });
   const data = await response.json();
 
   if (data.lastModified !== lastKnownTimestamp) {
-    console.log('Data updated! Refetching stats...');
+    console.log("Data updated! Refetching stats...");
     lastKnownTimestamp = data.lastModified;
     await refetchAllStats();
   }
@@ -651,5 +690,6 @@ Written with [TypeScript](https://www.typescriptlang.org/), using [micro](https:
 
 - Standardize request validation + error response shape
 - Tighten OpenAPI spec: type `scores` and `scoresByPosition` object keys as fixed stat-field enums (requires upgrading spec to OpenAPI 3.1 for `propertyNames` support)
+- Add paging or search-first loading for large career lists to reduce initial payload size further
 
 Feel free to suggest feature / implementation polishing with writing issue or make PR if you want to contribute!

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,6 +23,7 @@ npm run verify
 ```
 
 This should:
+
 - ✅ Pass ESLint checks (no warnings)
 - ✅ Pass TypeScript compilation
 - ✅ Build successfully to lib/
@@ -35,8 +36,9 @@ This should:
 ### Daily Development Loop
 
 1. **Create feature branch**
+
    ```bash
-   git checkout -b feat/your-feature-name
+   git checkout -b feature/your-feature-name
    ```
 
 2. **Make changes incrementally**
@@ -45,14 +47,16 @@ This should:
    - Run tests in watch mode: `npm run test:watch`
 
 3. **Before committing**
+
    ```bash
    npm run verify  # Must pass - runs all quality gates
    ```
 
 4. **Commit with descriptive message**
+
    ```bash
    git add .
-   git commit -m "feat: add XYZ functionality"
+   git commit -m "Feature: Add XYZ functionality"
    ```
 
 5. **Push and create PR** (if working with others)
@@ -66,6 +70,7 @@ npm run verify
 ```
 
 **What it runs:**
+
 1. `npm run lint:check` - ESLint with 0 warnings allowed
 2. `npm run typecheck` - TypeScript compilation check
 3. `npm run build` - Production build (outputs to lib/)
@@ -78,23 +83,27 @@ npm run verify
 ## npm Scripts Reference
 
 ### Development
+
 - `npm run dev` - Start development server with hot reload (nodemon)
 - `npm start` - Start production server
 - `npm run build` - Build for production (TypeScript → JavaScript)
 
 ### Code Quality
+
 - `npm run lint:check` - Run ESLint (read-only)
 - `npm run lint:fix` - Run ESLint with auto-fix
 - `npm run typecheck` - TypeScript type checking without build
 - `npm run format` - Format code with Prettier
 
 ### Testing
+
 - `npm test` - Run all tests once
 - `npm run test:watch` - Run tests in watch mode (development)
 - `npm run test:coverage` - Run tests with coverage report
 - `npm run verify` - **Full quality gate** (lint + typecheck + build + coverage)
 
 ### CSV Data Import
+
 - `npm run playwright:install` - Installs or refreshes Playwright's Chromium browser binaries
 - `npm run playwright:sync:leagues` - Scrape and save league IDs + season dates mapping
 - `npm run playwright:sync:playoffs` - Scrape and save playoff bracket data (schemaVersion 3: includes `roundReached` and `isChampion` per team). Use `--import-db` to upsert results into the local database after syncing.
@@ -116,27 +125,31 @@ npm run verify
 - Rows with `0` games are imported into the database, but player/goalie API queries currently filter them out.
 
 ### Database (Turso/SQLite)
+
 - `npm run db:migrate` - Create/update database schema
 - `npm run db:pull:remote` - Replace `local.db` by pulling full schema + data from remote Turso (`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` in `.env`); creates timestamped backup in `.backups/`
 - `npm run db:backups:clean` - Remove all files under `.backups/`
-- `npm run db:import:stats` - Import all CSV files into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote)
-- `npm run db:import:stats -- --season=YYYY` - Import only one season into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote)
-- `npm run db:import:stats:current` - Import only current season into database
-- `npm run db:import:stats -- --report-type=regular|playoffs` - Import only one report type into database
-- `npm run db:import:playoff-results` - Import playoff round results from `fantrax-playoffs.json` into database (set `USE_REMOTE_DB=true` to target remote Turso)
-- `npm run db:import:regular-results` - Imports regular season standings from `fantrax-regular.json` into the `regular_results` table. Set `USE_REMOTE_DB=true` to target remote Turso.
+- `npm run db:import:stats` - Import all CSV files into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Regenerates API snapshots after a successful import.
+- `npm run db:import:stats -- --season=YYYY` - Import only one season into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Regenerates API snapshots after a successful import.
+- `npm run db:import:stats:current` - Import only current season into database. Regenerates API snapshots after a successful import.
+- `npm run db:import:stats -- --report-type=regular|playoffs` - Import only one report type into database. Regenerates API snapshots after a successful import.
+- `npm run db:import:playoff-results` - Import playoff round results from `fantrax-playoffs.json` into database (set `USE_REMOTE_DB=true` to target remote Turso). Regenerates API snapshots after a successful import.
+- `npm run db:import:regular-results` - Imports regular season standings from `fantrax-regular.json` into the `regular_results` table. Set `USE_REMOTE_DB=true` to target remote Turso. Regenerates API snapshots after a successful import.
+- `npm run snapshot:generate` - Generate JSON snapshots for historical endpoints and default combined responses into `generated/snapshots/`. If `USE_R2_SNAPSHOTS=true`, uploads them to R2 too.
 
-### R2 Storage (CSV backup)
+### R2 Storage (CSV backup + optional API snapshots)
+
 - `npm run r2:upload` - Upload all CSV files to R2
 - `npm run r2:upload -- --season=YYYY` - Upload only one season to R2
 - `npm run r2:upload:current` - Upload only current season to R2
 - `npm run r2:upload -- --report-type=regular|playoffs` - Upload only one report type to R2
-- `npm run r2:download` - Download CSV files from R2
+- `npm run r2:download` - Download CSV files from R2. Snapshot objects under the configured snapshot prefix are ignored.
 - `npm run r2:upload:raw` - Force-upload raw `csv/temp/*.csv` to `rawFiles/<teamId>/...` and remove uploaded temp files
 - `npm run r2:download:raw` - Download all `rawFiles/` objects from R2 into `csv/temp/` (force overwrite)
 - `npm run parseAndUploadRawCsv` - Post-import raw pipeline: upload `csv/temp` to `rawFiles/` and clean uploaded temp files
 
 ### Utilities
+
 - `npm run clean` - Remove lib/ directory
 
 ---
@@ -149,12 +162,12 @@ The frontend generates TypeScript types from this file using `openapi-typescript
 
 ### When to update the spec
 
-| Change | Required spec update |
-|--------|----------------------|
-| New endpoint | Add path block with all parameters and response schemas |
-| Changed response shape | Update the matching `components/schemas` entry |
-| Deleted endpoint | Remove the path block |
-| Changed parameter | Update `components/parameters` or the path-level param definition |
+| Change                 | Required spec update                                              |
+| ---------------------- | ----------------------------------------------------------------- |
+| New endpoint           | Add path block with all parameters and response schemas           |
+| Changed response shape | Update the matching `components/schemas` entry                    |
+| Deleted endpoint       | Remove the path block                                             |
+| Changed parameter      | Update `components/parameters` or the path-level param definition |
 
 ### How to verify locally
 
@@ -200,6 +213,11 @@ USE_REMOTE_DB=false
 # R2_SECRET_ACCESS_KEY=your_secret_access_key
 # R2_BUCKET_NAME=ffhl-stats-csv
 # USE_R2_STORAGE=true               # Enables R2 upload in import pipeline
+# USE_R2_SNAPSHOTS=false            # Upload/read generated API snapshots via R2
+# R2_SNAPSHOT_BUCKET_NAME=          # Optional; defaults to R2_BUCKET_NAME
+# R2_SNAPSHOT_PREFIX=snapshots      # Optional object prefix for snapshot JSONs
+# SNAPSHOT_DIR=generated/snapshots  # Optional local snapshot directory
+# SNAPSHOT_CACHE_TTL_MS=60000       # Optional in-memory snapshot cache ttl
 # RAW_UPLOAD=false
 #   Optional Playwright post-import toggle when --out=csv/temp
 #   true  -> run parseAndUploadRawCsv (upload raw csv/temp to R2 rawFiles/ + cleanup)
@@ -220,16 +238,19 @@ Set these in Vercel Dashboard → Project Settings → Environment Variables:
 ## Code Style
 
 ### Enforced by Tooling
+
 - **ESLint**: TypeScript ESLint rules, no warnings allowed (`--max-warnings 0`)
 - **Prettier**: Auto-formatting on save (recommended VSCode settings)
 - **TypeScript**: Strict mode enabled
 
 #### Console output rules (ESLint `no-console`)
+
 `src/playwright/**/*.ts` files are CLI utilities and have a strict rule: only `console.info` and `console.error` are allowed — `console.log` and `console.warn` are ESLint **errors**. The rest of `src/` has `no-console: warn`, which also fails `lint:check` due to `--max-warnings 0`.
 
 **Rule of thumb for any `src/` file:** use `console.info` for informational output and `console.error` for errors. Never use `console.log` or `console.warn`.
 
 ### Conventions
+
 - Use `async/await` over promise chains
 - Prefer explicit types over `any`
 - Extract magic numbers to constants
@@ -240,9 +261,14 @@ Set these in Vercel Dashboard → Project Settings → Environment Variables:
 ### TypeScript patterns
 
 **Derive types from constants — don't duplicate them:**
+
 ```ts
 // ✅ Single source of truth
-export const REPORT_TYPES = ["playoffs", "regular", "both"] as const satisfies readonly Report[];
+export const REPORT_TYPES = [
+  "playoffs",
+  "regular",
+  "both",
+] as const satisfies readonly Report[];
 export type Report = (typeof REPORT_TYPES)[number];
 
 // ❌ Two things to keep in sync
@@ -251,21 +277,29 @@ export const REPORT_TYPES: Report[] = ["playoffs", "regular", "both"];
 ```
 
 **Use `satisfies` to validate constant shapes without widening types:**
+
 ```ts
 // ✅ Validates all values are numbers; literal types are preserved
-export const HTTP_STATUS = { OK: 200, BAD_REQUEST: 400 } as const satisfies Record<string, number>;
+export const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+} as const satisfies Record<string, number>;
 ```
 
 **Add `readonly` to array parameters that are not mutated:**
+
 ```ts
 // ✅ Communicates intent; callers can pass as-const arrays without a type error
 const getMaxByField = <T, K>(items: readonly T[], fields: readonly K[]) => { ... };
 ```
 
 **Cast DB rows through a named helper — don't scatter double-casts:**
+
 ```ts
 // ✅ Single trust boundary, one place to update if the DB client improves
-function castRows<T>(rows: unknown[]): T[] { return rows as T[]; }
+function castRows<T>(rows: unknown[]): T[] {
+  return rows as T[];
+}
 return castRows<PlayerRow>(result.rows).map(mapPlayerRow);
 
 // ❌ Noisy, intent unclear
@@ -273,17 +307,23 @@ return (result.rows as unknown as PlayerRow[]).map(mapPlayerRow);
 ```
 
 **Validate before casting union types — use existing guards:**
+
 ```ts
 // ✅ Cast only happens in the valid branch
-if (!reportTypeAvailable(req.params.reportType as Report)) { return 400; }
+if (!reportTypeAvailable(req.params.reportType as Report)) {
+  return 400;
+}
 const report = req.params.reportType as Report;
 
 // ❌ Cast before validation
 const report = req.params.reportType as Report;
-if (!reportTypeAvailable(report)) { return 400; }
+if (!reportTypeAvailable(report)) {
+  return 400;
+}
 ```
 
 ### File Organization
+
 - Source code: `src/`
 - Tests: `src/__tests__/`
 - Database layer: `src/db/`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -126,7 +126,7 @@ npm run verify
 
 ### Database (Turso/SQLite)
 
-- `npm run db:migrate` - Create/update database schema
+- `npm run db:migrate` - Create/update database schema and performance indexes, including career lookup indexes on `player_id` and `goalie_id`
 - `npm run db:pull:remote` - Replace `local.db` by pulling full schema + data from remote Turso (`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` in `.env`); creates timestamped backup in `.backups/`
 - `npm run db:backups:clean` - Remove all files under `.backups/`
 - `npm run db:import:stats` - Import all CSV files into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Regenerates API snapshots after a successful import.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,6 +12,7 @@ All new code **must maintain 100% test coverage:**
 **Enforcement:** `npm run verify` must pass before any commit.
 
 **Excluded from coverage:**
+
 - **db/client.ts only**: Thin wrapper around Turso/libSQL client — tested via integration
 
 ---
@@ -27,16 +28,19 @@ All new code **must maintain 100% test coverage:**
 ## Running Tests
 
 ### All tests with coverage
+
 ```bash
 npm run test:coverage
 ```
 
 ### Watch mode (development)
+
 ```bash
 npm run test:watch
 ```
 
 ### Full quality gate
+
 ```bash
 npm run verify  # Runs lint, typecheck, build, and test:coverage
 ```
@@ -51,13 +55,13 @@ Many functions are async (database queries, resolveTeamId, etc.). Always use `aw
 
 ```typescript
 // ❌ Wrong
-test('gets available seasons', () => {
+test("gets available seasons", () => {
   const result = availableSeasons();
   expect(result).toEqual([2023, 2024]);
 });
 
 // ✅ Correct
-test('gets available seasons', async () => {
+test("gets available seasons", async () => {
   const result = await availableSeasons();
   expect(result).toEqual([2023, 2024]);
 });
@@ -114,11 +118,12 @@ src/
     ├── mappings.test.ts  # Data transformation (CSV parsing for import, combined data mapping)
     ├── queries.test.ts   # Database query layer
     ├── routes.test.ts    # API endpoint handlers
+    ├── snapshots.test.ts # Snapshot loading, R2 fallback, cache behavior
     ├── services.test.ts  # Business logic (DB → scored data)
     └── fixtures.ts       # Shared test data
 ```
 
-**Total: 224 tests across 7 test suites**
+Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches.
 
 ---
 
@@ -133,12 +138,14 @@ src/
 5. **Async operations** - Test promise resolution and rejection
 
 **If you can't test something:**
+
 - Don't exclude it from coverage without discussion
 - Don't lower coverage thresholds (100% is required)
 - Do propose mocking strategies
 - Do document why it's difficult and seek guidance
 
 **For external SDK integrations:**
+
 - Mock at the module boundary (e.g., mock `../db/client`, not the libSQL SDK)
 - Test your wrapper code through the mocked dependency
 - Only exclude the thinnest possible adapter layer (e.g., `db/client.ts`)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "db:import:stats:current": "tsx scripts/import-stats-to-db.ts --current-only",
     "db:import:playoff-results": "tsx scripts/db-import-playoff-results.ts",
     "db:import:regular-results": "tsx scripts/db-import-regular-results.ts",
+    "snapshot:generate": "tsx scripts/generate-snapshots.ts",
     "parseAndUploadCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; USE_R2_STORAGE=${USE_R2_STORAGE:-false} USE_REMOTE_DB=${USE_REMOTE_DB:-false} ./scripts/import-temp-csv.sh",
     "parseAndUploadRawCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; tsx scripts/upload-raw-to-r2.ts",
     "start": "npm run build && node lib/server.js",

--- a/scripts/db-import-playoff-results.ts
+++ b/scripts/db-import-playoff-results.ts
@@ -19,6 +19,7 @@ console.info(`Import to DB: ${process.env.TURSO_DATABASE_URL}`);
 
 import { readFileSync } from "fs";
 import path from "path";
+import { spawnSync } from "child_process";
 import { getDbClient } from "../src/db/client";
 
 const PLAYOFFS_PATH = path.resolve(
@@ -51,7 +52,7 @@ const main = async () => {
   } catch {
     console.error(
       `❌  Could not read ${PLAYOFFS_PATH}.\n` +
-      `   Run npm run playwright:sync:playoffs first to generate it.`,
+        `   Run npm run playwright:sync:playoffs first to generate it.`,
     );
     process.exit(1);
   }
@@ -64,7 +65,7 @@ const main = async () => {
   ) {
     console.error(
       `❌  Unsupported schema version (${file.schemaVersion ?? "unknown"}).\n` +
-      `   Expected schemaVersion 2 or 3. Re-run npm run playwright:sync:playoffs.`,
+        `   Expected schemaVersion 2 or 3. Re-run npm run playwright:sync:playoffs.`,
     );
     process.exit(1);
   }
@@ -89,8 +90,22 @@ const main = async () => {
     }
   }
 
+  await db.execute({
+    sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
+    args: ["last_modified", new Date().toISOString()],
+  });
+
   console.log(`✅  Imported playoff results from ${PLAYOFFS_PATH}`);
   console.log(`   Upserted: ${upserted}  Skipped (no round data): ${skipped}`);
+
+  console.log("📸  Regenerating API snapshots...");
+  const snapshotRun = spawnSync("npm", ["run", "snapshot:generate"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (snapshotRun.status !== 0) {
+    throw new Error("Snapshot generation failed after playoff results import");
+  }
 };
 
 main().catch((error) => {

--- a/scripts/db-import-regular-results.ts
+++ b/scripts/db-import-regular-results.ts
@@ -18,6 +18,7 @@ console.info(`Import to DB: ${process.env.TURSO_DATABASE_URL}`);
 
 import { readFileSync } from "fs";
 import path from "path";
+import { spawnSync } from "child_process";
 import { getDbClient } from "../src/db/client";
 
 const REGULAR_PATH = path.resolve(
@@ -56,7 +57,7 @@ const main = async () => {
   } catch {
     console.error(
       `❌  Could not read ${REGULAR_PATH}.\n` +
-      `   Run npm run playwright:sync:regular first to generate it.`,
+        `   Run npm run playwright:sync:regular first to generate it.`,
     );
     process.exit(1);
   }
@@ -66,7 +67,7 @@ const main = async () => {
   if (file.schemaVersion !== 1 || !Array.isArray(file.seasons)) {
     console.error(
       `❌  Unsupported schema version (${file.schemaVersion ?? "unknown"}).\n` +
-      `   Expected schemaVersion 1. Re-run npm run playwright:sync:regular.`,
+        `   Expected schemaVersion 1. Re-run npm run playwright:sync:regular.`,
     );
     process.exit(1);
   }
@@ -97,8 +98,22 @@ const main = async () => {
     }
   }
 
+  await db.execute({
+    sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
+    args: ["last_modified", new Date().toISOString()],
+  });
+
   console.info(`✅  Imported regular results from ${REGULAR_PATH}`);
   console.info(`   Upserted: ${upserted}`);
+
+  console.info("📸  Regenerating API snapshots...");
+  const snapshotRun = spawnSync("npm", ["run", "snapshot:generate"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (snapshotRun.status !== 0) {
+    throw new Error("Snapshot generation failed after regular results import");
+  }
 };
 
 main().catch((error) => {

--- a/scripts/db-migrate.ts
+++ b/scripts/db-migrate.ts
@@ -53,6 +53,10 @@ const SCHEMA_SQL = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_players_lookup ON players(team_id, season, report_type)`,
   `CREATE INDEX IF NOT EXISTS idx_goalies_lookup ON goalies(team_id, season, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_players_career_id
+    ON players(player_id, season DESC, team_id, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_goalies_career_id
+    ON goalies(goalie_id, season DESC, team_id, report_type)`,
   `CREATE INDEX IF NOT EXISTS idx_players_name ON players(name)`,
   `CREATE INDEX IF NOT EXISTS idx_goalies_name ON goalies(name)`,
   `CREATE TABLE IF NOT EXISTS playoff_results (
@@ -92,13 +96,15 @@ const main = async () => {
 
   await db.execute({
     sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
-    args: ["schema_version", "3"],
+    args: ["schema_version", "4"],
   });
 
   console.log("✅ Migration complete!");
-  console.log("   Tables: players, goalies, import_metadata, playoff_results, regular_results");
   console.log(
-    "   Indexes: idx_players_lookup, idx_goalies_lookup, idx_players_name, idx_goalies_name, idx_playoff_results_season, idx_regular_results_season"
+    "   Tables: players, goalies, import_metadata, playoff_results, regular_results",
+  );
+  console.log(
+    "   Indexes: idx_players_lookup, idx_goalies_lookup, idx_players_career_id, idx_goalies_career_id, idx_players_name, idx_goalies_name, idx_playoff_results_season, idx_regular_results_season",
   );
 };
 

--- a/scripts/download-from-r2.ts
+++ b/scripts/download-from-r2.ts
@@ -14,10 +14,15 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { S3Client, ListObjectsV2Command, GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  ListObjectsV2Command,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
 import fs from "fs";
 import path from "path";
 import { Readable } from "stream";
+import { getSnapshotPrefix } from "../src/snapshots";
 
 interface DownloadOptions {
   teamId?: string;
@@ -50,7 +55,9 @@ const getR2Config = () => {
 
   if (!endpoint || !accessKeyId || !secretAccessKey || !bucketName) {
     console.error("❌ Missing R2 environment variables:");
-    console.error("   R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME");
+    console.error(
+      "   R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME",
+    );
     console.error("\nSet these in your .env file or environment.");
     process.exit(1);
   }
@@ -113,6 +120,9 @@ const downloadFiles = async (options: DownloadOptions) => {
     if (obj.Key === "manifest.json" || obj.Key === "last-modified.txt") {
       continue;
     }
+    if (obj.Key.startsWith(`${getSnapshotPrefix()}/`)) {
+      continue;
+    }
 
     const localPath = path.join(process.cwd(), "csv", obj.Key);
     const localDir = path.dirname(localPath);
@@ -164,12 +174,16 @@ const downloadFiles = async (options: DownloadOptions) => {
       console.log(`    ✓ ${action}: ${localPath}`);
       downloaded++;
     } catch (error) {
-      console.error(`    ❌ Failed: ${error instanceof Error ? error.message : String(error)}`);
+      console.error(
+        `    ❌ Failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
       skipped++;
     }
   }
 
-  console.log(`\n${options.dryRun ? "Would download" : "Downloaded"} ${downloaded} files`);
+  console.log(
+    `\n${options.dryRun ? "Would download" : "Downloaded"} ${downloaded} files`,
+  );
   if (skipped > 0) {
     console.log(`Skipped ${skipped} files`);
   }
@@ -182,7 +196,10 @@ const main = async () => {
     const options = parseArgs();
     await downloadFiles(options);
   } catch (error) {
-    console.error("\n❌ Error:", error instanceof Error ? error.message : String(error));
+    console.error(
+      "\n❌ Error:",
+      error instanceof Error ? error.message : String(error),
+    );
     process.exit(1);
   }
 };

--- a/scripts/generate-snapshots.ts
+++ b/scripts/generate-snapshots.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env tsx
+
+import dotenv from "dotenv";
+dotenv.config();
+
+if (process.env.USE_REMOTE_DB !== "true") {
+  process.env.TURSO_DATABASE_URL = "file:local.db";
+  delete process.env.TURSO_AUTH_TOKEN;
+}
+
+import fs from "fs";
+import path from "path";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { TEAMS } from "../src/constants";
+import {
+  getCareerGoaliesData,
+  getCareerPlayersData,
+  getGoaliesStatsCombined,
+  getPlayoffLeaderboardData,
+  getPlayersStatsCombined,
+  getRegularLeaderboardData,
+} from "../src/services";
+import {
+  createSnapshotR2Client,
+  getCareerGoaliesSnapshotKey,
+  getCareerPlayersSnapshotKey,
+  getCombinedSnapshotKey,
+  getPlayoffsLeaderboardSnapshotKey,
+  getRegularLeaderboardSnapshotKey,
+  getSnapshotBucketName,
+  getSnapshotFilePath,
+  getSnapshotManifestKey,
+  getSnapshotObjectKey,
+  isR2SnapshotConfigAvailable,
+} from "../src/snapshots";
+import { getLastModifiedFromDb } from "../src/db/queries";
+
+type SnapshotReport = "regular" | "playoffs" | "both";
+
+type SnapshotEntry = {
+  bytes: number;
+  data: unknown;
+  key: string;
+};
+
+type SnapshotManifest = {
+  generatedAt: string;
+  lastModified: string | null;
+  schemaVersion: number;
+  snapshots: Array<{
+    bytes: number;
+    key: string;
+  }>;
+};
+
+const SNAPSHOT_REPORTS: readonly SnapshotReport[] = [
+  "regular",
+  "playoffs",
+  "both",
+];
+
+const shouldUploadToR2 = (): boolean => process.env.USE_R2_SNAPSHOTS === "true";
+
+const writeSnapshotFile = (snapshotKey: string, body: string): number => {
+  const filePath = getSnapshotFilePath(snapshotKey);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, body);
+  return Buffer.byteLength(body);
+};
+
+const uploadSnapshotFile = async (
+  snapshotKey: string,
+  body: string,
+  generatedAt: string,
+): Promise<void> => {
+  const bucketName = getSnapshotBucketName();
+  if (!bucketName) {
+    throw new Error("Missing snapshot bucket configuration");
+  }
+
+  await createSnapshotR2Client().send(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: getSnapshotObjectKey(snapshotKey),
+      Body: body,
+      ContentType: "application/json",
+      Metadata: {
+        "generated-at": generatedAt,
+      },
+    }),
+  );
+};
+
+const buildSnapshotEntries = async (): Promise<SnapshotEntry[]> => {
+  const entries: SnapshotEntry[] = [];
+
+  entries.push({
+    key: getCareerPlayersSnapshotKey(),
+    data: await getCareerPlayersData(),
+    bytes: 0,
+  });
+  entries.push({
+    key: getCareerGoaliesSnapshotKey(),
+    data: await getCareerGoaliesData(),
+    bytes: 0,
+  });
+  entries.push({
+    key: getRegularLeaderboardSnapshotKey(),
+    data: await getRegularLeaderboardData(),
+    bytes: 0,
+  });
+  entries.push({
+    key: getPlayoffsLeaderboardSnapshotKey(),
+    data: await getPlayoffLeaderboardData(),
+    bytes: 0,
+  });
+
+  for (const team of TEAMS) {
+    for (const report of SNAPSHOT_REPORTS) {
+      entries.push({
+        key: getCombinedSnapshotKey("players", report, team.id),
+        data: await getPlayersStatsCombined(report, team.id),
+        bytes: 0,
+      });
+      entries.push({
+        key: getCombinedSnapshotKey("goalies", report, team.id),
+        data: await getGoaliesStatsCombined(report, team.id),
+        bytes: 0,
+      });
+    }
+  }
+
+  return entries;
+};
+
+const main = async () => {
+  const generatedAt = new Date().toISOString();
+  const lastModified = await getLastModifiedFromDb();
+
+  console.info("📸 Generating API snapshots...");
+  console.info(`   Target DB: ${process.env.TURSO_DATABASE_URL}`);
+  console.info(`   Upload to R2: ${shouldUploadToR2()}`);
+
+  const entries = await buildSnapshotEntries();
+
+  for (const entry of entries) {
+    const body = JSON.stringify(entry.data);
+    entry.bytes = writeSnapshotFile(entry.key, body);
+
+    if (shouldUploadToR2()) {
+      if (!isR2SnapshotConfigAvailable()) {
+        throw new Error(
+          "USE_R2_SNAPSHOTS=true requires R2 snapshot environment variables",
+        );
+      }
+      await uploadSnapshotFile(entry.key, body, generatedAt);
+    }
+  }
+
+  const manifest: SnapshotManifest = {
+    schemaVersion: 1,
+    generatedAt,
+    lastModified,
+    snapshots: entries.map((entry) => ({
+      key: entry.key,
+      bytes: entry.bytes,
+    })),
+  };
+
+  const manifestBody = JSON.stringify(manifest, null, 2);
+  writeSnapshotFile(getSnapshotManifestKey(), manifestBody);
+
+  if (shouldUploadToR2()) {
+    await uploadSnapshotFile(
+      getSnapshotManifestKey(),
+      manifestBody,
+      generatedAt,
+    );
+  }
+
+  console.info(`✅ Snapshot generation complete (${entries.length} payloads)`);
+};
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/scripts/import-stats-to-db.ts
+++ b/scripts/import-stats-to-db.ts
@@ -46,7 +46,11 @@ const main = async () => {
   const dryRun = args.includes("--dry-run");
 
   const csvDir = path.resolve(process.cwd(), "csv");
-  const csvHandlerScript = path.resolve(process.cwd(), "scripts", "handle-csv.sh");
+  const csvHandlerScript = path.resolve(
+    process.cwd(),
+    "scripts",
+    "handle-csv.sh",
+  );
   const db = getDbClient();
 
   console.log("📥 Starting database import...");
@@ -57,7 +61,7 @@ const main = async () => {
         : onlyCurrentSeason
           ? "Current season only"
           : "All seasons"
-    }`
+    }`,
   );
   console.log(`   Report type: ${reportTypeFilter ?? "all"}`);
   console.log(`   Dry run: ${dryRun}`);
@@ -74,7 +78,9 @@ const main = async () => {
   for (const team of TEAMS) {
     const teamDir = path.join(csvDir, team.id);
     if (!fs.existsSync(teamDir)) {
-      console.log(`⚠️  Team ${team.id} (${team.name}): No CSV directory, skipping`);
+      console.log(
+        `⚠️  Team ${team.id} (${team.name}): No CSV directory, skipping`,
+      );
       continue;
     }
 
@@ -89,23 +95,29 @@ const main = async () => {
       const season = parseInt(startYear, 10);
 
       if (seasonFilter !== null && season !== seasonFilter) continue;
-      if (seasonFilter === null && onlyCurrentSeason && season < CURRENT_SEASON) continue;
-      if (reportTypeFilter !== null && reportType !== reportTypeFilter) continue;
+      if (seasonFilter === null && onlyCurrentSeason && season < CURRENT_SEASON)
+        continue;
+      if (reportTypeFilter !== null && reportType !== reportTypeFilter)
+        continue;
 
       const filePath = path.join(teamDir, file);
       const normalizedPath = path.join(
         os.tmpdir(),
-        `ffhl-import-${process.pid}-${team.id}-${Date.now()}-${file}`
+        `ffhl-import-${process.pid}-${team.id}-${Date.now()}-${file}`,
       );
 
       try {
         // Always normalize via handle-csv so DB import works even if csv/<teamId>/ contains raw Fantrax exports.
-        const normalize = spawnSync("bash", [csvHandlerScript, filePath, normalizedPath], {
-          encoding: "utf8",
-        });
+        const normalize = spawnSync(
+          "bash",
+          [csvHandlerScript, filePath, normalizedPath],
+          {
+            encoding: "utf8",
+          },
+        );
         if (normalize.status !== 0) {
           throw new Error(
-            `CSV normalization failed for ${file}: ${normalize.stderr || normalize.stdout || "unknown error"}`
+            `CSV normalization failed for ${file}: ${normalize.stderr || normalize.stdout || "unknown error"}`,
           );
         }
 
@@ -113,8 +125,12 @@ const main = async () => {
         const rawData = await csv().fromFile(normalizedPath);
         const dataWithSeason = rawData.map((item) => ({ ...item, season }));
 
-        const players = mapPlayerData(dataWithSeason, { includeZeroGames: true });
-        const goalies = mapGoalieData(dataWithSeason, { includeZeroGames: true });
+        const players = mapPlayerData(dataWithSeason, {
+          includeZeroGames: true,
+        });
+        const goalies = mapGoalieData(dataWithSeason, {
+          includeZeroGames: true,
+        });
         const playersMissingId = players.filter((p) => !p.id).length;
         const goaliesMissingId = goalies.filter((g) => !g.id).length;
         const playersToImport = players.filter((p) => p.id);
@@ -123,7 +139,7 @@ const main = async () => {
         if (playersMissingId > 0 || goaliesMissingId > 0) {
           missingIdMessages.push(
             `Missing Fantrax IDs in ${file}: players=${playersMissingId}, goalies=${goaliesMissingId}. ` +
-              "All rows must have IDs before DB import."
+              "All rows must have IDs before DB import.",
           );
           skippedPlayersMissingId += playersMissingId;
           skippedGoaliesMissingId += goaliesMissingId;
@@ -131,7 +147,7 @@ const main = async () => {
 
         if (dryRun) {
           console.log(
-            `  🔍 Would import: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`
+            `  🔍 Would import: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`,
           );
         } else {
           // Build batch: delete existing + insert all rows atomically
@@ -201,7 +217,7 @@ const main = async () => {
           await db.batch(statements, "write");
 
           console.log(
-            `  ✅ Imported: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`
+            `  ✅ Imported: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`,
           );
         }
 
@@ -224,6 +240,16 @@ const main = async () => {
       sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
       args: ["last_modified", new Date().toISOString()],
     });
+
+    console.log("");
+    console.log("📸 Regenerating API snapshots...");
+    const snapshotRun = spawnSync("npm", ["run", "snapshot:generate"], {
+      stdio: "inherit",
+      env: process.env,
+    });
+    if (snapshotRun.status !== 0) {
+      throw new Error("Snapshot generation failed after DB import");
+    }
   }
 
   console.log("");
@@ -232,7 +258,9 @@ const main = async () => {
   console.log(`   Players imported: ${totalPlayers}`);
   console.log(`   Goalies imported: ${totalGoalies}`);
   console.log(`   Errors: ${errors}`);
-  console.log(`   Rows skipped (missing IDs): players=${skippedPlayersMissingId}, goalies=${skippedGoaliesMissingId}`);
+  console.log(
+    `   Rows skipped (missing IDs): players=${skippedPlayersMissingId}, goalies=${skippedGoaliesMissingId}`,
+  );
 
   if (missingIdMessages.length > 0) {
     console.log("");

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -45,11 +45,23 @@ import {
 } from "../helpers";
 import { getLastModifiedFromDb } from "../db/queries";
 import { makeEtagForJson } from "../cache";
+import { loadSnapshot } from "../snapshots";
 
 jest.mock("micro");
 jest.mock("../services");
 jest.mock("../helpers");
 jest.mock("../db/queries");
+jest.mock("../snapshots", () => ({
+  loadSnapshot: jest.fn(),
+  getCareerGoaliesSnapshotKey: jest.fn(() => "career/goalies"),
+  getCareerPlayersSnapshotKey: jest.fn(() => "career/players"),
+  getCombinedSnapshotKey: jest.fn(
+    (kind: "players" | "goalies", report: string, teamId: string) =>
+      `${kind}/combined/${report}/team-${teamId}`,
+  ),
+  getPlayoffsLeaderboardSnapshotKey: jest.fn(() => "leaderboard/playoffs"),
+  getRegularLeaderboardSnapshotKey: jest.fn(() => "leaderboard/regular"),
+}));
 
 type RouteReq = Parameters<typeof getSeasons>[0];
 const asRouteReq = (req: unknown): RouteReq => req as RouteReq;
@@ -58,6 +70,7 @@ describe("routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetRouteCachesForTests();
+    (loadSnapshot as jest.Mock).mockResolvedValue(null);
     (resolveTeamId as jest.Mock).mockResolvedValue("1");
     (reportTypeAvailable as jest.Mock).mockReturnValue(true);
     (seasonAvailable as jest.Mock).mockResolvedValue(true);
@@ -78,7 +91,7 @@ describe("routes", () => {
           status: "ok",
           uptimeSeconds: expect.any(Number),
           timestamp: expect.any(String),
-        })
+        }),
       );
     });
   });
@@ -93,7 +106,11 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "regular",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -109,7 +126,11 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "playoffs", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "playoffs",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -122,7 +143,11 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
 
     test("returns 400 for invalid report type path param", async () => {
@@ -136,7 +161,11 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.INVALID_REPORT_TYPE,
+      );
     });
 
     test("handles request without url (defaults query params)", async () => {
@@ -145,9 +174,18 @@ describe("routes", () => {
 
       const res = createResponse();
 
-      await getSeasons(asRouteReq({ params: {} } as unknown as ReturnType<typeof createRequest>), res);
+      await getSeasons(
+        asRouteReq({ params: {} } as unknown as ReturnType<
+          typeof createRequest
+        >),
+        res,
+      );
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "regular",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -155,12 +193,18 @@ describe("routes", () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
 
-      const req = { url: 123, params: {} } as unknown as ReturnType<typeof createRequest>;
+      const req = { url: 123, params: {} } as unknown as ReturnType<
+        typeof createRequest
+      >;
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "regular",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -168,7 +212,7 @@ describe("routes", () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
       (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
-        typeof raw === "string" && raw ? raw : "1"
+        typeof raw === "string" && raw ? raw : "1",
       );
 
       const req = {
@@ -180,7 +224,11 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "regular",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -188,15 +236,22 @@ describe("routes", () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
       (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
-        typeof raw === "string" && raw ? raw : "1"
+        typeof raw === "string" && raw ? raw : "1",
       );
 
-      const req = { url: "/seasons?teamId=1", params: {} } as unknown as ReturnType<typeof createRequest>;
+      const req = {
+        url: "/seasons?teamId=1",
+        params: {},
+      } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", undefined);
+      expect(getAvailableSeasons).toHaveBeenCalledWith(
+        "1",
+        "regular",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
     });
 
@@ -221,15 +276,24 @@ describe("routes", () => {
 
       await getSeasons(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
 
     test("treats missing teamId query param as undefined", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) => (raw ? String(raw) : "1"));
+      (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
+        raw ? String(raw) : "1",
+      );
 
-      const req = createRequest({ url: "/seasons", headers: { host: "localhost" } });
+      const req = createRequest({
+        url: "/seasons",
+        headers: { host: "localhost" },
+      });
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);
@@ -353,7 +417,7 @@ describe("routes", () => {
       const cachedRes = createResponse();
       const endSpy = jest.spyOn(cachedRes, "end");
 
-  await getTeams(asRouteReq(cachedReq), cachedRes);
+      await getTeams(asRouteReq(cachedReq), cachedRes);
 
       expect(getTeamsWithData).toHaveBeenCalledTimes(1);
       expect(send).toHaveBeenCalledTimes(0);
@@ -429,7 +493,11 @@ describe("routes", () => {
 
       await getPlayersSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.INVALID_REPORT_TYPE,
+      );
     });
 
     test("returns 400 for unavailable season", async () => {
@@ -443,7 +511,11 @@ describe("routes", () => {
 
       await getPlayersSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
+      );
     });
 
     test("returns 500 on service error", async () => {
@@ -459,7 +531,11 @@ describe("routes", () => {
 
       await getPlayersSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
   });
 
@@ -477,8 +553,35 @@ describe("routes", () => {
       await getPlayersCombined(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "players/combined/regular/team-1",
+      );
+      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
+        "regular",
+        "1",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
+    });
+
+    test("returns snapshot data when available", async () => {
+      const snapshotPlayers = [
+        { name: "Snapshot Player", goals: 120, seasons: [] },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotPlayers);
+
+      const req = createRequest({
+        params: { reportType: "regular" },
+      });
+      const res = createResponse();
+
+      await getPlayersCombined(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "players/combined/regular/team-1",
+      );
+      expect(getPlayersStatsCombined).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotPlayers);
     });
 
     test("returns 400 for invalid report type", async () => {
@@ -491,13 +594,20 @@ describe("routes", () => {
 
       await getPlayersCombined(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.INVALID_REPORT_TYPE,
+      );
     });
 
     test("returns 500 on service error", async () => {
       const error = new Error("Service error");
       (reportTypeAvailable as jest.Mock).mockReturnValue(true);
       (getPlayersStatsCombined as jest.Mock).mockRejectedValue(error);
+      (loadSnapshot as jest.Mock).mockRejectedValue(
+        new Error("snapshot unavailable"),
+      );
 
       const req = createRequest({
         params: { reportType: "regular" },
@@ -506,7 +616,11 @@ describe("routes", () => {
 
       await getPlayersCombined(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
 
     test("passes startFrom to service correctly", async () => {
@@ -525,7 +639,12 @@ describe("routes", () => {
       await getPlayersCombined(asRouteReq(req), res);
 
       expect(parseSeasonParam).toHaveBeenCalledWith("2020");
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("regular", "1", 2020);
+      expect(loadSnapshot).not.toHaveBeenCalled();
+      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
+        "regular",
+        "1",
+        2020,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
     });
 
@@ -544,7 +663,11 @@ describe("routes", () => {
 
       await getPlayersCombined(asRouteReq(req), res);
 
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith("playoffs", "1", 2018);
+      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
+        "playoffs",
+        "1",
+        2018,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
     });
   });
@@ -581,7 +704,11 @@ describe("routes", () => {
 
       await getGoaliesSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.INVALID_REPORT_TYPE,
+      );
     });
 
     test("returns 400 for unavailable season", async () => {
@@ -595,7 +722,11 @@ describe("routes", () => {
 
       await getGoaliesSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
+      );
     });
 
     test("returns 500 on service error", async () => {
@@ -611,7 +742,11 @@ describe("routes", () => {
 
       await getGoaliesSeason(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
   });
 
@@ -629,8 +764,35 @@ describe("routes", () => {
       await getGoaliesCombined(asRouteReq(req), res);
 
       expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1", undefined);
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "goalies/combined/regular/team-1",
+      );
+      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
+        "regular",
+        "1",
+        undefined,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
+    });
+
+    test("returns snapshot data when available", async () => {
+      const snapshotGoalies = [
+        { name: "Snapshot Goalie", wins: 44, seasons: [] },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotGoalies);
+
+      const req = createRequest({
+        params: { reportType: "regular" },
+      });
+      const res = createResponse();
+
+      await getGoaliesCombined(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "goalies/combined/regular/team-1",
+      );
+      expect(getGoaliesStatsCombined).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotGoalies);
     });
 
     test("returns 400 for invalid report type", async () => {
@@ -643,7 +805,11 @@ describe("routes", () => {
 
       await getGoaliesCombined(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.BAD_REQUEST,
+        ERROR_MESSAGES.INVALID_REPORT_TYPE,
+      );
     });
 
     test("returns 500 on service error", async () => {
@@ -658,7 +824,11 @@ describe("routes", () => {
 
       await getGoaliesCombined(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.INTERNAL_SERVER_ERROR, error);
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+        error,
+      );
     });
 
     test("passes startFrom to service correctly", async () => {
@@ -677,7 +847,12 @@ describe("routes", () => {
       await getGoaliesCombined(asRouteReq(req), res);
 
       expect(parseSeasonParam).toHaveBeenCalledWith("2020");
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("regular", "1", 2020);
+      expect(loadSnapshot).not.toHaveBeenCalled();
+      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
+        "regular",
+        "1",
+        2020,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
     });
 
@@ -696,7 +871,11 @@ describe("routes", () => {
 
       await getGoaliesCombined(asRouteReq(req), res);
 
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith("playoffs", "1", 2018);
+      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
+        "playoffs",
+        "1",
+        2018,
+      );
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
     });
   });
@@ -796,7 +975,11 @@ describe("routes", () => {
 
       await getCareerPlayer(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.NOT_FOUND, "Player not found");
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.NOT_FOUND,
+        "Player not found",
+      );
     });
   });
 
@@ -829,8 +1012,42 @@ describe("routes", () => {
 
       await getCareerPlayers(asRouteReq(req), res);
 
+      expect(loadSnapshot).toHaveBeenCalledWith("career/players");
       expect(getCareerPlayersData).toHaveBeenCalled();
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockList);
+    });
+
+    test("returns snapshot data when available", async () => {
+      const snapshotList = [
+        {
+          id: "p099",
+          name: "Snapshot Skater",
+          position: "D",
+          firstSeason: 2021,
+          lastSeason: 2026,
+          seasonsOwned: 6,
+          seasonsPlayedRegular: 3,
+          seasonsPlayedPlayoffs: 2,
+          teamsOwned: 3,
+          teamsPlayedRegular: 2,
+          teamsPlayedPlayoffs: 2,
+          regularGames: 280,
+          playoffGames: 30,
+        },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotList);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/players",
+      });
+      const res = createResponse();
+
+      await getCareerPlayers(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith("career/players");
+      expect(getCareerPlayersData).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotList);
     });
   });
 
@@ -925,7 +1142,11 @@ describe("routes", () => {
 
       await getCareerGoalie(asRouteReq(req), res);
 
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.NOT_FOUND, "Goalie not found");
+      expect(send).toHaveBeenCalledWith(
+        res,
+        HTTP_STATUS.NOT_FOUND,
+        "Goalie not found",
+      );
     });
   });
 
@@ -957,8 +1178,41 @@ describe("routes", () => {
 
       await getCareerGoalies(asRouteReq(req), res);
 
+      expect(loadSnapshot).toHaveBeenCalledWith("career/goalies");
       expect(getCareerGoaliesData).toHaveBeenCalled();
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockList);
+    });
+
+    test("returns snapshot data when available", async () => {
+      const snapshotList = [
+        {
+          id: "g099",
+          name: "Snapshot Goalie",
+          firstSeason: 2020,
+          lastSeason: 2026,
+          seasonsOwned: 6,
+          seasonsPlayedRegular: 4,
+          seasonsPlayedPlayoffs: 2,
+          teamsOwned: 4,
+          teamsPlayedRegular: 3,
+          teamsPlayedPlayoffs: 2,
+          regularGames: 240,
+          playoffGames: 28,
+        },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotList);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/goalies",
+      });
+      const res = createResponse();
+
+      await getCareerGoalies(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith("career/goalies");
+      expect(getCareerGoaliesData).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotList);
     });
   });
 
@@ -1092,18 +1346,55 @@ describe("routes", () => {
       ];
       (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue(mockData);
 
-      const req = createRequest({ method: "GET", url: "/leaderboard/playoffs" });
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
       const res = createResponse();
 
       await getPlayoffsLeaderboard(asRouteReq(req), res);
 
+      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/playoffs");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
+    });
+
+    test("returns snapshot data when available", async () => {
+      const snapshotData = [
+        {
+          teamId: "2",
+          teamName: "Snapshot Team",
+          appearances: 8,
+          championships: 1,
+          finals: 2,
+          conferenceFinals: 1,
+          secondRound: 2,
+          firstRound: 2,
+          seasons: [{ season: 2025, round: 4, key: "final" }],
+          tieRank: false,
+        },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotData);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
+      const res = createResponse();
+
+      await getPlayoffsLeaderboard(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/playoffs");
+      expect(getPlayoffLeaderboardData).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotData);
     });
 
     test("returns 200 with empty array when no data", async () => {
       (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue([]);
 
-      const req = createRequest({ method: "GET", url: "/leaderboard/playoffs" });
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
       const res = createResponse();
 
       await getPlayoffsLeaderboard(asRouteReq(req), res);
@@ -1116,7 +1407,10 @@ describe("routes", () => {
         new Error("DB error"),
       );
 
-      const req = createRequest({ method: "GET", url: "/leaderboard/playoffs" });
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
       const res = createResponse();
 
       await getPlayoffsLeaderboard(asRouteReq(req), res);
@@ -1172,6 +1466,7 @@ describe("routes", () => {
 
       await getRegularLeaderboard(asRouteReq(req), res);
 
+      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/regular");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
     });
 
@@ -1184,6 +1479,40 @@ describe("routes", () => {
       await getRegularLeaderboard(asRouteReq(req), res);
 
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, []);
+    });
+
+    test("falls back to live data when snapshot loading fails", async () => {
+      const mockData = [
+        {
+          teamId: "1",
+          teamName: "Colorado Avalanche",
+          wins: 355,
+          losses: 79,
+          ties: 46,
+          points: 756,
+          divWins: 86,
+          divLosses: 24,
+          divTies: 10,
+          winPercent: 0.74,
+          divWinPercent: 0.717,
+          pointsPercent: 0.788,
+          regularTrophies: 2,
+          seasons: [],
+          tieRank: false,
+        },
+      ];
+      (loadSnapshot as jest.Mock).mockRejectedValue(
+        new Error("snapshot unavailable"),
+      );
+      (getRegularLeaderboardData as jest.Mock).mockResolvedValue(mockData);
+
+      const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
+      const res = createResponse();
+
+      await getRegularLeaderboard(asRouteReq(req), res);
+
+      expect(getRegularLeaderboardData).toHaveBeenCalledTimes(1);
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
     });
 
     test("handles service error", async () => {
@@ -1205,13 +1534,17 @@ describe("routes", () => {
   });
 
   describe("spec schema conformance", () => {
-    function buildArrayValidator(schemaName: string): ReturnType<Ajv["compile"]> {
+    function buildArrayValidator(
+      schemaName: string,
+    ): ReturnType<Ajv["compile"]> {
       const specPath = path.join(__dirname, "..", "..", "openapi.yaml");
       const raw = fs.readFileSync(specPath, "utf8");
-      const spec = yaml.load(raw) as { components: { schemas: Record<string, unknown> } };
+      const spec = yaml.load(raw) as {
+        components: { schemas: Record<string, unknown> };
+      };
       const defsJson = JSON.stringify(spec.components.schemas).replace(
         /#\/components\/schemas\//g,
-        "#/definitions/"
+        "#/definitions/",
       );
       const definitions = JSON.parse(defsJson) as Record<string, unknown>;
       const ajv = new Ajv({ allErrors: true, strict: false });
@@ -1222,13 +1555,17 @@ describe("routes", () => {
       });
     }
 
-    function buildObjectValidator(schemaName: string): ReturnType<Ajv["compile"]> {
+    function buildObjectValidator(
+      schemaName: string,
+    ): ReturnType<Ajv["compile"]> {
       const specPath = path.join(__dirname, "..", "..", "openapi.yaml");
       const raw = fs.readFileSync(specPath, "utf8");
-      const spec = yaml.load(raw) as { components: { schemas: Record<string, unknown> } };
+      const spec = yaml.load(raw) as {
+        components: { schemas: Record<string, unknown> };
+      };
       const defsJson = JSON.stringify(spec.components.schemas).replace(
         /#\/components\/schemas\//g,
-        "#/definitions/"
+        "#/definitions/",
       );
       const definitions = JSON.parse(defsJson) as Record<string, unknown>;
       const ajv = new Ajv({ allErrors: true, strict: false });
@@ -1244,7 +1581,11 @@ describe("routes", () => {
 
     const validSeason = { season: 2023, text: "2023-2024" };
 
-    const validTeam = { id: "1", name: "colorado", presentName: "Colorado Avalanche" };
+    const validTeam = {
+      id: "1",
+      name: "colorado",
+      presentName: "Colorado Avalanche",
+    };
 
     const validPlayer = {
       id: "p900",
@@ -1593,7 +1934,9 @@ describe("routes", () => {
       (seasonAvailable as jest.Mock).mockResolvedValue(true);
       (parseSeasonParam as jest.Mock).mockReturnValue(2023);
       (getPlayersStatsSeason as jest.Mock).mockResolvedValue([validPlayer]);
-      const req = createRequest({ params: { reportType: "regular", season: "2023" } });
+      const req = createRequest({
+        params: { reportType: "regular", season: "2023" },
+      });
       const res = createResponse();
       await getPlayersSeason(asRouteReq(req), res);
       const validate = buildArrayValidator("Player");
@@ -1602,8 +1945,13 @@ describe("routes", () => {
 
     test("getPlayersCombined response conforms to CombinedPlayer[] schema", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      const validCombinedPlayer = { ...validPlayer, seasons: [{ ...validPlayer, season: 2023 }] };
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue([validCombinedPlayer]);
+      const validCombinedPlayer = {
+        ...validPlayer,
+        seasons: [{ ...validPlayer, season: 2023 }],
+      };
+      (getPlayersStatsCombined as jest.Mock).mockResolvedValue([
+        validCombinedPlayer,
+      ]);
       const req = createRequest({ params: { reportType: "regular" } });
       const res = createResponse();
       await getPlayersCombined(asRouteReq(req), res);
@@ -1616,7 +1964,9 @@ describe("routes", () => {
       (seasonAvailable as jest.Mock).mockResolvedValue(true);
       (parseSeasonParam as jest.Mock).mockReturnValue(2023);
       (getGoaliesStatsSeason as jest.Mock).mockResolvedValue([validGoalie]);
-      const req = createRequest({ params: { reportType: "regular", season: "2023" } });
+      const req = createRequest({
+        params: { reportType: "regular", season: "2023" },
+      });
       const res = createResponse();
       await getGoaliesSeason(asRouteReq(req), res);
       const validate = buildArrayValidator("Goalie");
@@ -1625,8 +1975,13 @@ describe("routes", () => {
 
     test("getGoaliesCombined response conforms to CombinedGoalie[] schema", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      const validCombinedGoalie = { ...validGoalie, seasons: [{ ...validGoalie, season: 2023 }] };
-      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue([validCombinedGoalie]);
+      const validCombinedGoalie = {
+        ...validGoalie,
+        seasons: [{ ...validGoalie, season: 2023 }],
+      };
+      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue([
+        validCombinedGoalie,
+      ]);
       const req = createRequest({ params: { reportType: "regular" } });
       const res = createResponse();
       await getGoaliesCombined(asRouteReq(req), res);
@@ -1644,7 +1999,9 @@ describe("routes", () => {
     });
 
     test("getCareerPlayers response conforms to CareerPlayerListItem[] schema", async () => {
-      (getCareerPlayersData as jest.Mock).mockResolvedValue([validCareerPlayerListItem]);
+      (getCareerPlayersData as jest.Mock).mockResolvedValue([
+        validCareerPlayerListItem,
+      ]);
       const req = createRequest({ method: "GET", url: "/career/players" });
       const res = createResponse();
       await getCareerPlayers(asRouteReq(req), res);
@@ -1662,7 +2019,9 @@ describe("routes", () => {
     });
 
     test("getCareerGoalies response conforms to CareerGoalieListItem[] schema", async () => {
-      (getCareerGoaliesData as jest.Mock).mockResolvedValue([validCareerGoalieListItem]);
+      (getCareerGoaliesData as jest.Mock).mockResolvedValue([
+        validCareerGoalieListItem,
+      ]);
       const req = createRequest({ method: "GET", url: "/career/goalies" });
       const res = createResponse();
       await getCareerGoalies(asRouteReq(req), res);
@@ -1671,8 +2030,13 @@ describe("routes", () => {
     });
 
     test("getPlayoffsLeaderboard response conforms to PlayoffLeaderboardEntry[] schema", async () => {
-      (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue([validPlayoffEntry]);
-      const req = createRequest({ method: "GET", url: "/leaderboard/playoffs" });
+      (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue([
+        validPlayoffEntry,
+      ]);
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
       const res = createResponse();
       await getPlayoffsLeaderboard(asRouteReq(req), res);
       const validate = buildArrayValidator("PlayoffLeaderboardEntry");
@@ -1680,7 +2044,9 @@ describe("routes", () => {
     });
 
     test("getRegularLeaderboard response conforms to RegularLeaderboardEntry[] schema", async () => {
-      (getRegularLeaderboardData as jest.Mock).mockResolvedValue([validRegularEntry]);
+      (getRegularLeaderboardData as jest.Mock).mockResolvedValue([
+        validRegularEntry,
+      ]);
       const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
       const res = createResponse();
       await getRegularLeaderboard(asRouteReq(req), res);

--- a/src/__tests__/snapshots.test.ts
+++ b/src/__tests__/snapshots.test.ts
@@ -1,0 +1,298 @@
+import path from "path";
+import fs from "fs/promises";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  createSnapshotR2Client,
+  getCareerGoaliesSnapshotKey,
+  getCareerPlayersSnapshotKey,
+  getCombinedSnapshotKey,
+  getPlayoffsLeaderboardSnapshotKey,
+  getRegularLeaderboardSnapshotKey,
+  getSnapshotBucketName,
+  getSnapshotCacheTtlMs,
+  getSnapshotDir,
+  getSnapshotFilePath,
+  getSnapshotManifestKey,
+  getSnapshotObjectKey,
+  getSnapshotPrefix,
+  isR2SnapshotConfigAvailable,
+  loadSnapshot,
+  resetSnapshotCacheForTests,
+} from "../snapshots";
+
+const mockSend = jest.fn();
+
+jest.mock("fs/promises", () => ({
+  __esModule: true,
+  default: {
+    readFile: jest.fn(),
+  },
+}));
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  GetObjectCommand: jest.fn().mockImplementation((input: unknown) => input),
+  S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+}));
+
+const mockReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+const mockS3Client = S3Client as unknown as jest.Mock;
+const mockGetObjectCommand = GetObjectCommand as unknown as jest.Mock;
+
+const originalEnv = process.env;
+
+const applyR2Env = (): void => {
+  process.env.R2_ENDPOINT = "https://example.r2.cloudflarestorage.com";
+  process.env.R2_ACCESS_KEY_ID = "access-key";
+  process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+  process.env.R2_BUCKET_NAME = "csv-bucket";
+};
+
+describe("snapshots", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    resetSnapshotCacheForTests();
+    process.env = { ...originalEnv };
+    delete process.env.SNAPSHOT_DIR;
+    delete process.env.R2_SNAPSHOT_PREFIX;
+    delete process.env.R2_SNAPSHOT_BUCKET_NAME;
+    delete process.env.R2_BUCKET_NAME;
+    delete process.env.R2_ENDPOINT;
+    delete process.env.R2_ACCESS_KEY_ID;
+    delete process.env.R2_SECRET_ACCESS_KEY;
+    delete process.env.SNAPSHOT_CACHE_TTL_MS;
+    mockReadFile.mockReset();
+    mockSend.mockReset();
+    mockS3Client.mockReset().mockImplementation(() => ({ send: mockSend }));
+    mockGetObjectCommand
+      .mockReset()
+      .mockImplementation((input: unknown) => input);
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test("returns default helper values and normalized snapshot keys", () => {
+    expect(getSnapshotDir()).toBe(
+      path.resolve(process.cwd(), "generated", "snapshots"),
+    );
+    expect(getSnapshotPrefix()).toBe("snapshots");
+    expect(getSnapshotBucketName()).toBeUndefined();
+    expect(isR2SnapshotConfigAvailable()).toBe(false);
+    expect(getSnapshotCacheTtlMs()).toBe(60_000);
+    expect(getSnapshotFilePath("/career/players.json")).toBe(
+      path.resolve(
+        process.cwd(),
+        "generated",
+        "snapshots",
+        "career",
+        "players.json",
+      ),
+    );
+    expect(getSnapshotObjectKey("/career/players.json")).toBe(
+      "snapshots/career/players.json",
+    );
+    expect(getCareerPlayersSnapshotKey()).toBe("career/players");
+    expect(getCareerGoaliesSnapshotKey()).toBe("career/goalies");
+    expect(getRegularLeaderboardSnapshotKey()).toBe("leaderboard/regular");
+    expect(getPlayoffsLeaderboardSnapshotKey()).toBe("leaderboard/playoffs");
+    expect(getCombinedSnapshotKey("players", "both", "7")).toBe(
+      "players/combined/both/team-7",
+    );
+    expect(getSnapshotManifestKey()).toBe("manifest");
+  });
+
+  test("uses environment overrides for snapshot settings", () => {
+    process.env.SNAPSHOT_DIR = " /tmp/custom-snapshots ";
+    process.env.R2_SNAPSHOT_PREFIX = " edge-cache ";
+    process.env.R2_BUCKET_NAME = " csv-bucket ";
+    process.env.R2_SNAPSHOT_BUCKET_NAME = " snapshot-bucket ";
+    process.env.SNAPSHOT_CACHE_TTL_MS = "90000";
+    applyR2Env();
+
+    expect(getSnapshotDir()).toBe("/tmp/custom-snapshots");
+    expect(getSnapshotPrefix()).toBe("edge-cache");
+    expect(getSnapshotBucketName()).toBe("snapshot-bucket");
+    expect(getSnapshotCacheTtlMs()).toBe(90_000);
+    expect(isR2SnapshotConfigAvailable()).toBe(true);
+  });
+
+  test("falls back to the default ttl when the configured value is invalid", () => {
+    process.env.SNAPSHOT_CACHE_TTL_MS = "0";
+
+    expect(getSnapshotCacheTtlMs()).toBe(60_000);
+  });
+
+  test("throws when creating an R2 client without required configuration", () => {
+    expect(() => createSnapshotR2Client()).toThrow(
+      "Missing R2 snapshot configuration",
+    );
+    expect(mockS3Client).not.toHaveBeenCalled();
+  });
+
+  test("reuses the R2 client singleton until caches are reset", () => {
+    applyR2Env();
+
+    const first = createSnapshotR2Client();
+    const second = createSnapshotR2Client();
+
+    expect(first).toBe(second);
+    expect(mockS3Client).toHaveBeenCalledTimes(1);
+
+    resetSnapshotCacheForTests();
+
+    const third = createSnapshotR2Client();
+
+    expect(third).not.toBe(first);
+    expect(mockS3Client).toHaveBeenCalledTimes(2);
+  });
+
+  test("loads local snapshots and re-reads them after the ttl expires", async () => {
+    let now = 1_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    mockReadFile
+      .mockResolvedValueOnce(JSON.stringify({ source: "local-1" }) as never)
+      .mockResolvedValueOnce(JSON.stringify({ source: "local-2" }) as never);
+
+    const first = await loadSnapshot<{ source: string }>("career/players");
+    now = 1_050;
+    const second = await loadSnapshot<{ source: string }>("career/players");
+    now = 62_000;
+    const third = await loadSnapshot<{ source: string }>("career/players");
+
+    expect(first).toEqual({ source: "local-1" });
+    expect(second).toEqual({ source: "local-1" });
+    expect(third).toEqual({ source: "local-2" });
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+  });
+
+  test("caches missing local snapshots as null", async () => {
+    const nowSpy = jest.spyOn(Date, "now");
+    nowSpy
+      .mockReturnValueOnce(500)
+      .mockReturnValueOnce(500)
+      .mockReturnValueOnce(550);
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+
+    const first = await loadSnapshot("career/players");
+    const second = await loadSnapshot("career/players");
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test("loads snapshots from R2 when the local file is missing", async () => {
+    applyR2Env();
+    const transformToString = jest.fn().mockResolvedValue('{"source":"r2"}');
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+    mockSend.mockResolvedValue({
+      Body: { transformToString },
+    });
+
+    const result = await loadSnapshot<{ source: string }>("career/goalies");
+
+    expect(result).toEqual({ source: "r2" });
+    expect(mockS3Client).toHaveBeenCalledTimes(1);
+    expect(mockGetObjectCommand).toHaveBeenCalledWith({
+      Bucket: "csv-bucket",
+      Key: "snapshots/career/goalies.json",
+    });
+    expect(transformToString).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns null when the R2 body cannot be transformed", async () => {
+    applyR2Env();
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+    mockSend.mockResolvedValue({ Body: {} });
+
+    await expect(loadSnapshot("career/goalies")).resolves.toBeNull();
+  });
+
+  test("returns null when the R2 object is missing", async () => {
+    applyR2Env();
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+    mockSend.mockRejectedValue(
+      Object.assign(new Error("missing"), { name: "NoSuchKey" }),
+    );
+
+    await expect(loadSnapshot("career/goalies")).resolves.toBeNull();
+  });
+
+  test("rethrows unexpected local read errors", async () => {
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("denied"), { code: "EACCES" }) as never,
+    );
+
+    await expect(loadSnapshot("career/players")).rejects.toThrow("denied");
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test("rethrows unexpected R2 errors", async () => {
+    applyR2Env();
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+    mockSend.mockRejectedValue(new Error("boom"));
+
+    await expect(loadSnapshot("career/goalies")).rejects.toThrow("boom");
+  });
+
+  test("rethrows non-Error R2 failures", async () => {
+    applyR2Env();
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }) as never,
+    );
+    mockSend.mockRejectedValue({ status: 500 });
+
+    await expect(loadSnapshot("career/goalies")).rejects.toEqual({
+      status: 500,
+    });
+  });
+
+  test("deduplicates inflight loads for the same snapshot key", async () => {
+    let resolveReadFile: ((value: string) => void) | undefined;
+    mockReadFile.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReadFile = resolve;
+        }) as ReturnType<typeof fs.readFile>,
+    );
+
+    const first = loadSnapshot<{ source: string }>("career/players");
+    const second = loadSnapshot<{ source: string }>("career/players");
+
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+
+    resolveReadFile?.(JSON.stringify({ source: "shared" }));
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { source: "shared" },
+      { source: "shared" },
+    ]);
+  });
+
+  test("clears inflight state after a malformed snapshot payload", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("not-json" as never)
+      .mockResolvedValueOnce(JSON.stringify({ source: "fixed" }) as never);
+
+    await expect(loadSnapshot("career/players")).rejects.toThrow();
+    await expect(
+      loadSnapshot<{ source: string }>("career/players"),
+    ).resolves.toEqual({
+      source: "fixed",
+    });
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -31,6 +31,14 @@ import {
   setNoStoreHeaders,
 } from "./cache";
 import { getLastModifiedFromDb } from "./db/queries";
+import {
+  getCareerGoaliesSnapshotKey,
+  getCareerPlayersSnapshotKey,
+  getCombinedSnapshotKey,
+  getPlayoffsLeaderboardSnapshotKey,
+  getRegularLeaderboardSnapshotKey,
+  loadSnapshot,
+} from "./snapshots";
 
 const responseCache = new Map<string, { etag: string; data: unknown }>();
 
@@ -55,10 +63,14 @@ export const resetRouteCachesForTests = (): void => {
 
 type QueryParamRequest = { url?: unknown; headers?: Record<string, unknown> };
 
-const getQueryParam = (req: QueryParamRequest, key: string): string | undefined => {
+const getQueryParam = (
+  req: QueryParamRequest,
+  key: string,
+): string | undefined => {
   if (typeof req.url !== "string") return undefined;
 
-  const host = typeof req.headers?.host === "string" ? req.headers.host : "localhost";
+  const host =
+    typeof req.headers?.host === "string" ? req.headers.host : "localhost";
   const url = new URL(req.url, `http://${host}`);
   const value = url.searchParams.get(key);
   return value === null ? undefined : value;
@@ -67,7 +79,7 @@ const getQueryParam = (req: QueryParamRequest, key: string): string | undefined 
 const withErrorHandlingCached = async (
   req: IncomingMessage | undefined,
   res: ServerResponse,
-  handler: () => Promise<unknown>
+  handler: () => Promise<unknown>,
 ) => {
   const cacheKey = req ? buildCacheKey(req) : undefined;
   if (cacheKey) {
@@ -103,9 +115,31 @@ const withErrorHandlingCached = async (
   }
 };
 
-const sendNoStore = (res: ServerResponse, status: number, body: unknown): void => {
+const sendNoStore = (
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+): void => {
   setNoStoreHeaders(res);
   send(res, status, body);
+};
+
+const loadSnapshotOrFallback = async <T>(
+  snapshotKey: string | undefined,
+  fallback: () => Promise<T>,
+): Promise<T> => {
+  if (snapshotKey) {
+    try {
+      const snapshot = await loadSnapshot<T>(snapshotKey);
+      if (snapshot !== null) {
+        return snapshot;
+      }
+    } catch {
+      // Fall back to live data when snapshot storage is unavailable or malformed.
+    }
+  }
+
+  return fallback();
 };
 
 export const getHealthcheck: AugmentedRequestHandler = async (_req, res) => {
@@ -127,86 +161,146 @@ export const getSeasons: AugmentedRequestHandler = async (req, res) => {
 
   const rawReport = req.params.reportType || "regular";
   if (!reportTypeAvailable(rawReport as Report)) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.INVALID_REPORT_TYPE,
+    );
     return;
   }
   const report = rawReport as Report;
 
-  await withErrorHandlingCached(req, res, () => getAvailableSeasons(teamId, report, startFrom));
+  await withErrorHandlingCached(req, res, () =>
+    getAvailableSeasons(teamId, report, startFrom),
+  );
 };
 
 export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.INVALID_REPORT_TYPE,
+    );
     return;
   }
   const report = req.params.reportType as Report;
 
   if (!(await seasonAvailable(season, teamId, report))) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
+    );
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getPlayersStatsSeason(report, season, teamId));
+  await withErrorHandlingCached(req, res, () =>
+    getPlayersStatsSeason(report, season, teamId),
+  );
 };
 
 export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.INVALID_REPORT_TYPE,
+    );
     return;
   }
   const report = req.params.reportType as Report;
 
-  await withErrorHandlingCached(req, res, () => getPlayersStatsCombined(report, teamId, startFrom));
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(
+      startFrom === undefined
+        ? getCombinedSnapshotKey("players", report, teamId)
+        : undefined,
+      () => getPlayersStatsCombined(report, teamId, startFrom),
+    ),
+  );
 };
 
 export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.INVALID_REPORT_TYPE,
+    );
     return;
   }
   const report = req.params.reportType as Report;
 
   if (!(await seasonAvailable(season, teamId, report))) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
+    );
     return;
   }
 
-  await withErrorHandlingCached(req, res, () => getGoaliesStatsSeason(report, season, teamId));
+  await withErrorHandlingCached(req, res, () =>
+    getGoaliesStatsSeason(report, season, teamId),
+  );
 };
 
 export const getGoaliesCombined: AugmentedRequestHandler = async (req, res) => {
   const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {
-    sendNoStore(res, HTTP_STATUS.BAD_REQUEST, ERROR_MESSAGES.INVALID_REPORT_TYPE);
+    sendNoStore(
+      res,
+      HTTP_STATUS.BAD_REQUEST,
+      ERROR_MESSAGES.INVALID_REPORT_TYPE,
+    );
     return;
   }
   const report = req.params.reportType as Report;
 
-  await withErrorHandlingCached(req, res, () => getGoaliesStatsCombined(report, teamId, startFrom));
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(
+      startFrom === undefined
+        ? getCombinedSnapshotKey("goalies", report, teamId)
+        : undefined,
+      () => getGoaliesStatsCombined(report, teamId, startFrom),
+    ),
+  );
 };
 
 export const getCareerPlayer: AugmentedRequestHandler = async (req, res) => {
-  await withErrorHandlingCached(req, res, () => getPlayerCareerData(req.params.id));
+  await withErrorHandlingCached(req, res, () =>
+    getPlayerCareerData(req.params.id),
+  );
 };
 
 export const getCareerGoalie: AugmentedRequestHandler = async (req, res) => {
-  await withErrorHandlingCached(req, res, () => getGoalieCareerData(req.params.id));
+  await withErrorHandlingCached(req, res, () =>
+    getGoalieCareerData(req.params.id),
+  );
 };
 
 export const getCareerPlayers: AugmentedRequestHandler = async (req, res) => {
-  await withErrorHandlingCached(req, res, () => getCareerPlayersData());
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(getCareerPlayersSnapshotKey(), () =>
+      getCareerPlayersData(),
+    ),
+  );
 };
 
 export const getCareerGoalies: AugmentedRequestHandler = async (req, res) => {
-  await withErrorHandlingCached(req, res, () => getCareerGoaliesData());
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(getCareerGoaliesSnapshotKey(), () =>
+      getCareerGoaliesData(),
+    ),
+  );
 };
 
 export const getLastModified: AugmentedRequestHandler = async (req, res) => {
@@ -220,12 +314,20 @@ export const getPlayoffsLeaderboard: AugmentedRequestHandler = async (
   req,
   res,
 ) => {
-  await withErrorHandlingCached(req, res, () => getPlayoffLeaderboardData());
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(getPlayoffsLeaderboardSnapshotKey(), () =>
+      getPlayoffLeaderboardData(),
+    ),
+  );
 };
 
 export const getRegularLeaderboard: AugmentedRequestHandler = async (
   req,
   res,
 ) => {
-  await withErrorHandlingCached(req, res, () => getRegularLeaderboardData());
+  await withErrorHandlingCached(req, res, () =>
+    loadSnapshotOrFallback(getRegularLeaderboardSnapshotKey(), () =>
+      getRegularLeaderboardData(),
+    ),
+  );
 };

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -1,0 +1,195 @@
+import fs from "fs/promises";
+import path from "path";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type { Report } from "./types";
+
+const DEFAULT_SNAPSHOT_DIR = path.resolve(
+  process.cwd(),
+  "generated",
+  "snapshots",
+);
+const DEFAULT_SNAPSHOT_PREFIX = "snapshots";
+const DEFAULT_CACHE_TTL_MS = 60_000;
+
+type SnapshotCacheEntry = {
+  expiresAt: number;
+  value: unknown | null;
+};
+
+type SnapshotBody = {
+  transformToString?: () => Promise<string>;
+};
+
+const snapshotCache = new Map<string, SnapshotCacheEntry>();
+const snapshotInflight = new Map<string, Promise<unknown | null>>();
+
+let snapshotR2Client: S3Client | null = null;
+
+const getEnv = (key: string): string | undefined => {
+  const value = process.env[key]?.trim();
+  return value ? value : undefined;
+};
+
+const parsePositiveInt = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const normalizeSnapshotKey = (snapshotKey: string): string =>
+  snapshotKey.replace(/^\/+/, "").replace(/\.json$/u, "");
+
+const isMissingObjectError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const maybeStatus = (
+    error as Error & { $metadata?: { httpStatusCode?: number } }
+  ).$metadata;
+  return (
+    error.name === "NoSuchKey" ||
+    error.name === "NotFound" ||
+    error.name === "NotFoundError" ||
+    maybeStatus?.httpStatusCode === 404
+  );
+};
+
+export const getSnapshotDir = (): string =>
+  getEnv("SNAPSHOT_DIR") ?? DEFAULT_SNAPSHOT_DIR;
+
+export const getSnapshotPrefix = (): string =>
+  getEnv("R2_SNAPSHOT_PREFIX") ?? DEFAULT_SNAPSHOT_PREFIX;
+
+export const getSnapshotBucketName = (): string | undefined =>
+  getEnv("R2_SNAPSHOT_BUCKET_NAME") ?? getEnv("R2_BUCKET_NAME");
+
+export const isR2SnapshotConfigAvailable = (): boolean =>
+  Boolean(
+    getSnapshotBucketName() &&
+    getEnv("R2_ENDPOINT") &&
+    getEnv("R2_ACCESS_KEY_ID") &&
+    getEnv("R2_SECRET_ACCESS_KEY"),
+  );
+
+export const getSnapshotCacheTtlMs = (): number =>
+  parsePositiveInt(getEnv("SNAPSHOT_CACHE_TTL_MS")) ?? DEFAULT_CACHE_TTL_MS;
+
+export const getSnapshotFilePath = (snapshotKey: string): string =>
+  path.resolve(getSnapshotDir(), `${normalizeSnapshotKey(snapshotKey)}.json`);
+
+export const getSnapshotObjectKey = (snapshotKey: string): string =>
+  `${getSnapshotPrefix()}/${normalizeSnapshotKey(snapshotKey)}.json`;
+
+export const createSnapshotR2Client = (): S3Client => {
+  if (snapshotR2Client) return snapshotR2Client;
+
+  const endpoint = getEnv("R2_ENDPOINT");
+  const accessKeyId = getEnv("R2_ACCESS_KEY_ID");
+  const secretAccessKey = getEnv("R2_SECRET_ACCESS_KEY");
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) {
+    throw new Error("Missing R2 snapshot configuration");
+  }
+
+  snapshotR2Client = new S3Client({
+    region: "auto",
+    endpoint,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+  });
+
+  return snapshotR2Client;
+};
+
+const readLocalSnapshot = async (
+  snapshotKey: string,
+): Promise<string | null> => {
+  try {
+    return await fs.readFile(getSnapshotFilePath(snapshotKey), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const readR2Snapshot = async (snapshotKey: string): Promise<string | null> => {
+  const bucketName = getSnapshotBucketName();
+  if (!bucketName || !isR2SnapshotConfigAvailable()) return null;
+
+  try {
+    const response = await createSnapshotR2Client().send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: getSnapshotObjectKey(snapshotKey),
+      }),
+    );
+    const body = response.Body as SnapshotBody | undefined;
+    return body?.transformToString ? body.transformToString() : null;
+  } catch (error) {
+    if (isMissingObjectError(error)) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+export const loadSnapshot = async <T>(
+  snapshotKey: string,
+): Promise<T | null> => {
+  const normalizedKey = normalizeSnapshotKey(snapshotKey);
+  const cached = snapshotCache.get(normalizedKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value as T | null;
+  }
+
+  const inflight = snapshotInflight.get(normalizedKey);
+  if (inflight) {
+    return inflight as Promise<T | null>;
+  }
+
+  const loadPromise = (async () => {
+    const raw =
+      (await readLocalSnapshot(normalizedKey)) ??
+      (await readR2Snapshot(normalizedKey));
+    const value = raw === null ? null : (JSON.parse(raw) as T);
+    snapshotCache.set(normalizedKey, {
+      value,
+      expiresAt: Date.now() + getSnapshotCacheTtlMs(),
+    });
+    return value;
+  })();
+
+  snapshotInflight.set(normalizedKey, loadPromise);
+
+  try {
+    return (await loadPromise) as T | null;
+  } finally {
+    snapshotInflight.delete(normalizedKey);
+  }
+};
+
+export const getCareerPlayersSnapshotKey = (): string => "career/players";
+
+export const getCareerGoaliesSnapshotKey = (): string => "career/goalies";
+
+export const getRegularLeaderboardSnapshotKey = (): string =>
+  "leaderboard/regular";
+
+export const getPlayoffsLeaderboardSnapshotKey = (): string =>
+  "leaderboard/playoffs";
+
+export const getCombinedSnapshotKey = (
+  kind: "players" | "goalies",
+  report: Report,
+  teamId: string,
+): string => `${kind}/combined/${report}/team-${teamId}`;
+
+export const getSnapshotManifestKey = (): string => "manifest";
+
+export const resetSnapshotCacheForTests = (): void => {
+  snapshotCache.clear();
+  snapshotInflight.clear();
+  snapshotR2Client = null;
+};


### PR DESCRIPTION
## Summary
- add snapshot infrastructure for API responses with local file reads, optional R2 fallback, and in-memory TTL caching
- serve career lists, leaderboards, and default combined team views from snapshots before falling back to live DB queries
- add `npm run snapshot:generate` to build snapshot JSON payloads and optional R2 uploads
- regenerate snapshots automatically after successful stats, regular-results, and playoff-results imports
- skip snapshot objects in the CSV R2 download script
- document snapshot env vars, import-triggered refresh flow, and future paging/search-first idea in README and development docs

## Bonus
- add career lookup indexes for `player_id` and `goalie_id` so single-player and single-goalie career queries avoid full table scans
- bump the migration schema version to 4 and update migration output/docs accordingly

## Verification
- npm run verify

