### PR TITLE
Fix: Remove DB lookups from teams and regular seasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Multi-team CSV layout (local or R2):
 
 Team configuration is defined in `src/constants.ts` (`TEAMS` and `DEFAULT_TEAM_ID`).
 
+
 ### Example requests
 
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -126,6 +126,7 @@ npm run verify
 
 ### Database (Turso/SQLite)
 
+- `/teams` and `regular` / `both` season availability are derived from `src/constants.ts`, not runtime DB lookups. Only playoff season availability remains DB-backed.
 - `npm run db:migrate` - Create/update database schema and performance indexes, including career lookup indexes on `player_id` and `goalie_id`
 - `npm run db:pull:remote` - Replace `local.db` by pulling full schema + data from remote Turso (`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` in `.env`); creates timestamped backup in `.backups/`
 - `npm run db:backups:clean` - Remove all files under `.backups/`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -74,7 +74,6 @@ Mock at the module boundary (`../db/queries` or `../db/client`):
 ```typescript
 jest.mock("../db/queries", () => ({
   getAvailableSeasonsFromDb: jest.fn(),
-  getTeamIdsWithData: jest.fn(),
 }));
 
 import { getAvailableSeasonsFromDb } from "../db/queries";

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -3,8 +3,12 @@ jest.mock("../db/queries", () => ({
   getTeamIdsWithData: jest.fn(),
 }));
 
-import { MIN_GAMES_FOR_ADJUSTED_SCORE } from "../constants";
-import { getAvailableSeasonsFromDb, getTeamIdsWithData } from "../db/queries";
+import {
+  CURRENT_SEASON,
+  MIN_GAMES_FOR_ADJUSTED_SCORE,
+  TEAMS,
+} from "../constants";
+import { getAvailableSeasonsFromDb } from "../db/queries";
 import {
   sortItemsByStatField,
   applyPlayerScores,
@@ -20,10 +24,10 @@ import {
 } from "../helpers";
 import { Player, Goalie, Report } from "../types";
 
-const mockGetAvailableSeasonsFromDb = getAvailableSeasonsFromDb as jest.MockedFunction<
-  typeof getAvailableSeasonsFromDb
->;
-const mockGetTeamIdsWithData = getTeamIdsWithData as jest.MockedFunction<typeof getTeamIdsWithData>;
+const mockGetAvailableSeasonsFromDb =
+  getAvailableSeasonsFromDb as jest.MockedFunction<
+    typeof getAvailableSeasonsFromDb
+  >;
 
 describe("helpers", () => {
   beforeEach(() => {
@@ -32,7 +36,9 @@ describe("helpers", () => {
 
   describe("sortItemsByStatField", () => {
     const players: Player[] = [
-      { id: "id", name: "Player A",
+      {
+        id: "id",
+        name: "Player A",
         games: 82,
         goals: 30,
         assists: 40,
@@ -47,7 +53,9 @@ describe("helpers", () => {
         score: 0,
         scoreAdjustedByGames: 0,
       },
-      { id: "id", name: "Player B",
+      {
+        id: "id",
+        name: "Player B",
         games: 75,
         goals: 50,
         assists: 60,
@@ -62,7 +70,9 @@ describe("helpers", () => {
         score: 0,
         scoreAdjustedByGames: 0,
       },
-      { id: "id", name: "Player C",
+      {
+        id: "id",
+        name: "Player C",
         games: 80,
         goals: 40,
         assists: 40,
@@ -80,7 +90,9 @@ describe("helpers", () => {
     ];
 
     const goalies: Goalie[] = [
-      { id: "id", name: "Goalie A",
+      {
+        id: "id",
+        name: "Goalie A",
         games: 60,
         wins: 30,
         saves: 1500,
@@ -94,7 +106,9 @@ describe("helpers", () => {
         score: 0,
         scoreAdjustedByGames: 0,
       },
-      { id: "id", name: "Goalie B",
+      {
+        id: "id",
+        name: "Goalie B",
         games: 70,
         wins: 45,
         saves: 2000,
@@ -108,7 +122,9 @@ describe("helpers", () => {
         score: 0,
         scoreAdjustedByGames: 0,
       },
-      { id: "id", name: "Goalie C",
+      {
+        id: "id",
+        name: "Goalie C",
         games: 65,
         wins: 35,
         saves: 1800,
@@ -130,7 +146,10 @@ describe("helpers", () => {
         { ...players[1], points: 80, goals: 35 },
         { ...players[2], points: 100, goals: 40 },
       ];
-      const result = sortItemsByStatField(playersWithTie, "players") as Player[];
+      const result = sortItemsByStatField(
+        playersWithTie,
+        "players",
+      ) as Player[];
       expect(result[0].name).toBe("Player C"); // 100 points
       expect(result[1].name).toBe("Player B"); // 80 points, 35 goals
       expect(result[2].name).toBe("Player A"); // 80 points, 25 goals
@@ -142,7 +161,10 @@ describe("helpers", () => {
         { ...goalies[1], wins: 40, games: 70 },
         { ...goalies[2], wins: 50, games: 65 },
       ];
-      const result = sortItemsByStatField(goaliesWithTie, "goalies") as Goalie[];
+      const result = sortItemsByStatField(
+        goaliesWithTie,
+        "goalies",
+      ) as Goalie[];
       expect(result[0].name).toBe("Goalie C"); // 50 wins
       expect(result[1].name).toBe("Goalie B"); // 40 wins, 70 games
       expect(result[2].name).toBe("Goalie A"); // 40 wins, 60 games
@@ -160,7 +182,9 @@ describe("helpers", () => {
   describe("applyPlayerScores", () => {
     test("calculates relative scores between 0 and 100 for players", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Player High",
+        {
+          id: "id",
+          name: "Player High",
           games: 0,
           goals: 50,
           assists: 0,
@@ -175,7 +199,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Player Half",
+        {
+          id: "id",
+          name: "Player Half",
           games: 0,
           goals: 25,
           assists: 0,
@@ -226,7 +252,9 @@ describe("helpers", () => {
       const belowMinGames = Math.max(minGames - 1, 0);
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Few Games High Stats",
+        {
+          id: "id",
+          name: "Few Games High Stats",
           games: belowMinGames,
           goals: 5,
           assists: 0,
@@ -241,7 +269,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Eligible Player",
+        {
+          id: "id",
+          name: "Eligible Player",
           games: minGames,
           goals: 5,
           assists: 0,
@@ -270,7 +300,9 @@ describe("helpers", () => {
       const belowMinGamesB = Math.max(minGames - 2, 0);
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Under Min A",
+        {
+          id: "id",
+          name: "Under Min A",
           games: belowMinGamesA,
           goals: 5,
           assists: 3,
@@ -285,7 +317,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Under Min B",
+        {
+          id: "id",
+          name: "Under Min B",
           games: belowMinGamesB,
           goals: 4,
           assists: 2,
@@ -309,7 +343,9 @@ describe("helpers", () => {
 
     test("uses 0 baseline for always-positive stats", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Top Scorer",
+        {
+          id: "id",
+          name: "Top Scorer",
           games: 0,
           goals: 40,
           assists: 0,
@@ -324,7 +360,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Zero Goals",
+        {
+          id: "id",
+          name: "Zero Goals",
           games: 0,
           goals: 0,
           assists: 0,
@@ -339,7 +377,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Lowest With Goals",
+        {
+          id: "id",
+          name: "Lowest With Goals",
           games: 0,
           goals: 3,
           assists: 0,
@@ -365,7 +405,9 @@ describe("helpers", () => {
 
     test("handles equal positive values for always-positive stats", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Player One",
+        {
+          id: "id",
+          name: "Player One",
           games: 0,
           goals: 10,
           assists: 0,
@@ -380,7 +422,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Player Two",
+        {
+          id: "id",
+          name: "Player Two",
           games: 0,
           goals: 10,
           assists: 0,
@@ -409,7 +453,9 @@ describe("helpers", () => {
   describe("applyPlayerScores plusMinus handling", () => {
     test("maps plusMinus linearly between min and max", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Best",
+        {
+          id: "id",
+          name: "Best",
           games: 0,
           goals: 0,
           assists: 0,
@@ -424,7 +470,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Worst",
+        {
+          id: "id",
+          name: "Worst",
           games: 0,
           goals: 0,
           assists: 0,
@@ -439,7 +487,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Middle",
+        {
+          id: "id",
+          name: "Middle",
           games: 0,
           goals: 0,
           assists: 0,
@@ -478,7 +528,9 @@ describe("helpers", () => {
 
     test("handles equal plusMinus values without contributing", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Equal A",
+        {
+          id: "id",
+          name: "Equal A",
           games: 0,
           goals: 0,
           assists: 0,
@@ -493,7 +545,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Equal B",
+        {
+          id: "id",
+          name: "Equal B",
           games: 0,
           goals: 0,
           assists: 0,
@@ -520,7 +574,9 @@ describe("helpers", () => {
       const minGames = MIN_GAMES_FOR_ADJUSTED_SCORE;
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Best PlusMinus",
+        {
+          id: "id",
+          name: "Best PlusMinus",
           games: minGames,
           goals: 0,
           assists: 0,
@@ -535,7 +591,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Middle PlusMinus",
+        {
+          id: "id",
+          name: "Middle PlusMinus",
           games: minGames,
           goals: 0,
           assists: 0,
@@ -550,7 +608,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Worst PlusMinus",
+        {
+          id: "id",
+          name: "Worst PlusMinus",
           games: minGames,
           goals: 0,
           assists: 0,
@@ -591,7 +651,9 @@ describe("helpers", () => {
       const minGames = MIN_GAMES_FOR_ADJUSTED_SCORE;
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Zero Stats Eligible A",
+        {
+          id: "id",
+          name: "Zero Stats Eligible A",
           games: minGames,
           goals: 0,
           assists: 0,
@@ -606,7 +668,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Zero Stats Eligible B",
+        {
+          id: "id",
+          name: "Zero Stats Eligible B",
           games: minGames + 1,
           goals: 0,
           assists: 0,
@@ -632,7 +696,9 @@ describe("helpers", () => {
   describe("applyPlayerScores with invalid numbers", () => {
     test("treats NaN stat values as 0", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "NaN Player",
+        {
+          id: "id",
+          name: "NaN Player",
           games: 0,
           goals: Number.NaN,
           assists: 0,
@@ -647,7 +713,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Valid Player",
+        {
+          id: "id",
+          name: "Valid Player",
           games: 0,
           goals: 10,
           assists: 0,
@@ -681,7 +749,9 @@ describe("helpers", () => {
 
     test("scores forwards against forwards only", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Forward High",
+        {
+          id: "id",
+          name: "Forward High",
           position: "F",
           games: 10,
           goals: 20,
@@ -697,7 +767,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Forward Low",
+        {
+          id: "id",
+          name: "Forward Low",
           position: "F",
           games: 10,
           goals: 10,
@@ -713,7 +785,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Defenseman",
+        {
+          id: "id",
+          name: "Defenseman",
           position: "D",
           games: 10,
           goals: 5,
@@ -748,7 +822,9 @@ describe("helpers", () => {
 
     test("handles players with no position", () => {
       const testPlayers = [
-        { id: "id", name: "No Position Player",
+        {
+          id: "id",
+          name: "No Position Player",
           games: 10,
           goals: 10,
           assists: 10,
@@ -776,7 +852,9 @@ describe("helpers", () => {
       const belowMinGames = Math.max(minGames - 1, 0);
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Few Games Forward",
+        {
+          id: "id",
+          name: "Few Games Forward",
           position: "F",
           games: belowMinGames,
           goals: 10,
@@ -792,7 +870,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Eligible Forward",
+        {
+          id: "id",
+          name: "Eligible Forward",
           position: "F",
           games: minGames,
           goals: 10,
@@ -813,14 +893,18 @@ describe("helpers", () => {
       const result = applyPlayerScoresByPosition(testPlayers);
 
       expect(result[0].scoreByPositionAdjustedByGames).toBe(0);
-      expect((result[1].scoreByPositionAdjustedByGames as number) > 0).toBe(true);
+      expect((result[1].scoreByPositionAdjustedByGames as number) > 0).toBe(
+        true,
+      );
     });
 
     test("handles all players below minimum games in position group", () => {
       const belowMinGames = Math.max(MIN_GAMES_FOR_ADJUSTED_SCORE - 1, 0);
 
       const testPlayers: Player[] = [
-        { id: "id", name: "Few Games Forward 1",
+        {
+          id: "id",
+          name: "Few Games Forward 1",
           position: "F",
           games: belowMinGames,
           goals: 10,
@@ -836,7 +920,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Few Games Forward 2",
+        {
+          id: "id",
+          name: "Few Games Forward 2",
           position: "F",
           games: belowMinGames,
           goals: 5,
@@ -862,7 +948,9 @@ describe("helpers", () => {
 
     test("handles plusMinus with equal values in position group", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Forward 1",
+        {
+          id: "id",
+          name: "Forward 1",
           position: "F",
           games: 10,
           goals: 10,
@@ -878,7 +966,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Forward 2",
+        {
+          id: "id",
+          name: "Forward 2",
           position: "F",
           games: 10,
           goals: 10,
@@ -904,7 +994,9 @@ describe("helpers", () => {
 
     test("treats NaN stat values as 0 in position scoring", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "NaN Forward",
+        {
+          id: "id",
+          name: "NaN Forward",
           position: "F",
           games: 10,
           goals: NaN,
@@ -920,7 +1012,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Valid Forward",
+        {
+          id: "id",
+          name: "Valid Forward",
           position: "F",
           games: 10,
           goals: 10,
@@ -947,7 +1041,9 @@ describe("helpers", () => {
 
     test("handles negative plusMinus per game in position scoring", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Positive Forward",
+        {
+          id: "id",
+          name: "Positive Forward",
           position: "F",
           games: 10,
           goals: 10,
@@ -963,7 +1059,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Negative Forward",
+        {
+          id: "id",
+          name: "Negative Forward",
           position: "F",
           games: 10,
           goals: 5,
@@ -984,12 +1082,17 @@ describe("helpers", () => {
       const result = applyPlayerScoresByPosition(testPlayers);
 
       // Positive plusMinus player should score higher in position scoring
-      expect((result[0].scoreByPositionAdjustedByGames as number) > (result[1].scoreByPositionAdjustedByGames as number)).toBe(true);
+      expect(
+        (result[0].scoreByPositionAdjustedByGames as number) >
+          (result[1].scoreByPositionAdjustedByGames as number),
+      ).toBe(true);
     });
 
     test("handles all stats at zero in position group", () => {
       const testPlayers: Player[] = [
-        { id: "id", name: "Zero Forward 1",
+        {
+          id: "id",
+          name: "Zero Forward 1",
           position: "F",
           games: 1,
           goals: 0,
@@ -1005,7 +1108,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Zero Forward 2",
+        {
+          id: "id",
+          name: "Zero Forward 2",
           position: "F",
           games: 1,
           goals: 0,
@@ -1033,7 +1138,9 @@ describe("helpers", () => {
   describe("applyGoalieScores", () => {
     test("calculates relative scores between 0 and 100 for goalies", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie High",
+        {
+          id: "id",
+          name: "Goalie High",
           games: 0,
           wins: 40,
           saves: 0,
@@ -1047,7 +1154,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Half",
+        {
+          id: "id",
+          name: "Goalie Half",
           games: 0,
           wins: 20,
           saves: 0,
@@ -1095,7 +1204,9 @@ describe("helpers", () => {
       // When all eligible goalies have 0 for every base field, maxPerGameByField[field] = 0
       // so the if (max > 0) branch is never taken and scoreAdjustedByGames stays 0
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Zero Stats Goalie",
+        {
+          id: "id",
+          name: "Zero Stats Goalie",
           games: MIN_GAMES_FOR_ADJUSTED_SCORE,
           wins: 0,
           saves: 0,
@@ -1121,7 +1232,9 @@ describe("helpers", () => {
       const belowMinGames = Math.max(minGames - 1, 0);
 
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Few Games Goalie",
+        {
+          id: "id",
+          name: "Few Games Goalie",
           games: belowMinGames,
           wins: 5,
           saves: 200,
@@ -1135,7 +1248,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Eligible Goalie",
+        {
+          id: "id",
+          name: "Eligible Goalie",
           games: minGames,
           wins: 5,
           saves: 200,
@@ -1163,7 +1278,9 @@ describe("helpers", () => {
       const belowMinGamesB = Math.max(minGames - 2, 0);
 
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Under Min Goalie A",
+        {
+          id: "id",
+          name: "Under Min Goalie A",
           games: belowMinGamesA,
           wins: 2,
           saves: 50,
@@ -1177,7 +1294,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Under Min Goalie B",
+        {
+          id: "id",
+          name: "Under Min Goalie B",
           games: belowMinGamesB,
           wins: 3,
           saves: 60,
@@ -1200,7 +1319,9 @@ describe("helpers", () => {
 
     test("uses 0 baseline for goalie always-positive stats", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Top Goalie",
+        {
+          id: "id",
+          name: "Top Goalie",
           games: 0,
           wins: 40,
           saves: 0,
@@ -1214,7 +1335,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Zero Wins",
+        {
+          id: "id",
+          name: "Zero Wins",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1228,7 +1351,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Lowest With Wins",
+        {
+          id: "id",
+          name: "Lowest With Wins",
           games: 0,
           wins: 3,
           saves: 0,
@@ -1253,7 +1378,9 @@ describe("helpers", () => {
 
     test("handles equal positive values for goalie always-positive stats", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie One",
+        {
+          id: "id",
+          name: "Goalie One",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1267,7 +1394,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Two",
+        {
+          id: "id",
+          name: "Goalie Two",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1293,7 +1422,9 @@ describe("helpers", () => {
 
     test("handles equal savePercent values using full contribution", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Equal A",
+        {
+          id: "id",
+          name: "Equal A",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1308,7 +1439,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Equal B",
+        {
+          id: "id",
+          name: "Equal B",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1335,7 +1468,9 @@ describe("helpers", () => {
 
     test("sets savePercent contribution to 0 when below baseline", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Above Baseline",
+        {
+          id: "id",
+          name: "Above Baseline",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1350,7 +1485,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Below Baseline",
+        {
+          id: "id",
+          name: "Below Baseline",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1377,7 +1514,9 @@ describe("helpers", () => {
       // When maxSavePercent <= GOALIE_SAVE_PERCENT_BASELINE (0.85), best > baseline is false
       // so relative stays 0 for all goalies in that branch
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie A",
+        {
+          id: "id",
+          name: "Goalie A",
           games: 0,
           wins: 5,
           saves: 100,
@@ -1392,7 +1531,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie B",
+        {
+          id: "id",
+          name: "Goalie B",
           games: 0,
           wins: 3,
           saves: 80,
@@ -1418,7 +1559,9 @@ describe("helpers", () => {
 
     test("includes savePercent and gaa contributions when present, including invalid values", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie Best",
+        {
+          id: "id",
+          name: "Goalie Best",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1434,7 +1577,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Slightly Worse GAA",
+        {
+          id: "id",
+          name: "Goalie Slightly Worse GAA",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1450,7 +1595,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Worse Advanced",
+        {
+          id: "id",
+          name: "Goalie Worse Advanced",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1466,7 +1613,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Invalid Advanced",
+        {
+          id: "id",
+          name: "Goalie Invalid Advanced",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1482,7 +1631,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie No Advanced",
+        {
+          id: "id",
+          name: "Goalie No Advanced",
           games: 0,
           wins: 10,
           saves: 0,
@@ -1498,8 +1649,13 @@ describe("helpers", () => {
         },
       ];
 
-      const [best, slightlyWorseGaa, worseAdvanced, invalidAdvanced, noAdvanced] =
-        applyGoalieScores(testGoalies);
+      const [
+        best,
+        slightlyWorseGaa,
+        worseAdvanced,
+        invalidAdvanced,
+        noAdvanced,
+      ] = applyGoalieScores(testGoalies);
 
       expect(best.score).toBeDefined();
       expect(slightlyWorseGaa.score).toBeDefined();
@@ -1526,7 +1682,9 @@ describe("helpers", () => {
 
     test("sets score to 0 when no contributing metrics", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie No Metrics",
+        {
+          id: "id",
+          name: "Goalie No Metrics",
           games: 0,
           wins: 0,
           saves: 0,
@@ -1548,7 +1706,9 @@ describe("helpers", () => {
 
     test("sets GAA score to 0 when GAA is 75% or more worse than best (ratio >= GOALIE_GAA_MAX_DIFF_RATIO)", () => {
       const testGoalies: Goalie[] = [
-        { id: "id", name: "Goalie Best GAA",
+        {
+          id: "id",
+          name: "Goalie Best GAA",
           games: 30,
           wins: 20,
           saves: 800,
@@ -1564,7 +1724,9 @@ describe("helpers", () => {
           score: 0,
           scoreAdjustedByGames: 0,
         },
-        { id: "id", name: "Goalie Extreme GAA",
+        {
+          id: "id",
+          name: "Goalie Extreme GAA",
           games: 30,
           wins: 10,
           saves: 600,
@@ -1604,69 +1766,75 @@ describe("helpers", () => {
       expect(await resolveTeamId("999")).toBe("1");
     });
 
-    test("keeps configured team id when team has data in DB", async () => {
-      mockGetTeamIdsWithData.mockResolvedValue(["1", "2"]);
+    test("keeps configured team id when the team exists in constants", async () => {
       expect(await resolveTeamId("2")).toBe("2");
     });
 
-    test("defaults to DEFAULT_TEAM_ID for configured team with no DB data", async () => {
-      mockGetTeamIdsWithData.mockResolvedValue(["1"]);
-      expect(await resolveTeamId("2")).toBe("1");
+    test("trims a valid configured team id", async () => {
+      expect(await resolveTeamId(" 28 ")).toBe("28");
     });
   });
 
   describe("availableSeasons", () => {
-    test("returns seasons from DB for default team", async () => {
-      mockGetAvailableSeasonsFromDb.mockResolvedValue([2012, 2013, 2014]);
-
+    test("returns computed regular seasons for the default team", async () => {
       const result = await availableSeasons();
-      expect(result).toEqual([2012, 2013, 2014]);
-      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith("1", "regular");
+      expect(result[0]).toBe(2012);
+      expect(result.at(-1)).toBe(CURRENT_SEASON);
+      expect(result).toHaveLength(CURRENT_SEASON - 2012 + 1);
+      expect(mockGetAvailableSeasonsFromDb).not.toHaveBeenCalled();
     });
 
-    test("when reportType is both, returns union of regular and playoffs seasons", async () => {
-      mockGetAvailableSeasonsFromDb
-        .mockResolvedValueOnce([2012, 2013]) // regular
-        .mockResolvedValueOnce([2013, 2014]); // playoffs
-
-      const result = await availableSeasons("1", "both");
-      expect(result).toEqual([2012, 2013, 2014]);
+    test("when reportType is both, returns the team's regular era range", async () => {
+      const result = await availableSeasons("28", "both");
+      expect(result[0]).toBe(2021);
+      expect(result.at(-1)).toBe(CURRENT_SEASON);
+      expect(result).toHaveLength(CURRENT_SEASON - 2021 + 1);
+      expect(mockGetAvailableSeasonsFromDb).not.toHaveBeenCalled();
     });
 
-    test("returns empty array when no seasons", async () => {
-      mockGetAvailableSeasonsFromDb.mockResolvedValue([]);
-
-      const result = await availableSeasons();
-      expect(result).toEqual([]);
-    });
-
-    test("delegates to listSeasonsForTeam for non-both reportType", async () => {
+    test("delegates playoff seasons to the DB", async () => {
       mockGetAvailableSeasonsFromDb.mockResolvedValue([2023, 2024]);
 
       const result = await availableSeasons("2", "playoffs");
       expect(result).toEqual([2023, 2024]);
-      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith("2", "playoffs");
+      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith(
+        "2",
+        "playoffs",
+      );
+    });
+
+    test("returns empty array when playoffs have no seasons", async () => {
+      mockGetAvailableSeasonsFromDb.mockResolvedValue([]);
+
+      const result = await availableSeasons("1", "playoffs");
+      expect(result).toEqual([]);
     });
   });
 
   describe("seasonAvailable", () => {
-    beforeEach(() => {
-      mockGetAvailableSeasonsFromDb.mockResolvedValue([2012, 2013, 2014]);
-    });
-
-    test("returns true for available season", async () => {
+    test("returns true for an available regular season", async () => {
       expect(await seasonAvailable(2012)).toBe(true);
-      expect(await seasonAvailable(2013)).toBe(true);
-      expect(await seasonAvailable(2014)).toBe(true);
+      expect(await seasonAvailable(CURRENT_SEASON)).toBe(true);
     });
 
-    test("returns false for unavailable season", async () => {
-      expect(await seasonAvailable(2020)).toBe(false);
+    test("returns false for an unavailable regular season", async () => {
       expect(await seasonAvailable(2000)).toBe(false);
+      expect(await seasonAvailable(2020, "28", "regular")).toBe(false);
     });
 
     test("returns true for undefined season", async () => {
       expect(await seasonAvailable(undefined)).toBe(true);
+    });
+
+    test("uses DB-backed seasons for playoffs", async () => {
+      mockGetAvailableSeasonsFromDb.mockResolvedValue([2023, 2024]);
+
+      expect(await seasonAvailable(2024, "1", "playoffs")).toBe(true);
+      expect(await seasonAvailable(2022, "1", "playoffs")).toBe(false);
+      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith(
+        "1",
+        "playoffs",
+      );
     });
   });
 
@@ -1724,26 +1892,20 @@ describe("helpers", () => {
   });
 
   describe("getTeamsWithData", () => {
-    test("filters TEAMS to those with data in DB", async () => {
-      mockGetTeamIdsWithData.mockResolvedValue(["1"]);
-
-      const teams = await getTeamsWithData();
-      expect(teams).toHaveLength(1);
+    test("returns all configured teams", () => {
+      const teams = getTeamsWithData();
+      expect(teams).toHaveLength(TEAMS.length);
       expect(teams[0]).toMatchObject({ id: "1", name: "colorado" });
     });
 
-    test("returns empty array when no teams have data", async () => {
-      mockGetTeamIdsWithData.mockResolvedValue([]);
-
-      const teams = await getTeamsWithData();
-      expect(teams).toEqual([]);
-    });
-
-    test("returns multiple teams when multiple have data", async () => {
-      mockGetTeamIdsWithData.mockResolvedValue(["1", "2"]);
-
-      const teams = await getTeamsWithData();
-      expect(teams).toHaveLength(2);
+    test("includes expansion teams from constants", () => {
+      const teams = getTeamsWithData();
+      expect(teams).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "28", name: "seattle" }),
+          expect.objectContaining({ id: "32", name: "vegas" }),
+        ]),
+      );
     });
   });
 
@@ -1753,7 +1915,10 @@ describe("helpers", () => {
 
       const result = await listSeasonsForTeam("1", "regular");
       expect(result).toEqual([2023, 2024]);
-      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith("1", "regular");
+      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith(
+        "1",
+        "regular",
+      );
     });
   });
 });

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -1,6 +1,5 @@
 jest.mock("../db/queries", () => ({
   getAvailableSeasonsFromDb: jest.fn(),
-  getTeamIdsWithData: jest.fn(),
 }));
 
 import {

--- a/src/__tests__/queries.test.ts
+++ b/src/__tests__/queries.test.ts
@@ -14,7 +14,6 @@ import {
   getAllPlayerCareerRowsFromDb,
   getAllGoalieCareerRowsFromDb,
   getAvailableSeasonsFromDb,
-  getTeamIdsWithData,
   getLastModifiedFromDb,
   getPlayoffLeaderboard,
   getPlayoffSeasons,
@@ -521,25 +520,6 @@ describe("db/queries", () => {
     test("returns empty array when no seasons", async () => {
       mockExecute.mockResolvedValue({ rows: [] });
       const result = await getAvailableSeasonsFromDb("1", "regular");
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe("getTeamIdsWithData", () => {
-    test("returns distinct team IDs from both tables", async () => {
-      mockExecute.mockResolvedValue({
-        rows: [{ team_id: "1" }, { team_id: "2" }, { team_id: "3" }],
-      });
-
-      const result = await getTeamIdsWithData();
-
-      expect(mockExecute).toHaveBeenCalledWith(expect.stringContaining("games > 0"));
-      expect(result).toEqual(["1", "2", "3"]);
-    });
-
-    test("returns empty array when no data", async () => {
-      mockExecute.mockResolvedValue({ rows: [] });
-      const result = await getTeamIdsWithData();
       expect(result).toEqual([]);
     });
   });

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -71,7 +71,7 @@ describe("routes", () => {
     jest.clearAllMocks();
     resetRouteCachesForTests();
     (loadSnapshot as jest.Mock).mockResolvedValue(null);
-    (resolveTeamId as jest.Mock).mockResolvedValue("1");
+    (resolveTeamId as jest.Mock).mockReturnValue("1");
     (reportTypeAvailable as jest.Mock).mockReturnValue(true);
     (seasonAvailable as jest.Mock).mockResolvedValue(true);
     (parseSeasonParam as jest.Mock).mockReturnValue(undefined);
@@ -211,7 +211,7 @@ describe("routes", () => {
     test("parses query params even when host header is not a string", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
+      (resolveTeamId as jest.Mock).mockImplementation((raw: unknown) =>
         typeof raw === "string" && raw ? raw : "1",
       );
 
@@ -235,7 +235,7 @@ describe("routes", () => {
     test("parses query params with valid url but no headers object", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
+      (resolveTeamId as jest.Mock).mockImplementation((raw: unknown) =>
         typeof raw === "string" && raw ? raw : "1",
       );
 
@@ -286,7 +286,7 @@ describe("routes", () => {
     test("treats missing teamId query param as undefined", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation(async (raw: unknown) =>
+      (resolveTeamId as jest.Mock).mockImplementation((raw: unknown) =>
         raw ? String(raw) : "1",
       );
 
@@ -342,7 +342,7 @@ describe("routes", () => {
   describe("getTeams", () => {
     test("returns 200 with configured teams", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const req = createRequest();
       const res = createResponse();
@@ -355,7 +355,7 @@ describe("routes", () => {
 
     test("memoizes successful responses and avoids re-calling the handler", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const req1 = createRequest({ url: "/teams" });
       const res1 = createResponse();
@@ -373,7 +373,7 @@ describe("routes", () => {
 
     test("returns 304 for matching If-None-Match", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const req1 = createRequest({ url: "/teams", method: "GET" });
       const res1 = createResponse();
@@ -399,7 +399,7 @@ describe("routes", () => {
 
     test("hits cached 304 branch on repeat request", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const primeReq = {
         method: "GET",
@@ -430,7 +430,7 @@ describe("routes", () => {
 
     test("returns 304 on first request when If-None-Match matches freshly computed etag", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const etag = makeEtagForJson(filteredTeams);
       const req = {
@@ -451,7 +451,7 @@ describe("routes", () => {
 
     test("works when req is undefined (no caching possible)", async () => {
       const filteredTeams = [{ id: "1", name: "colorado" }];
-      (getTeamsWithData as jest.Mock).mockResolvedValue(filteredTeams);
+      (getTeamsWithData as jest.Mock).mockReturnValue(filteredTeams);
 
       const res = createResponse();
       await getTeams(undefined as unknown as RouteReq, res);
@@ -830,7 +830,7 @@ describe("routes", () => {
         { name: "Seattle Window Goalie", wins: 33, seasons: [] },
       ];
       (loadSnapshot as jest.Mock).mockResolvedValue(snapshotGoalies);
-      (resolveTeamId as jest.Mock).mockResolvedValue("28");
+      (resolveTeamId as jest.Mock).mockReturnValue("28");
       (parseSeasonParam as jest.Mock).mockReturnValue(2021);
 
       const req = createRequest({
@@ -1966,7 +1966,7 @@ describe("routes", () => {
     };
 
     test("getTeams response conforms to Team[] schema", async () => {
-      (getTeamsWithData as jest.Mock).mockResolvedValue([validTeam]);
+      (getTeamsWithData as jest.Mock).mockReturnValue([validTeam]);
       const req = createRequest({ url: "/teams" });
       const res = createResponse();
       await getTeams(asRouteReq(req), res);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -229,19 +229,6 @@ export const getAvailableSeasonsFromDb = async (
   return castRows<{ season: number }>(result.rows).map((r) => r.season);
 };
 
-export const getTeamIdsWithData = async (): Promise<string[]> => {
-  const db = getDbClient();
-  const result = await db.execute(
-    `SELECT DISTINCT team_id FROM players
-     WHERE games > 0
-     UNION
-     SELECT DISTINCT team_id FROM goalies
-     WHERE games > 0
-     ORDER BY team_id`
-  );
-  return castRows<{ team_id: string }>(result.rows).map((r) => r.team_id);
-};
-
 export const getLastModifiedFromDb = async (): Promise<string | null> => {
   const db = getDbClient();
   const result = await db.execute({

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,11 @@
-import { Player, PlayerFields, Goalie, Report, CsvReport, GoalieScoreField } from "./types";
+import {
+  Player,
+  PlayerFields,
+  Goalie,
+  Report,
+  CsvReport,
+  GoalieScoreField,
+} from "./types";
 import {
   REPORT_TYPES,
   PLAYER_SCORE_FIELDS,
@@ -9,31 +16,46 @@ import {
   GOALIE_SAVE_PERCENT_BASELINE,
   GOALIE_SCORING_DAMPENING_EXPONENT,
   MIN_GAMES_FOR_ADJUSTED_SCORE,
+  CURRENT_SEASON,
   DEFAULT_TEAM_ID,
+  START_SEASON,
   TEAMS,
 } from "./constants";
-import { getAvailableSeasonsFromDb, getTeamIdsWithData } from "./db/queries";
+import { getAvailableSeasonsFromDb } from "./db/queries";
 
 export { HTTP_STATUS, ERROR_MESSAGES } from "./constants";
 
-const isConfiguredTeamId = (teamId: string): boolean => TEAMS.some((t) => t.id === teamId);
+const isConfiguredTeamId = (teamId: string): boolean =>
+  TEAMS.some((t) => t.id === teamId);
 
-export const getTeamsWithData = async (): Promise<Array<(typeof TEAMS)[number]>> => {
-  const teamIds = await getTeamIdsWithData();
-  const teamIdSet = new Set(teamIds);
-  return TEAMS.filter((team) => teamIdSet.has(team.id));
+const getTeamStartSeason = (teamId: string): number =>
+  TEAMS.find((team) => team.id === teamId)?.firstSeason ?? START_SEASON;
+
+const getRegularSeasonRangeForTeam = (teamId: string): number[] => {
+  const startSeason = getTeamStartSeason(teamId);
+  const seasons: number[] = [];
+
+  for (let season = startSeason; season <= CURRENT_SEASON; season++) {
+    seasons.push(season);
+  }
+
+  return seasons;
 };
 
-export const resolveTeamId = async (raw: unknown): Promise<string> => {
+export const getTeamsWithData = (): Array<(typeof TEAMS)[number]> => [...TEAMS];
+
+export const resolveTeamId = (raw: unknown): string => {
   if (typeof raw !== "string") return DEFAULT_TEAM_ID;
   const teamId = raw.trim();
   if (!teamId) return DEFAULT_TEAM_ID;
   if (!isConfiguredTeamId(teamId)) return DEFAULT_TEAM_ID;
-  const teams = await getTeamsWithData();
-  return teams.some((t) => t.id === teamId) ? teamId : DEFAULT_TEAM_ID;
+  return teamId;
 };
 
-export const listSeasonsForTeam = async (teamId: string, reportType: CsvReport): Promise<number[]> => {
+export const listSeasonsForTeam = async (
+  teamId: string,
+  reportType: CsvReport,
+): Promise<number[]> => {
   return getAvailableSeasonsFromDb(teamId, reportType);
 };
 
@@ -48,7 +70,10 @@ const toTwoDecimals = (value: number): number => Number(value.toFixed(2));
 // Normalize a numeric field so that the highest positive value becomes 100
 // and all other positive values are scaled proportionally into the 0–100 range.
 // Used for both total scores (score) and games-adjusted scores (scoreAdjustedByGames).
-const normalizeFieldToBest = <T, K extends keyof T & string>(items: T[], field: K): void => {
+const normalizeFieldToBest = <T, K extends keyof T & string>(
+  items: T[],
+  field: K,
+): void => {
   let max = 0;
 
   for (const item of items as Array<Record<string, unknown>>) {
@@ -69,7 +94,10 @@ const normalizeFieldToBest = <T, K extends keyof T & string>(items: T[], field: 
   }
 };
 
-const getMaxByField = <T extends Record<K, number>, K extends keyof T>(items: readonly T[], fields: readonly K[]): Record<K, number> => {
+const getMaxByField = <T extends Record<K, number>, K extends keyof T>(
+  items: readonly T[],
+  fields: readonly K[],
+): Record<K, number> => {
   return fields.reduce(
     (acc, field) => {
       let max = 0;
@@ -83,11 +111,14 @@ const getMaxByField = <T extends Record<K, number>, K extends keyof T>(items: re
       acc[field] = max;
       return acc;
     },
-    {} as Record<K, number>
+    {} as Record<K, number>,
   );
 };
 
-const getMinByField = <T extends Record<K, number>, K extends keyof T>(items: readonly T[], fields: readonly K[]): Record<K, number> => {
+const getMinByField = <T extends Record<K, number>, K extends keyof T>(
+  items: readonly T[],
+  fields: readonly K[],
+): Record<K, number> => {
   return fields.reduce(
     (acc, field) => {
       let min = 0;
@@ -101,17 +132,20 @@ const getMinByField = <T extends Record<K, number>, K extends keyof T>(items: re
       acc[field] = min;
       return acc;
     },
-    {} as Record<K, number>
+    {} as Record<K, number>,
   );
 };
 
 const applyScoresInternal = <
-  T extends Record<K, number> & { score?: number; scores?: Record<string, number> },
+  T extends Record<K, number> & {
+    score?: number;
+    scores?: Record<string, number>;
+  },
   K extends keyof T & string,
 >(
   items: T[],
   fields: K[],
-  weights: Record<K, number>
+  weights: Record<K, number>,
 ): T[] => {
   if (!items.length) return items;
 
@@ -161,7 +195,7 @@ const applyScoresInternal = <
 
 export const sortItemsByStatField = (
   data: Player[] | Goalie[],
-  kind: "players" | "goalies"
+  kind: "players" | "goalies",
 ): Player[] | Goalie[] => {
   if (kind === "players") {
     return (data as Player[]).sort(defaultSortPlayers);
@@ -174,7 +208,9 @@ export const sortItemsByStatField = (
 const applyPlayerScoresByGames = (players: Player[]): void => {
   if (!players.length) return;
 
-  const eligible = players.filter((player) => player.games >= MIN_GAMES_FOR_ADJUSTED_SCORE);
+  const eligible = players.filter(
+    (player) => player.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  );
 
   if (!eligible.length) {
     for (const player of players) {
@@ -189,7 +225,7 @@ const applyPlayerScoresByGames = (players: Player[]): void => {
       acc[field as PlayerFields] = 0;
       return acc;
     },
-    {} as Record<PlayerFields, number>
+    {} as Record<PlayerFields, number>,
   );
 
   let minPlusMinusPerGame = 0;
@@ -246,7 +282,9 @@ const applyPlayerScoresByGames = (players: Player[]): void => {
     }
 
     const average = total / fieldCount;
-    player.scoreAdjustedByGames = toTwoDecimals(Math.min(Math.max(average, 0), 100));
+    player.scoreAdjustedByGames = toTwoDecimals(
+      Math.min(Math.max(average, 0), 100),
+    );
   }
 
   normalizeFieldToBest(players, "scoreAdjustedByGames");
@@ -310,7 +348,9 @@ const applyPositionScoresForGroup = (players: Player[]): void => {
   normalizeFieldToBest(players, "scoreByPosition");
 
   // Calculate scoreByPositionAdjustedByGames
-  const eligible = players.filter((p) => p.games >= MIN_GAMES_FOR_ADJUSTED_SCORE);
+  const eligible = players.filter(
+    (p) => p.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  );
 
   if (!eligible.length) {
     for (const player of players) {
@@ -377,7 +417,9 @@ const applyPositionScoresForGroup = (players: Player[]): void => {
     }
 
     const average = total / fieldCount;
-    player.scoreByPositionAdjustedByGames = toTwoDecimals(Math.min(Math.max(average, 0), 100));
+    player.scoreByPositionAdjustedByGames = toTwoDecimals(
+      Math.min(Math.max(average, 0), 100),
+    );
   }
 
   normalizeFieldToBest(players, "scoreByPositionAdjustedByGames");
@@ -441,10 +483,13 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
       if (max > 0) {
         const raw = Number(goalie[field]);
         const value = Math.max(0, raw);
-        const relative = Math.pow(value / max, GOALIE_SCORING_DAMPENING_EXPONENT) * 100;
+        const relative =
+          Math.pow(value / max, GOALIE_SCORING_DAMPENING_EXPONENT) * 100;
         const weight = GOALIE_SCORE_WEIGHTS[field];
 
-        goalie.scores![field] = toTwoDecimals(Math.min(Math.max(relative, 0), 100));
+        goalie.scores![field] = toTwoDecimals(
+          Math.min(Math.max(relative, 0), 100),
+        );
 
         total += relative * weight;
         count += 1;
@@ -470,7 +515,9 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
         total += relative * weight;
         count += 1;
 
-        goalie.scores!.savePercent = toTwoDecimals(Math.min(Math.max(relative, 0), 100));
+        goalie.scores!.savePercent = toTwoDecimals(
+          Math.min(Math.max(relative, 0), 100),
+        );
       }
     }
 
@@ -484,14 +531,18 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
         if (diff > 0 && GOALIE_GAA_MAX_DIFF_RATIO > 0 && best > 0) {
           const ratio = diff / best; // how much worse than best, as a fraction
           relative =
-            ratio >= GOALIE_GAA_MAX_DIFF_RATIO ? 0 : (1 - ratio / GOALIE_GAA_MAX_DIFF_RATIO) * 100;
+            ratio >= GOALIE_GAA_MAX_DIFF_RATIO
+              ? 0
+              : (1 - ratio / GOALIE_GAA_MAX_DIFF_RATIO) * 100;
         }
 
         const weight = GOALIE_SCORE_WEIGHTS.gaa;
         total += relative * weight;
         count += 1;
 
-        goalie.scores!.gaa = toTwoDecimals(Math.min(Math.max(relative, 0), 100));
+        goalie.scores!.gaa = toTwoDecimals(
+          Math.min(Math.max(relative, 0), 100),
+        );
       }
     }
 
@@ -505,7 +556,9 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
   }
 
   normalizeFieldToBest(goalies, "score");
-  const eligible = goalies.filter((goalie) => goalie.games >= MIN_GAMES_FOR_ADJUSTED_SCORE);
+  const eligible = goalies.filter(
+    (goalie) => goalie.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  );
 
   if (!eligible.length) {
     for (const goalie of goalies) {
@@ -520,7 +573,7 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
       acc[field] = 0;
       return acc;
     },
-    {} as Record<GoalieScoreField, number>
+    {} as Record<GoalieScoreField, number>,
   );
 
   for (const goalie of eligible) {
@@ -557,7 +610,9 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
     }
 
     const average = total / fieldCount;
-    goalie.scoreAdjustedByGames = toTwoDecimals(Math.min(Math.max(average, 0), 100));
+    goalie.scoreAdjustedByGames = toTwoDecimals(
+      Math.min(Math.max(average, 0), 100),
+    );
   }
 
   normalizeFieldToBest(goalies, "scoreAdjustedByGames");
@@ -567,16 +622,10 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
 
 export const availableSeasons = async (
   teamId: string = DEFAULT_TEAM_ID,
-  reportType: Report = "regular"
+  reportType: Report = "regular",
 ): Promise<number[]> => {
-  if (reportType === "both") {
-    const seasons = new Set<number>();
-    for (const report of ["regular", "playoffs"] as const) {
-      for (const season of await listSeasonsForTeam(teamId, report)) {
-        seasons.add(season);
-      }
-    }
-    return [...seasons].sort((a, b) => a - b);
+  if (reportType === "regular" || reportType === "both") {
+    return getRegularSeasonRangeForTeam(teamId);
   }
 
   return await listSeasonsForTeam(teamId, reportType);
@@ -585,13 +634,14 @@ export const availableSeasons = async (
 export const seasonAvailable = async (
   season: number | undefined,
   teamId: string = DEFAULT_TEAM_ID,
-  reportType: Report = "regular"
+  reportType: Report = "regular",
 ): Promise<boolean> => {
   if (season === undefined) return true;
   return (await availableSeasons(teamId, reportType)).includes(season);
 };
 
-export const reportTypeAvailable = (report?: Report) => !!report && REPORT_TYPES.includes(report);
+export const reportTypeAvailable = (report?: Report) =>
+  !!report && REPORT_TYPES.includes(report);
 
 export const parseSeasonParam = (value: unknown): number | undefined => {
   if (!value) return undefined;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -175,13 +175,13 @@ export const getHealthcheck: AugmentedRequestHandler = async (_req, res) => {
 
 export const getTeams: AugmentedRequestHandler = async (req, res) => {
   await withErrorHandlingCached(req, res, async () => ({
-    data: await getTeamsWithData(),
+    data: getTeamsWithData(),
     dataSource: "db",
   }));
 };
 
 export const getSeasons: AugmentedRequestHandler = async (req, res) => {
-  const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
+  const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
 
   const rawReport = req.params.reportType || "regular";
@@ -202,7 +202,7 @@ export const getSeasons: AugmentedRequestHandler = async (req, res) => {
 };
 
 export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
-  const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
+  const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
     sendNoStore(
@@ -230,7 +230,7 @@ export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
 };
 
 export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
-  const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
+  const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {
     sendNoStore(
@@ -254,7 +254,7 @@ export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
 };
 
 export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
-  const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
+  const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
     sendNoStore(
@@ -282,7 +282,7 @@ export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
 };
 
 export const getGoaliesCombined: AugmentedRequestHandler = async (req, res) => {
-  const teamId = await resolveTeamId(getQueryParam(req, "teamId"));
+  const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {
     sendNoStore(


### PR DESCRIPTION
## Summary
- remove runtime DB lookups from `/teams` by serving configured teams directly from `TEAMS`
- derive `regular` and `both` season availability from team start season plus `CURRENT_SEASON`
- keep only playoff season availability DB-backed
- make `resolveTeamId()` and `getTeamsWithData()` synchronous and update route call sites
- update helper and route tests to match the new sync/config-driven behavior
- keep the implementation detail in development docs while removing it from README

### Cleanup
- remove the unused `getTeamIdsWithData` query from the DB layer
- delete the obsolete unit tests that only covered that dead query
- clean stale mock examples from helper tests and the testing guide

## Verification
- npm run verify
