### PR TITLE
Fix: Use snapshots for default startFrom windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,8 @@ Currently snapshotted response families are:
 - `/career/goalies`
 - `/leaderboard/regular`
 - `/leaderboard/playoffs`
-- `/players/combined/{reportType}?teamId=<id>` when `startFrom` is omitted
-- `/goalies/combined/{reportType}?teamId=<id>` when `startFrom` is omitted
+- `/players/combined/{reportType}?teamId=<id>` when `startFrom` is omitted or matches the team's default start season
+- `/goalies/combined/{reportType}?teamId=<id>` when `startFrom` is omitted or matches the team's default start season
 
 Behavior:
 

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -584,6 +584,29 @@ describe("routes", () => {
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotPlayers);
     });
 
+    test("uses snapshot when startFrom matches the default league start season", async () => {
+      const snapshotPlayers = [
+        { name: "Default Window Player", goals: 88, seasons: [] },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotPlayers);
+      (parseSeasonParam as jest.Mock).mockReturnValue(2012);
+
+      const req = createRequest({
+        url: "/players/combined/regular?startFrom=2012",
+        params: { reportType: "regular" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getPlayersCombined(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "players/combined/regular/team-1",
+      );
+      expect(getPlayersStatsCombined).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotPlayers);
+    });
+
     test("returns 400 for invalid report type", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(false);
 
@@ -790,6 +813,30 @@ describe("routes", () => {
 
       expect(loadSnapshot).toHaveBeenCalledWith(
         "goalies/combined/regular/team-1",
+      );
+      expect(getGoaliesStatsCombined).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotGoalies);
+    });
+
+    test("uses snapshot when startFrom matches the team's first season", async () => {
+      const snapshotGoalies = [
+        { name: "Seattle Window Goalie", wins: 33, seasons: [] },
+      ];
+      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotGoalies);
+      (resolveTeamId as jest.Mock).mockResolvedValue("28");
+      (parseSeasonParam as jest.Mock).mockReturnValue(2021);
+
+      const req = createRequest({
+        url: "/goalies/combined/regular?teamId=28&startFrom=2021",
+        params: { reportType: "regular" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getGoaliesCombined(asRouteReq(req), res);
+
+      expect(loadSnapshot).toHaveBeenCalledWith(
+        "goalies/combined/regular/team-28",
       );
       expect(getGoaliesStatsCombined).not.toHaveBeenCalled();
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotGoalies);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,6 +39,7 @@ import {
   getRegularLeaderboardSnapshotKey,
   loadSnapshot,
 } from "./snapshots";
+import { START_SEASON, TEAMS } from "./constants";
 
 const responseCache = new Map<string, { etag: string; data: unknown }>();
 
@@ -142,6 +143,9 @@ const loadSnapshotOrFallback = async <T>(
   return fallback();
 };
 
+const getDefaultStartFromForTeam = (teamId: string): number =>
+  TEAMS.find((team) => team.id === teamId)?.firstSeason ?? START_SEASON;
+
 export const getHealthcheck: AugmentedRequestHandler = async (_req, res) => {
   setNoStoreHeaders(res);
   send(res, HTTP_STATUS.OK, {
@@ -214,10 +218,11 @@ export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
     return;
   }
   const report = req.params.reportType as Report;
+  const defaultStartFrom = getDefaultStartFromForTeam(teamId);
 
   await withErrorHandlingCached(req, res, () =>
     loadSnapshotOrFallback(
-      startFrom === undefined
+      startFrom === undefined || startFrom === defaultStartFrom
         ? getCombinedSnapshotKey("players", report, teamId)
         : undefined,
       () => getPlayersStatsCombined(report, teamId, startFrom),
@@ -264,10 +269,11 @@ export const getGoaliesCombined: AugmentedRequestHandler = async (req, res) => {
     return;
   }
   const report = req.params.reportType as Report;
+  const defaultStartFrom = getDefaultStartFromForTeam(teamId);
 
   await withErrorHandlingCached(req, res, () =>
     loadSnapshotOrFallback(
-      startFrom === undefined
+      startFrom === undefined || startFrom === defaultStartFrom
         ? getCombinedSnapshotKey("goalies", report, teamId)
         : undefined,
       () => getGoaliesStatsCombined(report, teamId, startFrom),


### PR DESCRIPTION
## Summary
- allow combined player and goalie endpoints to use prebuilt snapshots when `startFrom` matches the team's default era window
- keep snapshot eligibility for omitted `startFrom`, while still falling back to live DB queries for non-default custom ranges
- add route tests for league-default and expansion-team default `startFrom` cases
- update snapshot documentation to reflect default team start-season behavior

## Verification
- npm run verify
