### PR TITLE
Refactor: DB-backed integration testing system and unnecessary unit tests cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ The spec is hand-crafted in `openapi.yaml` at the repo root — there is no code
 
 ```
 npm test              # Run all tests
+npm run test:integration # Run DB-backed integration tests
 npm run test:watch    # Run tests in watch mode
 npm run test:coverage # Run tests with coverage report
 npm run unused        # Detect unused production exports
 npm run verify        # Full quality gate (lint + typecheck + unused exports + build + coverage)
 ```
 
-Coverage reports are generated in the `coverage/` directory. The `npm run verify` command runs ESLint, TypeScript compilation, Knip export analysis, production build, and Jest with enforced 100% global coverage thresholds.
+Coverage reports are generated in the `coverage/` directory. The `npm run verify` command runs ESLint, TypeScript compilation, Knip export analysis, production build, and Jest with enforced 100% global coverage thresholds. For route/service/database behavior, the suite now also includes DB-backed integration tests that run against a temporary SQLite database with isolated snapshot storage, so behavior can be validated with less internal mocking.
 
 ## CI
 
@@ -694,6 +695,6 @@ Written with [TypeScript](https://www.typescriptlang.org/), using [micro](https:
 - Standardize request validation + error response shape
 - Tighten OpenAPI spec: type `scores` and `scoresByPosition` object keys as fixed stat-field enums (requires upgrading spec to OpenAPI 3.1 for `propertyNames` support)
 - Add paging or search-first loading for large career lists to reduce initial payload size further
-- Add more realistic backend contract/integration tests so route behavior is validated with less internal mocking
+- Continue migrating route/service coverage toward DB-backed contract/integration tests and remove overlapping mock-heavy tests
 
 Feel free to suggest feature / implementation polishing with writing issue or make PR if you want to contribute!

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -102,6 +102,7 @@ npm run verify
 ### Testing
 
 - `npm test` - Run all tests once
+- `npm run test:integration` - Run DB-backed integration tests in-band against a temporary SQLite database
 - `npm run test:watch` - Run tests in watch mode (development)
 - `npm run test:coverage` - Run tests with coverage report
 - `npm run verify` - **Full quality gate** (lint + typecheck + unused exports + build + coverage)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -59,6 +59,7 @@ npm run verify  # Runs lint, typecheck, unused export check, build, and test:cov
 
 - Keep 100% coverage intact for now, but do not add mock-heavy tests just to satisfy the threshold.
 - For changes that cross `routes` + `services` + `db/queries`, prefer a DB-backed integration test before adding more delegation assertions.
+- When a DB-backed integration test already covers a route or service happy path end-to-end, delete the overlapping mocked happy-path test instead of keeping both.
 - Keep focused unit tests for pure logic such as scoring, mapping, auth parsing, cache normalization, and snapshot cache behavior.
 - The integration harness lives in `src/__tests__/integration-db.ts` and uses `src/db/schema.ts` so tests and the migration script share the same schema source.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -60,6 +60,7 @@ npm run verify  # Runs lint, typecheck, unused export check, build, and test:cov
 - Keep 100% coverage intact for now, but do not add mock-heavy tests just to satisfy the threshold.
 - For changes that cross `routes` + `services` + `db/queries`, prefer a DB-backed integration test before adding more delegation assertions.
 - When a DB-backed integration test already covers a route or service happy path end-to-end, delete the overlapping mocked happy-path test instead of keeping both.
+- In `services.test.ts`, keep aggregation, merge, sorting, and error-path coverage; remove tests that only prove query fan-out, default parameter forwarding, or other wiring already exercised by route integration.
 - Keep focused unit tests for pure logic such as scoring, mapping, auth parsing, cache normalization, and snapshot cache behavior.
 - The integration harness lives in `src/__tests__/integration-db.ts` and uses `src/db/schema.ts` so tests and the migration script share the same schema source.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,6 +13,7 @@ All new code **must maintain 100% test coverage:**
 
 **Excluded from coverage:**
 
+- **`src/__tests__/**`**: Test-only fixtures and harness helpers
 - **db/client.ts only**: Thin wrapper around Turso/libSQL client — tested via integration
 
 ---
@@ -22,6 +23,7 @@ All new code **must maintain 100% test coverage:**
 - **Jest** - Unit and integration tests
 - **ts-jest** - TypeScript transformation
 - **node-mocks-http** - HTTP request/response mocking
+- **Temporary SQLite/libSQL file DBs** - Route/service/query integration coverage without production snapshots or mocked DB queries
 
 ---
 
@@ -39,11 +41,26 @@ npm run test:coverage
 npm run test:watch
 ```
 
+### DB-backed integration tests
+
+```bash
+npm run test:integration
+```
+
 ### Full quality gate
 
 ```bash
 npm run verify  # Runs lint, typecheck, unused export check, build, and test:coverage
 ```
+
+---
+
+## Preferred Strategy
+
+- Keep 100% coverage intact for now, but do not add mock-heavy tests just to satisfy the threshold.
+- For changes that cross `routes` + `services` + `db/queries`, prefer a DB-backed integration test before adding more delegation assertions.
+- Keep focused unit tests for pure logic such as scoring, mapping, auth parsing, cache normalization, and snapshot cache behavior.
+- The integration harness lives in `src/__tests__/integration-db.ts` and uses `src/db/schema.ts` so tests and the migration script share the same schema source.
 
 ---
 
@@ -68,6 +85,8 @@ test("gets available seasons", async () => {
 ```
 
 ### Mocking the Database Layer
+
+Use this for narrow unit tests only. If the behavior under change spans routes/services/query composition, prefer the temporary SQLite integration harness instead.
 
 Mock at the module boundary (`../db/queries` or `../db/client`):
 
@@ -114,15 +133,17 @@ src/
     ├── auth.test.ts      # API key authentication
     ├── cache.test.ts     # Response caching & ETags
     ├── helpers.test.ts   # Core utilities, scoring, DB-backed helpers
+    ├── integration-db.ts # Temp DB + env isolation helpers for integration tests
     ├── mappings.test.ts  # Data transformation (CSV parsing for import, combined data mapping)
     ├── queries.test.ts   # Database query layer
+    ├── routes.integration.test.ts # Real route/service/query integration via temp SQLite
     ├── routes.test.ts    # API endpoint handlers
     ├── snapshots.test.ts # Snapshot loading, R2 fallback, cache behavior
     ├── services.test.ts  # Business logic (DB → scored data)
     └── fixtures.ts       # Shared test data
 ```
 
-Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches.
+Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches, and route-db integration now has a dedicated suite so endpoint behavior can be validated with less internal mocking.
 
 ---
 
@@ -140,21 +161,23 @@ Keep this directory updated whenever a new module or integration boundary is add
 
 1. **All new functions** - Unit tests covering happy path + edge cases
 2. **Modified functions** - Update existing tests, add new cases for new behavior
-3. **New API endpoints** - Route handler tests + integration tests
-4. **Error handling** - Test error cases explicitly
-5. **Async operations** - Test promise resolution and rejection
+3. **Route/service/db behavior changes** - Prefer DB-backed integration tests when the logic crosses module boundaries
+4. **New API endpoints** - Route handler tests + integration tests
+5. **Error handling** - Test error cases explicitly
+6. **Async operations** - Test promise resolution and rejection
 
 **If you can't test something:**
 
 - Don't exclude it from coverage without discussion
 - Don't lower coverage thresholds (100% is required)
-- Do propose mocking strategies
+- Do propose integration or mocking strategies
 - Do document why it's difficult and seek guidance
 
 **For external SDK integrations:**
 
 - Mock at the module boundary (e.g., mock `../db/client`, not the libSQL SDK)
-- Test your wrapper code through the mocked dependency
+- Test your thin wrapper code through the mocked dependency
+- Test higher-level DB behavior through the temp SQLite integration harness when possible
 - Only exclude the thinnest possible adapter layer (e.g., `db/client.ts`)
 
 ---

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   testMatch: ["**/__tests__/**/*.test.ts"],
   collectCoverageFrom: [
     "src/**/*.ts",
+    "!src/__tests__/**",
     "!src/playwright/**",
     "!src/types.ts",
     "!src/index.ts",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "parseAndUploadRawCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; tsx scripts/upload-raw-to-r2.ts",
     "start": "npm run build && node lib/server.js",
     "test": "jest --watchman=false",
+    "test:integration": "jest --watchman=false --runInBand --testPathPatterns=integration",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage --watchman=false",
     "verify": "npm run lint:check && npm run typecheck && npm run unused && npm run build && npm run test:coverage"

--- a/scripts/db-migrate.ts
+++ b/scripts/db-migrate.ts
@@ -5,99 +5,14 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import { getDbClient } from "../src/db/client";
-
-const SCHEMA_SQL = [
-  `CREATE TABLE IF NOT EXISTS players (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    team_id TEXT NOT NULL,
-    season INTEGER NOT NULL,
-    report_type TEXT NOT NULL,
-    player_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    position TEXT,
-    games INTEGER NOT NULL DEFAULT 0,
-    goals INTEGER NOT NULL DEFAULT 0,
-    assists INTEGER NOT NULL DEFAULT 0,
-    points INTEGER NOT NULL DEFAULT 0,
-    plus_minus INTEGER NOT NULL DEFAULT 0,
-    penalties INTEGER NOT NULL DEFAULT 0,
-    shots INTEGER NOT NULL DEFAULT 0,
-    ppp INTEGER NOT NULL DEFAULT 0,
-    shp INTEGER NOT NULL DEFAULT 0,
-    hits INTEGER NOT NULL DEFAULT 0,
-    blocks INTEGER NOT NULL DEFAULT 0
-  )`,
-  `CREATE TABLE IF NOT EXISTS goalies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    team_id TEXT NOT NULL,
-    season INTEGER NOT NULL,
-    report_type TEXT NOT NULL,
-    goalie_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    games INTEGER NOT NULL DEFAULT 0,
-    wins INTEGER NOT NULL DEFAULT 0,
-    saves INTEGER NOT NULL DEFAULT 0,
-    shutouts INTEGER NOT NULL DEFAULT 0,
-    goals INTEGER NOT NULL DEFAULT 0,
-    assists INTEGER NOT NULL DEFAULT 0,
-    points INTEGER NOT NULL DEFAULT 0,
-    penalties INTEGER NOT NULL DEFAULT 0,
-    ppp INTEGER NOT NULL DEFAULT 0,
-    shp INTEGER NOT NULL DEFAULT 0,
-    gaa REAL,
-    save_percent REAL
-  )`,
-  `CREATE TABLE IF NOT EXISTS import_metadata (
-    key TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-  )`,
-  `CREATE INDEX IF NOT EXISTS idx_players_lookup ON players(team_id, season, report_type)`,
-  `CREATE INDEX IF NOT EXISTS idx_goalies_lookup ON goalies(team_id, season, report_type)`,
-  `CREATE INDEX IF NOT EXISTS idx_players_career_id
-    ON players(player_id, season DESC, team_id, report_type)`,
-  `CREATE INDEX IF NOT EXISTS idx_goalies_career_id
-    ON goalies(goalie_id, season DESC, team_id, report_type)`,
-  `CREATE INDEX IF NOT EXISTS idx_players_name ON players(name)`,
-  `CREATE INDEX IF NOT EXISTS idx_goalies_name ON goalies(name)`,
-  `CREATE TABLE IF NOT EXISTS playoff_results (
-    id      INTEGER PRIMARY KEY AUTOINCREMENT,
-    team_id TEXT    NOT NULL,
-    season  INTEGER NOT NULL,
-    round   INTEGER NOT NULL,
-    UNIQUE(team_id, season)
-  )`,
-  `CREATE INDEX IF NOT EXISTS idx_playoff_results_season
-    ON playoff_results(season)`,
-  `CREATE TABLE IF NOT EXISTS regular_results (
-    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    team_id             TEXT    NOT NULL,
-    season              INTEGER NOT NULL,
-    wins                INTEGER NOT NULL,
-    losses              INTEGER NOT NULL,
-    ties                INTEGER NOT NULL,
-    points              INTEGER NOT NULL,
-    div_wins            INTEGER NOT NULL,
-    div_losses          INTEGER NOT NULL,
-    div_ties            INTEGER NOT NULL,
-    is_regular_champion INTEGER NOT NULL DEFAULT 0,
-    UNIQUE(team_id, season)
-  )`,
-  `CREATE INDEX IF NOT EXISTS idx_regular_results_season ON regular_results(season)`,
-];
+import { migrateDb } from "../src/db/schema";
 
 const main = async () => {
   const db = getDbClient();
 
   console.log("🗄️  Running database migration...");
 
-  for (const sql of SCHEMA_SQL) {
-    await db.execute(sql);
-  }
-
-  await db.execute({
-    sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
-    args: ["schema_version", "4"],
-  });
+  await migrateDb(db);
 
   console.log("✅ Migration complete!");
   console.log(

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -1752,76 +1752,61 @@ describe("helpers", () => {
   });
 
   describe("resolveTeamId", () => {
-    test("defaults to DEFAULT_TEAM_ID for non-string values", async () => {
-      expect(await resolveTeamId(123 as unknown)).toBe("1");
+    test("normalizes invalid inputs to the default team", () => {
+      expect(resolveTeamId(123 as unknown)).toBe("1");
+      expect(resolveTeamId("   ")).toBe("1");
+      expect(resolveTeamId("999")).toBe("1");
     });
 
-    test("defaults to DEFAULT_TEAM_ID for empty string", async () => {
-      expect(await resolveTeamId("   ")).toBe("1");
-    });
-
-    test("defaults to DEFAULT_TEAM_ID for unknown team", async () => {
-      expect(await resolveTeamId("999")).toBe("1");
-    });
-
-    test("keeps configured team id when the team exists in constants", async () => {
-      expect(await resolveTeamId("2")).toBe("2");
-    });
-
-    test("trims a valid configured team id", async () => {
-      expect(await resolveTeamId(" 28 ")).toBe("28");
+    test("keeps configured team ids and trims valid input", () => {
+      expect(resolveTeamId("2")).toBe("2");
+      expect(resolveTeamId(" 28 ")).toBe("28");
     });
   });
 
   describe("availableSeasons", () => {
-    test("returns computed regular seasons for the default team", async () => {
-      const result = await availableSeasons();
-      expect(result[0]).toBe(2012);
-      expect(result.at(-1)).toBe(CURRENT_SEASON);
-      expect(result).toHaveLength(CURRENT_SEASON - 2012 + 1);
+    test("returns computed regular-era ranges without DB lookups", async () => {
+      const defaultRegular = await availableSeasons();
+      const teamBoth = await availableSeasons("28", "both");
+
+      expect(defaultRegular[0]).toBe(2012);
+      expect(defaultRegular.at(-1)).toBe(CURRENT_SEASON);
+      expect(defaultRegular).toHaveLength(CURRENT_SEASON - 2012 + 1);
+
+      expect(teamBoth[0]).toBe(2021);
+      expect(teamBoth.at(-1)).toBe(CURRENT_SEASON);
+      expect(teamBoth).toHaveLength(CURRENT_SEASON - 2021 + 1);
       expect(mockGetAvailableSeasonsFromDb).not.toHaveBeenCalled();
     });
 
-    test("when reportType is both, returns the team's regular era range", async () => {
-      const result = await availableSeasons("28", "both");
-      expect(result[0]).toBe(2021);
-      expect(result.at(-1)).toBe(CURRENT_SEASON);
-      expect(result).toHaveLength(CURRENT_SEASON - 2021 + 1);
-      expect(mockGetAvailableSeasonsFromDb).not.toHaveBeenCalled();
-    });
-
-    test("delegates playoff seasons to the DB", async () => {
-      mockGetAvailableSeasonsFromDb.mockResolvedValue([2023, 2024]);
+    test("delegates playoff seasons to the DB for both populated and empty results", async () => {
+      mockGetAvailableSeasonsFromDb
+        .mockResolvedValueOnce([2023, 2024])
+        .mockResolvedValueOnce([]);
 
       const result = await availableSeasons("2", "playoffs");
+      const emptyResult = await availableSeasons("1", "playoffs");
+
       expect(result).toEqual([2023, 2024]);
+      expect(emptyResult).toEqual([]);
       expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith(
         "2",
         "playoffs",
       );
-    });
-
-    test("returns empty array when playoffs have no seasons", async () => {
-      mockGetAvailableSeasonsFromDb.mockResolvedValue([]);
-
-      const result = await availableSeasons("1", "playoffs");
-      expect(result).toEqual([]);
+      expect(mockGetAvailableSeasonsFromDb).toHaveBeenCalledWith(
+        "1",
+        "playoffs",
+      );
     });
   });
 
   describe("seasonAvailable", () => {
-    test("returns true for an available regular season", async () => {
+    test("handles undefined and regular-season membership checks", async () => {
+      expect(await seasonAvailable(undefined)).toBe(true);
       expect(await seasonAvailable(2012)).toBe(true);
       expect(await seasonAvailable(CURRENT_SEASON)).toBe(true);
-    });
-
-    test("returns false for an unavailable regular season", async () => {
       expect(await seasonAvailable(2000)).toBe(false);
       expect(await seasonAvailable(2020, "28", "regular")).toBe(false);
-    });
-
-    test("returns true for undefined season", async () => {
-      expect(await seasonAvailable(undefined)).toBe(true);
     });
 
     test("uses DB-backed seasons for playoffs", async () => {
@@ -1837,67 +1822,34 @@ describe("helpers", () => {
   });
 
   describe("reportTypeAvailable", () => {
-    test("returns true for regular", () => {
+    test("accepts supported report types and rejects invalid values", () => {
       expect(reportTypeAvailable("regular")).toBe(true);
-    });
-
-    test("returns true for playoffs", () => {
       expect(reportTypeAvailable("playoffs")).toBe(true);
-    });
-
-    test("returns true for both", () => {
       expect(reportTypeAvailable("both")).toBe(true);
-    });
-
-    test("returns false for invalid report type", () => {
       expect(reportTypeAvailable("invalid" as Report)).toBe(false);
-    });
-
-    test("returns false for undefined", () => {
       expect(reportTypeAvailable(undefined)).toBe(false);
     });
   });
 
   describe("parseSeasonParam", () => {
-    test("returns number for valid numeric string", () => {
+    test("parses numeric values and rejects missing or invalid ones", () => {
       expect(parseSeasonParam("2024")).toBe(2024);
       expect(parseSeasonParam("2012")).toBe(2012);
-    });
-
-    test("returns undefined for undefined", () => {
-      expect(parseSeasonParam(undefined)).toBe(undefined);
-    });
-
-    test("returns undefined for empty string", () => {
-      expect(parseSeasonParam("")).toBe(undefined);
-    });
-
-    test("returns undefined for null", () => {
-      expect(parseSeasonParam(null)).toBe(undefined);
-    });
-
-    test("returns undefined for non-numeric string", () => {
-      expect(parseSeasonParam("abc")).toBe(undefined);
-    });
-
-    test("returns undefined for NaN", () => {
-      expect(parseSeasonParam(NaN)).toBe(undefined);
-    });
-
-    test("handles number input correctly", () => {
       expect(parseSeasonParam(2024)).toBe(2024);
+      expect(parseSeasonParam(undefined)).toBe(undefined);
+      expect(parseSeasonParam("")).toBe(undefined);
+      expect(parseSeasonParam(null)).toBe(undefined);
+      expect(parseSeasonParam("abc")).toBe(undefined);
+      expect(parseSeasonParam(NaN)).toBe(undefined);
     });
   });
 
   describe("getTeamsWithData", () => {
-    test("returns all configured teams", () => {
+    test("returns all configured teams including expansion teams", () => {
       const teams = getTeamsWithData();
+
       expect(teams).toHaveLength(TEAMS.length);
       expect(teams[0]).toMatchObject({ id: "1", name: "colorado" });
-    });
-
-    test("includes expansion teams from constants", () => {
-      const teams = getTeamsWithData();
       expect(teams).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ id: "28", name: "seattle" }),

--- a/src/__tests__/integration-db.ts
+++ b/src/__tests__/integration-db.ts
@@ -1,0 +1,219 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import type { Client } from "@libsql/client";
+import { getDbClient, resetDbClientForTests } from "../db/client";
+import { migrateDb } from "../db/schema";
+import { resetRouteCachesForTests } from "../routes";
+import { resetSnapshotCacheForTests } from "../snapshots";
+
+type PlayerSeed = {
+  teamId: string;
+  season: number;
+  reportType: "regular" | "playoffs";
+  playerId: string;
+  name: string;
+  position?: string | null;
+  games?: number;
+  goals?: number;
+  assists?: number;
+  points?: number;
+  plusMinus?: number;
+  penalties?: number;
+  shots?: number;
+  ppp?: number;
+  shp?: number;
+  hits?: number;
+  blocks?: number;
+};
+
+type GoalieSeed = {
+  teamId: string;
+  season: number;
+  reportType: "regular" | "playoffs";
+  goalieId: string;
+  name: string;
+  games?: number;
+  wins?: number;
+  saves?: number;
+  shutouts?: number;
+  goals?: number;
+  assists?: number;
+  points?: number;
+  penalties?: number;
+  ppp?: number;
+  shp?: number;
+  gaa?: number | null;
+  savePercent?: number | null;
+};
+
+type PlayoffResultSeed = {
+  teamId: string;
+  season: number;
+  round: number;
+};
+
+type RegularResultSeed = {
+  teamId: string;
+  season: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  points: number;
+  divWins: number;
+  divLosses: number;
+  divTies: number;
+  isRegularChampion?: boolean;
+};
+
+type IntegrationDbContext = {
+  db: Client;
+  snapshotDir: string;
+  insertPlayers: (rows: readonly PlayerSeed[]) => Promise<void>;
+  insertGoalies: (rows: readonly GoalieSeed[]) => Promise<void>;
+  insertPlayoffResults: (rows: readonly PlayoffResultSeed[]) => Promise<void>;
+  insertRegularResults: (rows: readonly RegularResultSeed[]) => Promise<void>;
+  setLastModified: (value: string) => Promise<void>;
+  cleanup: () => Promise<void>;
+};
+
+const restoreEnv = (key: string, value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+};
+
+export const createIntegrationDb = async (): Promise<IntegrationDbContext> => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ffhl-test-db-"));
+  const snapshotDir = path.join(tempDir, "snapshots");
+  const dbPath = path.join(tempDir, "test.db");
+  const previousDbUrl = process.env.TURSO_DATABASE_URL;
+  const previousSnapshotDir = process.env.SNAPSHOT_DIR;
+
+  await fs.mkdir(snapshotDir, { recursive: true });
+
+  process.env.TURSO_DATABASE_URL = `file:${dbPath}`;
+  process.env.SNAPSHOT_DIR = snapshotDir;
+
+  resetDbClientForTests();
+  resetRouteCachesForTests();
+  resetSnapshotCacheForTests();
+
+  const db = getDbClient();
+  await migrateDb(db);
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } finally {
+      resetDbClientForTests();
+      resetRouteCachesForTests();
+      resetSnapshotCacheForTests();
+      restoreEnv("TURSO_DATABASE_URL", previousDbUrl);
+      restoreEnv("SNAPSHOT_DIR", previousSnapshotDir);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  };
+
+  return {
+    db,
+    snapshotDir,
+    insertPlayers: async (rows) => {
+      for (const row of rows) {
+        await db.execute({
+          sql: `INSERT INTO players (
+                  team_id, season, report_type, player_id, name, position, games,
+                  goals, assists, points, plus_minus, penalties, shots, ppp, shp, hits, blocks
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            row.teamId,
+            row.season,
+            row.reportType,
+            row.playerId,
+            row.name,
+            row.position ?? null,
+            row.games ?? 0,
+            row.goals ?? 0,
+            row.assists ?? 0,
+            row.points ?? 0,
+            row.plusMinus ?? 0,
+            row.penalties ?? 0,
+            row.shots ?? 0,
+            row.ppp ?? 0,
+            row.shp ?? 0,
+            row.hits ?? 0,
+            row.blocks ?? 0,
+          ],
+        });
+      }
+    },
+    insertGoalies: async (rows) => {
+      for (const row of rows) {
+        await db.execute({
+          sql: `INSERT INTO goalies (
+                  team_id, season, report_type, goalie_id, name, games, wins, saves, shutouts,
+                  goals, assists, points, penalties, ppp, shp, gaa, save_percent
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            row.teamId,
+            row.season,
+            row.reportType,
+            row.goalieId,
+            row.name,
+            row.games ?? 0,
+            row.wins ?? 0,
+            row.saves ?? 0,
+            row.shutouts ?? 0,
+            row.goals ?? 0,
+            row.assists ?? 0,
+            row.points ?? 0,
+            row.penalties ?? 0,
+            row.ppp ?? 0,
+            row.shp ?? 0,
+            row.gaa ?? null,
+            row.savePercent ?? null,
+          ],
+        });
+      }
+    },
+    insertPlayoffResults: async (rows) => {
+      for (const row of rows) {
+        await db.execute({
+          sql: "INSERT INTO playoff_results (team_id, season, round) VALUES (?, ?, ?)",
+          args: [row.teamId, row.season, row.round],
+        });
+      }
+    },
+    insertRegularResults: async (rows) => {
+      for (const row of rows) {
+        await db.execute({
+          sql: `INSERT INTO regular_results (
+                  team_id, season, wins, losses, ties, points,
+                  div_wins, div_losses, div_ties, is_regular_champion
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            row.teamId,
+            row.season,
+            row.wins,
+            row.losses,
+            row.ties,
+            row.points,
+            row.divWins,
+            row.divLosses,
+            row.divTies,
+            row.isRegularChampion ? 1 : 0,
+          ],
+        });
+      }
+    },
+    setLastModified: async (value) => {
+      await db.execute({
+        sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
+        args: ["last_modified", value],
+      });
+    },
+    cleanup,
+  };
+};

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -530,6 +530,43 @@ describe("routes integration", () => {
     }
   });
 
+  test("returns 400 for unavailable goalie season using the real DB season lookup", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertGoalies([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          goalieId: "g-playoff",
+          name: "Playoff Goalie",
+          games: 4,
+          wins: 2,
+          saves: 100,
+          shutouts: 1,
+          gaa: 2.1,
+          savePercent: 0.925,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/goalies/season/playoffs/2023?teamId=1",
+        params: { reportType: "playoffs", season: "2023" },
+      });
+      const res = createResponse();
+
+      await getGoaliesSeason(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(res._getData()).toBe(ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+      expect(res.getHeader("cache-control")).toBe("private, no-store");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("serves goalie combined snapshots from local snapshot storage", async () => {
     const db = await createIntegrationDb();
 

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -6,6 +6,7 @@ import {
   getCareerGoalie,
   getCareerPlayers,
   getCareerGoalies,
+  getSeasons,
   getGoaliesSeason,
   getGoaliesCombined,
   getLastModified,
@@ -35,6 +36,109 @@ const writeSnapshot = async (
 };
 
 describe("routes integration", () => {
+  test("returns regular seasons for the default team from the real helper range", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/seasons",
+      });
+      const res = createResponse();
+
+      await getSeasons(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body[0]).toEqual({ season: 2012, text: "2012-2013" });
+      expect(body.at(-1)).toEqual({ season: 2025, text: "2025-2026" });
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns filtered seasons for both-report requests using the real helper range", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/seasons/both?teamId=32&startFrom=2020",
+        params: { reportType: "both" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getSeasons(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toEqual([
+        { season: 2020, text: "2020-2021" },
+        { season: 2021, text: "2021-2022" },
+        { season: 2022, text: "2022-2023" },
+        { season: 2023, text: "2023-2024" },
+        { season: 2024, text: "2024-2025" },
+        { season: 2025, text: "2025-2026" },
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns playoff seasons from the live DB and honors teamId/startFrom", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "19",
+          season: 2023,
+          reportType: "playoffs",
+          playerId: "p-playoff-2023",
+          name: "Playoff Skater",
+          position: "F",
+          games: 3,
+          goals: 1,
+          assists: 1,
+          points: 2,
+        },
+        {
+          teamId: "19",
+          season: 2024,
+          reportType: "playoffs",
+          playerId: "p-playoff-2024",
+          name: "Playoff Skater",
+          position: "F",
+          games: 4,
+          goals: 2,
+          assists: 2,
+          points: 4,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/seasons/playoffs?teamId=19&startFrom=2024",
+        params: { reportType: "playoffs" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getSeasons(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(getJsonBody(res)).toEqual([
+        { season: 2024, text: "2024-2025" },
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("returns 400 for unavailable playoff season using the real DB season lookup", async () => {
     const db = await createIntegrationDb();
 

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -1,0 +1,333 @@
+import { createRequest, createResponse } from "node-mocks-http";
+import {
+  getCareerPlayer,
+  getGoaliesCombined,
+  getLastModified,
+  getPlayersSeason,
+  getRegularLeaderboard,
+} from "../routes";
+import { ERROR_MESSAGES, HTTP_STATUS } from "../constants";
+import { createIntegrationDb } from "./integration-db";
+
+type RouteReq = Parameters<typeof getPlayersSeason>[0];
+type MockResponse = ReturnType<typeof createResponse>;
+
+const asRouteReq = (req: unknown): RouteReq => req as RouteReq;
+
+const getJsonBody = <T>(res: MockResponse): T => res._getJSONData() as T;
+
+describe("routes integration", () => {
+  test("returns 400 for unavailable playoff season using the real DB season lookup", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          playerId: "p-playoff",
+          name: "Playoff Only",
+          position: "F",
+          games: 4,
+          goals: 2,
+          assists: 2,
+          points: 4,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/players/season/playoffs/2023?teamId=1",
+        params: { reportType: "playoffs", season: "2023" },
+      });
+      const res = createResponse();
+
+      await getPlayersSeason(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.BAD_REQUEST);
+      expect(res._getData()).toBe(ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
+      expect(res.getHeader("cache-control")).toBe("private, no-store");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("merges regular and playoff goalie stats in combined both route without leaking rate fields", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertGoalies([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          goalieId: "g-combined",
+          name: "Merged Goalie",
+          games: 10,
+          wins: 6,
+          saves: 300,
+          shutouts: 2,
+          goals: 0,
+          assists: 1,
+          points: 1,
+          gaa: 2.2,
+          savePercent: 0.92,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          goalieId: "g-combined",
+          name: "Merged Goalie",
+          games: 4,
+          wins: 2,
+          saves: 120,
+          shutouts: 1,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          gaa: 1.8,
+          savePercent: 0.935,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/goalies/combined/both?teamId=1&startFrom=2024",
+        params: { reportType: "both" },
+      });
+      const res = createResponse();
+
+      await getGoaliesCombined(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toHaveLength(1);
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          id: "g-combined",
+          name: "Merged Goalie",
+          games: 14,
+          wins: 8,
+          saves: 420,
+          shutouts: 3,
+          assists: 1,
+          points: 1,
+        }),
+      );
+      expect(body[0]).not.toHaveProperty("gaa");
+      expect(body[0]).not.toHaveProperty("savePercent");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns career player aggregates from real player rows", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          playerId: "p-career",
+          name: "Career Skater",
+          position: "F",
+          games: 10,
+          goals: 4,
+          assists: 6,
+          points: 10,
+          plusMinus: 3,
+          shots: 25,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          playerId: "p-career",
+          name: "Career Skater",
+          position: "F",
+          games: 2,
+          goals: 1,
+          assists: 1,
+          points: 2,
+          shots: 6,
+        },
+        {
+          teamId: "19",
+          season: 2023,
+          reportType: "regular",
+          playerId: "p-career",
+          name: "Career Skater",
+          position: "F",
+          games: 5,
+          goals: 2,
+          assists: 3,
+          points: 5,
+          plusMinus: 1,
+          shots: 11,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/player/p-career",
+        params: { id: "p-career" },
+      });
+      const res = createResponse();
+
+      await getCareerPlayer(asRouteReq(req), res);
+
+      const body = getJsonBody<Record<string, unknown>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(body).toEqual(
+        expect.objectContaining({
+          id: "p-career",
+          name: "Career Skater",
+          position: "F",
+        }),
+      );
+
+      const summary = body.summary as Record<string, unknown>;
+      expect(summary.firstSeason).toBe(2023);
+      expect(summary.lastSeason).toBe(2024);
+      expect(summary.seasonCount).toEqual({ owned: 2, played: 2 });
+      expect(summary.teamCount).toEqual({ owned: 2, played: 2 });
+
+      const totals = body.totals as Record<string, Record<string, unknown>>;
+      expect(totals.career.games).toBe(17);
+      expect(totals.career.points).toBe(17);
+      expect(totals.regular.games).toBe(15);
+      expect(totals.playoffs.games).toBe(2);
+
+      const seasons = body.seasons as Array<Record<string, unknown>>;
+      expect(seasons).toHaveLength(3);
+      expect(seasons.map((season) => `${season.season}-${season.teamId}-${season.reportType}`)).toEqual([
+        "2024-1-regular",
+        "2024-1-playoffs",
+        "2023-19-regular",
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("builds regular leaderboard rows from the live regular_results tables", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertRegularResults([
+        {
+          teamId: "1",
+          season: 2024,
+          wins: 10,
+          losses: 5,
+          ties: 1,
+          points: 21,
+          divWins: 4,
+          divLosses: 2,
+          divTies: 0,
+          isRegularChampion: true,
+        },
+        {
+          teamId: "19",
+          season: 2024,
+          wins: 8,
+          losses: 7,
+          ties: 1,
+          points: 17,
+          divWins: 3,
+          divLosses: 3,
+          divTies: 0,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/regular",
+      });
+      const res = createResponse();
+
+      await getRegularLeaderboard(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toHaveLength(2);
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          teamId: "1",
+          teamName: "Colorado Avalanche",
+          wins: 10,
+          losses: 5,
+          ties: 1,
+          points: 21,
+          regularTrophies: 1,
+          winPercent: 0.625,
+          divWinPercent: 0.667,
+          pointsPercent: 0.656,
+          tieRank: false,
+        }),
+      );
+      expect(body[0].seasons).toEqual([
+        {
+          season: 2024,
+          regularTrophy: true,
+          wins: 10,
+          losses: 5,
+          ties: 1,
+          points: 21,
+          divWins: 4,
+          divLosses: 2,
+          divTies: 0,
+          winPercent: 0.625,
+          divWinPercent: 0.667,
+          pointsPercent: 0.656,
+        },
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves cached last-modified responses with a real ETag/304 flow", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.setLastModified("2026-03-10T12:00:00.000Z");
+
+      const firstReq = createRequest({
+        method: "GET",
+        url: "/last-modified",
+      });
+      const firstRes = createResponse();
+
+      await getLastModified(asRouteReq(firstReq), firstRes);
+
+      const firstBody = getJsonBody<Record<string, string | null>>(firstRes);
+      const etag = String(firstRes.getHeader("etag"));
+
+      expect(firstRes.statusCode).toBe(HTTP_STATUS.OK);
+      expect(firstBody).toEqual({ lastModified: "2026-03-10T12:00:00.000Z" });
+      expect(firstRes.getHeader("x-stats-data-source")).toBe("db");
+      expect(etag).toMatch(/^".+"$/);
+
+      const secondReq = createRequest({
+        method: "GET",
+        url: "/last-modified",
+        headers: { "if-none-match": etag },
+      });
+      const secondRes = createResponse();
+
+      await getLastModified(asRouteReq(secondReq), secondRes);
+
+      expect(secondRes.statusCode).toBe(304);
+      expect(secondRes._getData()).toBe("");
+    } finally {
+      await db.cleanup();
+    }
+  });
+});

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -1,9 +1,15 @@
+import fs from "fs/promises";
+import path from "path";
 import { createRequest, createResponse } from "node-mocks-http";
 import {
   getCareerPlayer,
+  getCareerPlayers,
+  getGoaliesSeason,
   getGoaliesCombined,
   getLastModified,
+  getPlayersCombined,
   getPlayersSeason,
+  getPlayoffsLeaderboard,
   getRegularLeaderboard,
 } from "../routes";
 import { ERROR_MESSAGES, HTTP_STATUS } from "../constants";
@@ -15,6 +21,16 @@ type MockResponse = ReturnType<typeof createResponse>;
 const asRouteReq = (req: unknown): RouteReq => req as RouteReq;
 
 const getJsonBody = <T>(res: MockResponse): T => res._getJSONData() as T;
+
+const writeSnapshot = async (
+  snapshotDir: string,
+  snapshotKey: string,
+  payload: unknown,
+): Promise<void> => {
+  const filePath = path.join(snapshotDir, `${snapshotKey}.json`);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(payload), "utf8");
+};
 
 describe("routes integration", () => {
   test("returns 400 for unavailable playoff season using the real DB season lookup", async () => {
@@ -124,6 +140,187 @@ describe("routes integration", () => {
     }
   });
 
+  test("returns combined player data from the live DB and honors startFrom", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "1",
+          season: 2023,
+          reportType: "regular",
+          playerId: "p-combined",
+          name: "Combined Skater",
+          position: "F",
+          games: 8,
+          goals: 3,
+          assists: 4,
+          points: 7,
+          plusMinus: 1,
+          penalties: 2,
+          shots: 14,
+          ppp: 1,
+          hits: 4,
+          blocks: 3,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          playerId: "p-combined",
+          name: "Combined Skater",
+          position: "F",
+          games: 10,
+          goals: 5,
+          assists: 6,
+          points: 11,
+          plusMinus: 3,
+          penalties: 1,
+          shots: 20,
+          ppp: 2,
+          shp: 1,
+          hits: 7,
+          blocks: 6,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/players/combined/regular?teamId=1&startFrom=2024",
+        params: { reportType: "regular" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getPlayersCombined(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toHaveLength(1);
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          id: "p-combined",
+          name: "Combined Skater",
+          games: 10,
+          goals: 5,
+          assists: 6,
+          points: 11,
+        }),
+      );
+      expect(body[0].seasons).toEqual([
+        expect.objectContaining({
+          season: 2024,
+          games: 10,
+          points: 11,
+        }),
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves player combined snapshots from local snapshot storage", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "p-snapshot",
+          name: "Snapshot Skater",
+          position: "F",
+          games: 99,
+          goals: 44,
+          assists: 55,
+          points: 99,
+          plusMinus: 11,
+          penalties: 12,
+          shots: 320,
+          ppp: 22,
+          shp: 1,
+          hits: 80,
+          blocks: 42,
+          score: 100,
+          scoreAdjustedByGames: 100,
+          seasons: [],
+        },
+      ];
+      await writeSnapshot(
+        db.snapshotDir,
+        "players/combined/regular/team-1",
+        snapshotPayload,
+      );
+
+      const req = createRequest({
+        method: "GET",
+        url: "/players/combined/regular",
+        params: { reportType: "regular" },
+      });
+      const res = createResponse();
+
+      await getPlayersCombined(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns goalie season rows from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertGoalies([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          goalieId: "g-season",
+          name: "Season Goalie",
+          games: 12,
+          wins: 8,
+          saves: 340,
+          shutouts: 2,
+          goals: 0,
+          assists: 1,
+          points: 1,
+          gaa: 2.15,
+          savePercent: 0.918,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/goalies/season/regular/2024?teamId=1",
+        params: { reportType: "regular", season: "2024" },
+      });
+      const res = createResponse();
+
+      await getGoaliesSeason(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toHaveLength(1);
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          id: "g-season",
+          name: "Season Goalie",
+          games: 12,
+          wins: 8,
+          saves: 340,
+          shutouts: 2,
+          savePercent: "0.918",
+          gaa: "2.15",
+        }),
+      );
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("returns career player aggregates from real player rows", async () => {
     const db = await createIntegrationDb();
 
@@ -210,6 +407,152 @@ describe("routes integration", () => {
         "2024-1-playoffs",
         "2023-19-regular",
       ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns career player list data from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          playerId: "p-list",
+          name: "List Skater",
+          position: "F",
+          games: 10,
+          goals: 4,
+          assists: 6,
+          points: 10,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          playerId: "p-list",
+          name: "List Skater",
+          position: "F",
+          games: 2,
+          goals: 1,
+          assists: 1,
+          points: 2,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/players",
+      });
+      const res = createResponse();
+
+      await getCareerPlayers(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toEqual([
+        {
+          id: "p-list",
+          name: "List Skater",
+          position: "F",
+          firstSeason: 2024,
+          lastSeason: 2024,
+          seasonsOwned: 1,
+          seasonsPlayedRegular: 1,
+          seasonsPlayedPlayoffs: 1,
+          teamsOwned: 1,
+          teamsPlayedRegular: 1,
+          teamsPlayedPlayoffs: 1,
+          regularGames: 10,
+          playoffGames: 2,
+        },
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves career player list snapshots from local snapshot storage", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "p-list-snapshot",
+          name: "Snapshot List Skater",
+          position: "D",
+          firstSeason: 2020,
+          lastSeason: 2024,
+          seasonsOwned: 5,
+          seasonsPlayedRegular: 4,
+          seasonsPlayedPlayoffs: 2,
+          teamsOwned: 2,
+          teamsPlayedRegular: 2,
+          teamsPlayedPlayoffs: 1,
+          regularGames: 250,
+          playoffGames: 20,
+        },
+      ];
+      await writeSnapshot(db.snapshotDir, "career/players", snapshotPayload);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/players",
+      });
+      const res = createResponse();
+
+      await getCareerPlayers(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("builds playoff leaderboard rows from the live playoff_results table", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayoffResults([
+        { teamId: "1", season: 2024, round: 5 },
+        { teamId: "19", season: 2024, round: 4 },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
+      const res = createResponse();
+
+      await getPlayoffsLeaderboard(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          teamId: "1",
+          teamName: "Colorado Avalanche",
+          championships: 1,
+          finals: 0,
+          conferenceFinals: 0,
+          secondRound: 0,
+          firstRound: 0,
+          appearances: 1,
+          tieRank: false,
+        }),
+      );
+      expect((body[0].seasons as Array<Record<string, unknown>>).at(-1)).toEqual({
+        season: 2024,
+        round: 5,
+        key: "championship",
+      });
     } finally {
       await db.cleanup();
     }

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -3,7 +3,9 @@ import path from "path";
 import { createRequest, createResponse } from "node-mocks-http";
 import {
   getCareerPlayer,
+  getCareerGoalie,
   getCareerPlayers,
+  getCareerGoalies,
   getGoaliesSeason,
   getGoaliesCombined,
   getLastModified,
@@ -64,6 +66,60 @@ describe("routes integration", () => {
       expect(res.statusCode).toBe(HTTP_STATUS.BAD_REQUEST);
       expect(res._getData()).toBe(ERROR_MESSAGES.SEASON_NOT_AVAILABLE);
       expect(res.getHeader("cache-control")).toBe("private, no-store");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns player season rows from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertPlayers([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          playerId: "p-season",
+          name: "Season Skater",
+          position: "F",
+          games: 12,
+          goals: 5,
+          assists: 7,
+          points: 12,
+          plusMinus: 4,
+          penalties: 3,
+          shots: 24,
+          ppp: 2,
+          hits: 6,
+          blocks: 4,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/players/season/regular/2024?teamId=1",
+        params: { reportType: "regular", season: "2024" },
+      });
+      const res = createResponse();
+
+      await getPlayersSeason(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toHaveLength(1);
+      expect(body[0]).toEqual(
+        expect.objectContaining({
+          id: "p-season",
+          name: "Season Skater",
+          position: "F",
+          games: 12,
+          goals: 5,
+          assists: 7,
+          points: 12,
+        }),
+      );
     } finally {
       await db.cleanup();
     }
@@ -268,6 +324,55 @@ describe("routes integration", () => {
     }
   });
 
+  test("uses player combined snapshots when startFrom matches the default window", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "p-default-window",
+          name: "Default Window Skater",
+          position: "F",
+          games: 55,
+          goals: 21,
+          assists: 34,
+          points: 55,
+          plusMinus: 9,
+          penalties: 10,
+          shots: 210,
+          ppp: 11,
+          shp: 1,
+          hits: 20,
+          blocks: 18,
+          score: 100,
+          scoreAdjustedByGames: 100,
+          seasons: [],
+        },
+      ];
+      await writeSnapshot(
+        db.snapshotDir,
+        "players/combined/regular/team-1",
+        snapshotPayload,
+      );
+
+      const req = createRequest({
+        method: "GET",
+        url: "/players/combined/regular?startFrom=2012",
+        params: { reportType: "regular" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getPlayersCombined(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("returns goalie season rows from the live DB", async () => {
     const db = await createIntegrationDb();
 
@@ -316,6 +421,99 @@ describe("routes integration", () => {
           gaa: "2.15",
         }),
       );
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves goalie combined snapshots from local snapshot storage", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "g-snapshot",
+          name: "Snapshot Goalie",
+          games: 66,
+          wins: 40,
+          saves: 1800,
+          shutouts: 6,
+          goals: 0,
+          assists: 2,
+          points: 2,
+          penalties: 3,
+          ppp: 0,
+          shp: 0,
+          score: 100,
+          scoreAdjustedByGames: 100,
+          seasons: [],
+        },
+      ];
+      await writeSnapshot(
+        db.snapshotDir,
+        "goalies/combined/regular/team-1",
+        snapshotPayload,
+      );
+
+      const req = createRequest({
+        method: "GET",
+        url: "/goalies/combined/regular",
+        params: { reportType: "regular" },
+      });
+      const res = createResponse();
+
+      await getGoaliesCombined(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("uses goalie combined snapshots when startFrom matches the team window", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "g-window",
+          name: "Window Goalie",
+          games: 44,
+          wins: 27,
+          saves: 1200,
+          shutouts: 4,
+          goals: 0,
+          assists: 1,
+          points: 1,
+          penalties: 1,
+          ppp: 0,
+          shp: 0,
+          score: 100,
+          scoreAdjustedByGames: 100,
+          seasons: [],
+        },
+      ];
+      await writeSnapshot(
+        db.snapshotDir,
+        "goalies/combined/regular/team-28",
+        snapshotPayload,
+      );
+
+      const req = createRequest({
+        method: "GET",
+        url: "/goalies/combined/regular?teamId=28&startFrom=2021",
+        params: { reportType: "regular" },
+        headers: { host: "localhost" },
+      });
+      const res = createResponse();
+
+      await getGoaliesCombined(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
     } finally {
       await db.cleanup();
     }
@@ -553,6 +751,207 @@ describe("routes integration", () => {
         round: 5,
         key: "championship",
       });
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns career goalie aggregates from real goalie rows", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertGoalies([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          goalieId: "g-career",
+          name: "Career Goalie",
+          games: 12,
+          wins: 8,
+          saves: 340,
+          shutouts: 2,
+          assists: 1,
+          points: 1,
+          gaa: 2.15,
+          savePercent: 0.918,
+        },
+        {
+          teamId: "19",
+          season: 2023,
+          reportType: "playoffs",
+          goalieId: "g-career",
+          name: "Career Goalie",
+          games: 4,
+          wins: 2,
+          saves: 110,
+          shutouts: 1,
+          gaa: 2.05,
+          savePercent: 0.925,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/goalie/g-career",
+        params: { id: "g-career" },
+      });
+      const res = createResponse();
+
+      await getCareerGoalie(asRouteReq(req), res);
+
+      const body = getJsonBody<Record<string, unknown>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(body).toEqual(
+        expect.objectContaining({
+          id: "g-career",
+          name: "Career Goalie",
+        }),
+      );
+      const totals = body.totals as Record<string, Record<string, unknown>>;
+      expect(totals.career.games).toBe(16);
+      expect(totals.career.wins).toBe(10);
+      expect(totals.regular.games).toBe(12);
+      expect(totals.playoffs.games).toBe(4);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns career goalie list data from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertGoalies([
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "regular",
+          goalieId: "g-list",
+          name: "List Goalie",
+          games: 10,
+          wins: 7,
+          saves: 280,
+          shutouts: 2,
+        },
+        {
+          teamId: "1",
+          season: 2024,
+          reportType: "playoffs",
+          goalieId: "g-list",
+          name: "List Goalie",
+          games: 3,
+          wins: 1,
+          saves: 75,
+          shutouts: 0,
+        },
+      ]);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/goalies",
+      });
+      const res = createResponse();
+
+      await getCareerGoalies(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toEqual([
+        {
+          id: "g-list",
+          name: "List Goalie",
+          firstSeason: 2024,
+          lastSeason: 2024,
+          seasonsOwned: 1,
+          seasonsPlayedRegular: 1,
+          seasonsPlayedPlayoffs: 1,
+          teamsOwned: 1,
+          teamsPlayedRegular: 1,
+          teamsPlayedPlayoffs: 1,
+          regularGames: 10,
+          playoffGames: 3,
+        },
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves career goalie list snapshots from local snapshot storage", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          id: "g-list-snapshot",
+          name: "Snapshot List Goalie",
+          firstSeason: 2021,
+          lastSeason: 2025,
+          seasonsOwned: 5,
+          seasonsPlayedRegular: 4,
+          seasonsPlayedPlayoffs: 2,
+          teamsOwned: 2,
+          teamsPlayedRegular: 2,
+          teamsPlayedPlayoffs: 1,
+          regularGames: 210,
+          playoffGames: 18,
+        },
+      ];
+      await writeSnapshot(db.snapshotDir, "career/goalies", snapshotPayload);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/career/goalies",
+      });
+      const res = createResponse();
+
+      await getCareerGoalies(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("serves playoff leaderboard snapshots from local snapshot storage", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const snapshotPayload = [
+        {
+          teamId: "2",
+          teamName: "Carolina Hurricanes",
+          appearances: 4,
+          championships: 1,
+          finals: 1,
+          conferenceFinals: 0,
+          secondRound: 1,
+          firstRound: 1,
+          seasons: [{ season: 2025, round: 5, key: "championship" }],
+          tieRank: false,
+        },
+      ];
+      await writeSnapshot(
+        db.snapshotDir,
+        "leaderboard/playoffs",
+        snapshotPayload,
+      );
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
+      const res = createResponse();
+
+      await getPlayoffsLeaderboard(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
+      expect(getJsonBody(res)).toEqual(snapshotPayload);
     } finally {
       await db.cleanup();
     }

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -610,6 +610,27 @@ describe("routes integration", () => {
     }
   });
 
+  test("returns 404 for a missing career player from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/career/player/missing",
+        params: { id: "missing" },
+      });
+      const res = createResponse();
+
+      await getCareerPlayer(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.NOT_FOUND);
+      expect(res._getData()).toBe("Player not found");
+      expect(res.getHeader("cache-control")).toBe("private, no-store");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("returns career player list data from the live DB", async () => {
     const db = await createIntegrationDb();
 
@@ -756,6 +777,41 @@ describe("routes integration", () => {
     }
   });
 
+  test("returns playoff leaderboard zero-state from the live DB when no results exist", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/playoffs",
+      });
+      const res = createResponse();
+
+      await getPlayoffsLeaderboard(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      const colorado = body.find((entry) => entry.teamId === "1");
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(colorado).toEqual(
+        expect.objectContaining({
+          teamId: "1",
+          teamName: "Colorado Avalanche",
+          appearances: 0,
+          championships: 0,
+          finals: 0,
+          conferenceFinals: 0,
+          secondRound: 0,
+          firstRound: 0,
+          tieRank: false,
+        }),
+      );
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("returns career goalie aggregates from real goalie rows", async () => {
     const db = await createIntegrationDb();
 
@@ -813,6 +869,27 @@ describe("routes integration", () => {
       expect(totals.career.wins).toBe(10);
       expect(totals.regular.games).toBe(12);
       expect(totals.playoffs.games).toBe(4);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns 404 for a missing career goalie from the live DB", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/career/goalie/missing",
+        params: { id: "missing" },
+      });
+      const res = createResponse();
+
+      await getCareerGoalie(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.NOT_FOUND);
+      expect(res._getData()).toBe("Goalie not found");
+      expect(res.getHeader("cache-control")).toBe("private, no-store");
     } finally {
       await db.cleanup();
     }
@@ -1035,6 +1112,80 @@ describe("routes integration", () => {
     }
   });
 
+  test("returns an empty regular leaderboard from the live DB when no results exist", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/regular",
+      });
+      const res = createResponse();
+
+      await getRegularLeaderboard(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(getJsonBody(res)).toEqual([]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("falls back to live regular leaderboard data when the snapshot file is malformed", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      await db.insertRegularResults([
+        {
+          teamId: "1",
+          season: 2024,
+          wins: 10,
+          losses: 5,
+          ties: 1,
+          points: 21,
+          divWins: 4,
+          divLosses: 2,
+          divTies: 0,
+          isRegularChampion: true,
+        },
+      ]);
+
+      const malformedSnapshotPath = path.join(
+        db.snapshotDir,
+        "leaderboard",
+        "regular.json",
+      );
+      await fs.mkdir(path.dirname(malformedSnapshotPath), { recursive: true });
+      await fs.writeFile(malformedSnapshotPath, "{ invalid json", "utf8");
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/regular",
+      });
+      const res = createResponse();
+
+      await getRegularLeaderboard(asRouteReq(req), res);
+
+      const body = getJsonBody<Array<Record<string, unknown>>>(res);
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(body).toEqual([
+        expect.objectContaining({
+          teamId: "1",
+          teamName: "Colorado Avalanche",
+          wins: 10,
+          losses: 5,
+          ties: 1,
+          points: 21,
+          regularTrophies: 1,
+        }),
+      ]);
+    } finally {
+      await db.cleanup();
+    }
+  });
+
   test("serves cached last-modified responses with a real ETag/304 flow", async () => {
     const db = await createIntegrationDb();
 
@@ -1068,6 +1219,26 @@ describe("routes integration", () => {
 
       expect(secondRes.statusCode).toBe(304);
       expect(secondRes._getData()).toBe("");
+    } finally {
+      await db.cleanup();
+    }
+  });
+
+  test("returns null last-modified from the live DB when metadata is missing", async () => {
+    const db = await createIntegrationDb();
+
+    try {
+      const req = createRequest({
+        method: "GET",
+        url: "/last-modified",
+      });
+      const res = createResponse();
+
+      await getLastModified(asRouteReq(req), res);
+
+      expect(res.statusCode).toBe(HTTP_STATUS.OK);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expect(getJsonBody(res)).toEqual({ lastModified: null });
     } finally {
       await db.cleanup();
     }

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -96,43 +96,6 @@ describe("routes", () => {
   });
 
   describe("getSeasons", () => {
-    test("returns 200 with available seasons", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-
-      const req = createRequest();
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(getAvailableSeasons).toHaveBeenCalledWith(
-        "1",
-        "regular",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
-    test("uses report type from path params when present", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-
-      const req = createRequest({
-        url: "/seasons/playoffs",
-        params: { reportType: "playoffs" },
-      });
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(getAvailableSeasons).toHaveBeenCalledWith(
-        "1",
-        "playoffs",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
     test("returns 500 on service error", async () => {
       const error = new Error("DB error");
       (getAvailableSeasons as jest.Mock).mockRejectedValue(error);
@@ -167,27 +130,6 @@ describe("routes", () => {
       );
     });
 
-    test("handles request without url (defaults query params)", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-
-      const res = createResponse();
-
-      await getSeasons(
-        asRouteReq({ params: {} } as unknown as ReturnType<
-          typeof createRequest
-        >),
-        res,
-      );
-
-      expect(getAvailableSeasons).toHaveBeenCalledWith(
-        "1",
-        "regular",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
     test("handles request with non-string url (defaults query params)", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
@@ -195,30 +137,6 @@ describe("routes", () => {
       const req = { url: 123, params: {} } as unknown as ReturnType<
         typeof createRequest
       >;
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(getAvailableSeasons).toHaveBeenCalledWith(
-        "1",
-        "regular",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
-    test("parses query params even when host header is not a string", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation((raw: unknown) =>
-        typeof raw === "string" && raw ? raw : "1",
-      );
-
-      const req = {
-        url: "/seasons?teamId=1",
-        headers: { host: 123 },
-        params: {},
-      } as unknown as ReturnType<typeof createRequest>;
       const res = createResponse();
 
       await getSeasons(asRouteReq(req), res);
@@ -282,60 +200,6 @@ describe("routes", () => {
       );
     });
 
-    test("treats missing teamId query param as undefined", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (resolveTeamId as jest.Mock).mockImplementation((raw: unknown) =>
-        raw ? String(raw) : "1",
-      );
-
-      const req = createRequest({
-        url: "/seasons",
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(resolveTeamId).toHaveBeenCalledWith(undefined);
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
-    test("passes startFrom to service correctly", async () => {
-      const mockSeasons = [{ season: 2020, text: "2020-2021" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2020);
-
-      const req = createRequest({
-        url: "/seasons?startFrom=2020",
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(parseSeasonParam).toHaveBeenCalledWith("2020");
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "regular", 2020);
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
-
-    test("works with startFrom query param", async () => {
-      const mockSeasons = [{ season: 2018, text: "2018-2019" }];
-      (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2018);
-
-      const req = createRequest({
-        url: "/seasons/playoffs?startFrom=2018",
-        params: { reportType: "playoffs" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(getAvailableSeasons).toHaveBeenCalledWith("1", "playoffs", 2018);
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockSeasons);
-    });
   });
 
   describe("getTeams", () => {

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -501,52 +501,6 @@ describe("routes", () => {
   });
 
   describe("getPlayersCombined", () => {
-    test("returns 200 with combined player stats", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "players/combined/regular/team-1",
-      );
-      expect(res.getHeader("x-stats-data-source")).toBe("db");
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
-        "regular",
-        "1",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
-    });
-
-    test("returns snapshot data when available", async () => {
-      const snapshotPlayers = [
-        { name: "Snapshot Player", goals: 120, seasons: [] },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotPlayers);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "players/combined/regular/team-1",
-      );
-      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
-      expect(getPlayersStatsCombined).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotPlayers);
-    });
-
     test("uses snapshot when startFrom matches the default league start season", async () => {
       const snapshotPlayers = [
         { name: "Default Window Player", goals: 88, seasons: [] },
@@ -609,31 +563,6 @@ describe("routes", () => {
       );
     });
 
-    test("passes startFrom to service correctly", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2020);
-
-      const req = createRequest({
-        url: "/players/combined/regular?startFrom=2020",
-        params: { reportType: "regular" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(parseSeasonParam).toHaveBeenCalledWith("2020");
-      expect(loadSnapshot).not.toHaveBeenCalled();
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
-        "regular",
-        "1",
-        2020,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
-    });
-
     test("works with startFrom query param", async () => {
       const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
       (reportTypeAvailable as jest.Mock).mockReturnValue(true);
@@ -659,26 +588,6 @@ describe("routes", () => {
   });
 
   describe("getGoaliesSeason", () => {
-    test("returns 200 with goalie stats", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 40 }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2024);
-      (getGoaliesStatsSeason as jest.Mock).mockResolvedValue(mockGoalies);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2024" },
-      });
-      const res = createResponse();
-
-      await getGoaliesSeason(asRouteReq(req), res);
-
-      expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
-      expect(getGoaliesStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
-    });
-
     test("returns 400 for invalid report type", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(false);
       (seasonAvailable as jest.Mock).mockResolvedValue(true);
@@ -892,71 +801,6 @@ describe("routes", () => {
   });
 
   describe("getCareerPlayers", () => {
-    test("returns 200 with player career list data", async () => {
-      const mockList = [
-        {
-          id: "p001",
-          name: "Career Skater",
-          position: "F",
-          firstSeason: 2022,
-          lastSeason: 2024,
-          seasonsOwned: 3,
-          seasonsPlayedRegular: 1,
-          seasonsPlayedPlayoffs: 1,
-          teamsOwned: 2,
-          teamsPlayedRegular: 1,
-          teamsPlayedPlayoffs: 1,
-          regularGames: 82,
-          playoffGames: 5,
-        },
-      ];
-      (getCareerPlayersData as jest.Mock).mockResolvedValue(mockList);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/players",
-      });
-      const res = createResponse();
-
-      await getCareerPlayers(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("career/players");
-      expect(getCareerPlayersData).toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockList);
-    });
-
-    test("returns snapshot data when available", async () => {
-      const snapshotList = [
-        {
-          id: "p099",
-          name: "Snapshot Skater",
-          position: "D",
-          firstSeason: 2021,
-          lastSeason: 2026,
-          seasonsOwned: 6,
-          seasonsPlayedRegular: 3,
-          seasonsPlayedPlayoffs: 2,
-          teamsOwned: 3,
-          teamsPlayedRegular: 2,
-          teamsPlayedPlayoffs: 2,
-          regularGames: 280,
-          playoffGames: 30,
-        },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotList);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/players",
-      });
-      const res = createResponse();
-
-      await getCareerPlayers(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("career/players");
-      expect(getCareerPlayersData).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotList);
-    });
   });
 
   describe("getCareerGoalie", () => {
@@ -1175,35 +1019,6 @@ describe("routes", () => {
   });
 
   describe("getPlayoffsLeaderboard", () => {
-    test("returns 200 with leaderboard data", async () => {
-      const mockData = [
-        {
-          teamId: "1",
-          teamName: "Colorado Avalanche",
-          appearances: 13,
-          championships: 3,
-          finals: 2,
-          conferenceFinals: 2,
-          secondRound: 4,
-          firstRound: 2,
-          seasons: [{ season: 2024, round: 5, key: "championship" }],
-          tieRank: false,
-        },
-      ];
-      (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue(mockData);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/leaderboard/playoffs",
-      });
-      const res = createResponse();
-
-      await getPlayoffsLeaderboard(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/playoffs");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
-    });
-
     test("returns snapshot data when available", async () => {
       const snapshotData = [
         {

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -708,74 +708,7 @@ describe("routes", () => {
     });
   });
 
-  describe("getCareerPlayer", () => {
-    test("returns 404 with string body when player is missing", async () => {
-      (getPlayerCareerData as jest.Mock).mockRejectedValue({
-        statusCode: HTTP_STATUS.NOT_FOUND,
-        body: "Player not found",
-      });
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/player/missing",
-        params: { id: "missing" },
-      });
-      const res = createResponse();
-
-      await getCareerPlayer(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.NOT_FOUND,
-        "Player not found",
-      );
-    });
-  });
-
-  describe("getCareerPlayers", () => {
-  });
-
-  describe("getCareerGoalie", () => {
-    test("returns 404 with string body when goalie is missing", async () => {
-      (getGoalieCareerData as jest.Mock).mockRejectedValue({
-        statusCode: HTTP_STATUS.NOT_FOUND,
-        body: "Goalie not found",
-      });
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/goalie/missing",
-        params: { id: "missing" },
-      });
-      const res = createResponse();
-
-      await getCareerGoalie(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.NOT_FOUND,
-        "Goalie not found",
-      );
-    });
-  });
-
-  describe("getCareerGoalies", () => {
-  });
-
   describe("getLastModified", () => {
-    test("returns null when no metadata row exists", async () => {
-      (getLastModifiedFromDb as jest.Mock).mockResolvedValue(null);
-
-      const req = createRequest({ url: "/last-modified" });
-      const res = createResponse();
-
-      await getLastModified(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, {
-        lastModified: null,
-      });
-    });
-
     test("returns 304 on first request when If-None-Match matches freshly computed etag", async () => {
       const mockTimestamp = "2026-01-28T10:00:00.000Z";
       const mockResponse = { lastModified: mockTimestamp };
@@ -813,20 +746,6 @@ describe("routes", () => {
   });
 
   describe("getPlayoffsLeaderboard", () => {
-    test("returns 200 with empty array when no data", async () => {
-      (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue([]);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/leaderboard/playoffs",
-      });
-      const res = createResponse();
-
-      await getPlayoffsLeaderboard(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, []);
-    });
-
     test("handles service error", async () => {
       (getPlayoffLeaderboardData as jest.Mock).mockRejectedValue(
         new Error("DB error"),
@@ -849,51 +768,6 @@ describe("routes", () => {
   });
 
   describe("getRegularLeaderboard", () => {
-    test("returns 200 with empty array when no data", async () => {
-      (getRegularLeaderboardData as jest.Mock).mockResolvedValue([]);
-
-      const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
-      const res = createResponse();
-
-      await getRegularLeaderboard(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, []);
-    });
-
-    test("falls back to live data when snapshot loading fails", async () => {
-      const mockData = [
-        {
-          teamId: "1",
-          teamName: "Colorado Avalanche",
-          wins: 355,
-          losses: 79,
-          ties: 46,
-          points: 756,
-          divWins: 86,
-          divLosses: 24,
-          divTies: 10,
-          winPercent: 0.74,
-          divWinPercent: 0.717,
-          pointsPercent: 0.788,
-          regularTrophies: 2,
-          seasons: [],
-          tieRank: false,
-        },
-      ];
-      (loadSnapshot as jest.Mock).mockRejectedValue(
-        new Error("snapshot unavailable"),
-      );
-      (getRegularLeaderboardData as jest.Mock).mockResolvedValue(mockData);
-
-      const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
-      const res = createResponse();
-
-      await getRegularLeaderboard(asRouteReq(req), res);
-
-      expect(getRegularLeaderboardData).toHaveBeenCalledTimes(1);
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
-    });
-
     test("handles service error", async () => {
       (getRegularLeaderboardData as jest.Mock).mockRejectedValue(
         new Error("DB error"),

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -404,28 +404,6 @@ describe("routes", () => {
       );
     });
 
-    test("works with startFrom query param", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockResolvedValue(mockPlayers);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2018);
-
-      const req = createRequest({
-        url: "/players/combined/playoffs?startFrom=2018",
-        params: { reportType: "playoffs" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(getPlayersStatsCombined).toHaveBeenCalledWith(
-        "playoffs",
-        "1",
-        2018,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
-    });
   });
 
   describe("getGoaliesSeason", () => {
@@ -444,24 +422,6 @@ describe("routes", () => {
         res,
         HTTP_STATUS.BAD_REQUEST,
         ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 400 for unavailable season", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(false);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2030" },
-      });
-      const res = createResponse();
-
-      await getGoaliesSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
       );
     });
 
@@ -523,53 +483,6 @@ describe("routes", () => {
       );
     });
 
-    test("passes startFrom to service correctly", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue(mockGoalies);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2020);
-
-      const req = createRequest({
-        url: "/goalies/combined/regular?startFrom=2020",
-        params: { reportType: "regular" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(parseSeasonParam).toHaveBeenCalledWith("2020");
-      expect(loadSnapshot).not.toHaveBeenCalled();
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
-        "regular",
-        "1",
-        2020,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
-    });
-
-    test("works with startFrom query param", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue(mockGoalies);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2018);
-
-      const req = createRequest({
-        url: "/goalies/combined/playoffs?startFrom=2018",
-        params: { reportType: "playoffs" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
-        "playoffs",
-        "1",
-        2018,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
-    });
   });
 
   describe("getLastModified", () => {

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -64,16 +64,21 @@ jest.mock("../snapshots", () => ({
 
 type RouteReq = Parameters<typeof getSeasons>[0];
 const asRouteReq = (req: unknown): RouteReq => req as RouteReq;
+type RouteHandler = typeof getSeasons;
+
+const primeRouteMocks = (): void => {
+  resetRouteCachesForTests();
+  (loadSnapshot as jest.Mock).mockResolvedValue(null);
+  (resolveTeamId as jest.Mock).mockReturnValue("1");
+  (reportTypeAvailable as jest.Mock).mockReturnValue(true);
+  (seasonAvailable as jest.Mock).mockResolvedValue(true);
+  (parseSeasonParam as jest.Mock).mockReturnValue(undefined);
+};
 
 describe("routes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    resetRouteCachesForTests();
-    (loadSnapshot as jest.Mock).mockResolvedValue(null);
-    (resolveTeamId as jest.Mock).mockReturnValue("1");
-    (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-    (seasonAvailable as jest.Mock).mockResolvedValue(true);
-    (parseSeasonParam as jest.Mock).mockReturnValue(undefined);
+    primeRouteMocks();
   });
 
   describe("getHealthcheck", () => {
@@ -96,40 +101,6 @@ describe("routes", () => {
   });
 
   describe("getSeasons", () => {
-    test("returns 500 on service error", async () => {
-      const error = new Error("DB error");
-      (getAvailableSeasons as jest.Mock).mockRejectedValue(error);
-
-      const req = createRequest();
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        error,
-      );
-    });
-
-    test("returns 400 for invalid report type path param", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(false);
-
-      const req = createRequest({
-        url: "/seasons/invalid",
-        params: { reportType: "invalid" },
-      });
-      const res = createResponse();
-
-      await getSeasons(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
     test("handles request with non-string url (defaults query params)", async () => {
       const mockSeasons = [{ season: 2012, text: "2012-2013" }];
       (getAvailableSeasons as jest.Mock).mockResolvedValue(mockSeasons);
@@ -200,6 +171,137 @@ describe("routes", () => {
       );
     });
 
+  });
+
+  describe("route guards and generic service errors", () => {
+    test("returns 400 for invalid report type across guarded routes", async () => {
+      const cases: Array<{ handler: RouteHandler; req: ReturnType<typeof createRequest> }> = [
+        {
+          handler: getSeasons,
+          req: createRequest({
+            url: "/seasons/invalid",
+            params: { reportType: "invalid" },
+          }),
+        },
+        {
+          handler: getPlayersSeason,
+          req: createRequest({ params: { reportType: "invalid" } }),
+        },
+        {
+          handler: getPlayersCombined,
+          req: createRequest({ params: { reportType: "invalid" } }),
+        },
+        {
+          handler: getGoaliesSeason,
+          req: createRequest({ params: { reportType: "invalid" } }),
+        },
+        {
+          handler: getGoaliesCombined,
+          req: createRequest({ params: { reportType: "invalid" } }),
+        },
+      ];
+
+      for (const routeCase of cases) {
+        jest.clearAllMocks();
+        primeRouteMocks();
+        (reportTypeAvailable as jest.Mock).mockReturnValue(false);
+
+        const res = createResponse();
+        await routeCase.handler(asRouteReq(routeCase.req), res as never);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send).toHaveBeenLastCalledWith(
+          res,
+          HTTP_STATUS.BAD_REQUEST,
+          ERROR_MESSAGES.INVALID_REPORT_TYPE,
+        );
+      }
+    });
+
+    test("returns 500 when underlying services reject across route handlers", async () => {
+      const cases: Array<{
+        handler: RouteHandler;
+        req: ReturnType<typeof createRequest>;
+        arrange: (error: Error) => void;
+      }> = [
+        {
+          handler: getSeasons,
+          req: createRequest(),
+          arrange: (error) => {
+            (getAvailableSeasons as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getPlayersSeason,
+          req: createRequest({
+            params: { reportType: "regular", season: "2024" },
+          }),
+          arrange: (error) => {
+            (getPlayersStatsSeason as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getPlayersCombined,
+          req: createRequest({ params: { reportType: "regular" } }),
+          arrange: (error) => {
+            (getPlayersStatsCombined as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getGoaliesSeason,
+          req: createRequest({
+            params: { reportType: "regular", season: "2024" },
+          }),
+          arrange: (error) => {
+            (getGoaliesStatsSeason as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getGoaliesCombined,
+          req: createRequest({ params: { reportType: "regular" } }),
+          arrange: (error) => {
+            (getGoaliesStatsCombined as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getPlayoffsLeaderboard,
+          req: createRequest({
+            method: "GET",
+            url: "/leaderboard/playoffs",
+          }),
+          arrange: (error) => {
+            (getPlayoffLeaderboardData as jest.Mock).mockRejectedValue(error);
+          },
+        },
+        {
+          handler: getRegularLeaderboard,
+          req: createRequest({
+            method: "GET",
+            url: "/leaderboard/regular",
+          }),
+          arrange: (error) => {
+            (getRegularLeaderboardData as jest.Mock).mockRejectedValue(error);
+          },
+        },
+      ];
+
+      for (const routeCase of cases) {
+        jest.clearAllMocks();
+        primeRouteMocks();
+        const error = new Error("Service error");
+        routeCase.arrange(error);
+
+        const res = createResponse();
+        await routeCase.handler(asRouteReq(routeCase.req), res as never);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send).toHaveBeenLastCalledWith(
+          res,
+          HTTP_STATUS.INTERNAL_SERVER_ERROR,
+          error,
+        );
+      }
+    });
   });
 
   describe("getTeams", () => {
@@ -324,167 +426,6 @@ describe("routes", () => {
     });
   });
 
-  describe("getPlayersSeason", () => {
-    test("returns 400 for invalid report type", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(false);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-
-      const req = createRequest({
-        params: { reportType: "invalid" },
-      });
-      const res = createResponse();
-
-      await getPlayersSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 500 on service error", async () => {
-      const error = new Error("Service error");
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-      (getPlayersStatsSeason as jest.Mock).mockRejectedValue(error);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2024" },
-      });
-      const res = createResponse();
-
-      await getPlayersSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        error,
-      );
-    });
-  });
-
-  describe("getPlayersCombined", () => {
-    test("returns 400 for invalid report type", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(false);
-
-      const req = createRequest({
-        params: { reportType: "invalid" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 500 on service error", async () => {
-      const error = new Error("Service error");
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getPlayersStatsCombined as jest.Mock).mockRejectedValue(error);
-      (loadSnapshot as jest.Mock).mockRejectedValue(
-        new Error("snapshot unavailable"),
-      );
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        error,
-      );
-    });
-
-  });
-
-  describe("getGoaliesSeason", () => {
-    test("returns 400 for invalid report type", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(false);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-
-      const req = createRequest({
-        params: { reportType: "invalid" },
-      });
-      const res = createResponse();
-
-      await getGoaliesSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 500 on service error", async () => {
-      const error = new Error("Service error");
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-      (getGoaliesStatsSeason as jest.Mock).mockRejectedValue(error);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2024" },
-      });
-      const res = createResponse();
-
-      await getGoaliesSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        error,
-      );
-    });
-  });
-
-  describe("getGoaliesCombined", () => {
-    test("returns 400 for invalid report type", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(false);
-
-      const req = createRequest({
-        params: { reportType: "invalid" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 500 on service error", async () => {
-      const error = new Error("Service error");
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getGoaliesStatsCombined as jest.Mock).mockRejectedValue(error);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        error,
-      );
-    });
-
-  });
-
   describe("getLastModified", () => {
     test("returns 304 on first request when If-None-Match matches freshly computed etag", async () => {
       const mockTimestamp = "2026-01-28T10:00:00.000Z";
@@ -519,47 +460,6 @@ describe("routes", () => {
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, {
         lastModified: "2026-01-28T10:00:00.000Z",
       });
-    });
-  });
-
-  describe("getPlayoffsLeaderboard", () => {
-    test("handles service error", async () => {
-      (getPlayoffLeaderboardData as jest.Mock).mockRejectedValue(
-        new Error("DB error"),
-      );
-
-      const req = createRequest({
-        method: "GET",
-        url: "/leaderboard/playoffs",
-      });
-      const res = createResponse();
-
-      await getPlayoffsLeaderboard(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        expect.any(Error),
-      );
-    });
-  });
-
-  describe("getRegularLeaderboard", () => {
-    test("handles service error", async () => {
-      (getRegularLeaderboardData as jest.Mock).mockRejectedValue(
-        new Error("DB error"),
-      );
-
-      const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
-      const res = createResponse();
-
-      await getRegularLeaderboard(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        expect.any(Error),
-      );
     });
   });
 

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -501,29 +501,6 @@ describe("routes", () => {
   });
 
   describe("getPlayersCombined", () => {
-    test("uses snapshot when startFrom matches the default league start season", async () => {
-      const snapshotPlayers = [
-        { name: "Default Window Player", goals: 88, seasons: [] },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotPlayers);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2012);
-
-      const req = createRequest({
-        url: "/players/combined/regular?startFrom=2012",
-        params: { reportType: "regular" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getPlayersCombined(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "players/combined/regular/team-1",
-      );
-      expect(getPlayersStatsCombined).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotPlayers);
-    });
-
     test("returns 400 for invalid report type", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(false);
 
@@ -646,51 +623,6 @@ describe("routes", () => {
   });
 
   describe("getGoaliesCombined", () => {
-    test("returns snapshot data when available", async () => {
-      const snapshotGoalies = [
-        { name: "Snapshot Goalie", wins: 44, seasons: [] },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotGoalies);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "goalies/combined/regular/team-1",
-      );
-      expect(res.getHeader("x-stats-data-source")).toBe("snapshot");
-      expect(getGoaliesStatsCombined).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotGoalies);
-    });
-
-    test("uses snapshot when startFrom matches the team's first season", async () => {
-      const snapshotGoalies = [
-        { name: "Seattle Window Goalie", wins: 33, seasons: [] },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotGoalies);
-      (resolveTeamId as jest.Mock).mockReturnValue("28");
-      (parseSeasonParam as jest.Mock).mockReturnValue(2021);
-
-      const req = createRequest({
-        url: "/goalies/combined/regular?teamId=28&startFrom=2021",
-        params: { reportType: "regular" },
-        headers: { host: "localhost" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "goalies/combined/regular/team-28",
-      );
-      expect(getGoaliesStatsCombined).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotGoalies);
-    });
-
     test("returns 400 for invalid report type", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(false);
 
@@ -804,81 +736,6 @@ describe("routes", () => {
   });
 
   describe("getCareerGoalie", () => {
-    test("returns 200 with goalie career data", async () => {
-      const mockCareer = {
-        id: "g001",
-        name: "Career Goalie",
-        summary: {
-          firstSeason: 2022,
-          lastSeason: 2024,
-          seasonCount: { owned: 3, played: 2 },
-          teamCount: { owned: 2, played: 1 },
-          teams: [],
-        },
-        totals: {
-          career: {
-            seasonCount: { owned: 3, played: 2 },
-            teamCount: { owned: 2, played: 1 },
-            teams: [],
-            games: 58,
-            wins: 35,
-            saves: 1610,
-            shutouts: 5,
-            goals: 0,
-            assists: 4,
-            points: 4,
-            penalties: 2,
-            ppp: 0,
-            shp: 0,
-          },
-          regular: {
-            seasonCount: { owned: 1, played: 1 },
-            teamCount: { owned: 1, played: 1 },
-            teams: [],
-            games: 50,
-            wins: 30,
-            saves: 1400,
-            shutouts: 4,
-            goals: 0,
-            assists: 3,
-            points: 3,
-            penalties: 2,
-            ppp: 0,
-            shp: 0,
-          },
-          playoffs: {
-            seasonCount: { owned: 2, played: 1 },
-            teamCount: { owned: 2, played: 1 },
-            teams: [],
-            games: 8,
-            wins: 5,
-            saves: 210,
-            shutouts: 1,
-            goals: 0,
-            assists: 1,
-            points: 1,
-            penalties: 0,
-            ppp: 0,
-            shp: 0,
-          },
-        },
-        seasons: [],
-      };
-      (getGoalieCareerData as jest.Mock).mockResolvedValue(mockCareer);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/goalie/g001",
-        params: { id: "g001" },
-      });
-      const res = createResponse();
-
-      await getCareerGoalie(asRouteReq(req), res);
-
-      expect(getGoalieCareerData).toHaveBeenCalledWith("g001");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockCareer);
-    });
-
     test("returns 404 with string body when goalie is missing", async () => {
       (getGoalieCareerData as jest.Mock).mockRejectedValue({
         statusCode: HTTP_STATUS.NOT_FOUND,
@@ -903,69 +760,6 @@ describe("routes", () => {
   });
 
   describe("getCareerGoalies", () => {
-    test("returns 200 with goalie career list data", async () => {
-      const mockList = [
-        {
-          id: "g001",
-          name: "Career Goalie",
-          firstSeason: 2022,
-          lastSeason: 2024,
-          seasonsOwned: 3,
-          seasonsPlayedRegular: 1,
-          seasonsPlayedPlayoffs: 1,
-          teamsOwned: 2,
-          teamsPlayedRegular: 1,
-          teamsPlayedPlayoffs: 1,
-          regularGames: 50,
-          playoffGames: 8,
-        },
-      ];
-      (getCareerGoaliesData as jest.Mock).mockResolvedValue(mockList);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/goalies",
-      });
-      const res = createResponse();
-
-      await getCareerGoalies(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("career/goalies");
-      expect(getCareerGoaliesData).toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockList);
-    });
-
-    test("returns snapshot data when available", async () => {
-      const snapshotList = [
-        {
-          id: "g099",
-          name: "Snapshot Goalie",
-          firstSeason: 2020,
-          lastSeason: 2026,
-          seasonsOwned: 6,
-          seasonsPlayedRegular: 4,
-          seasonsPlayedPlayoffs: 2,
-          teamsOwned: 4,
-          teamsPlayedRegular: 3,
-          teamsPlayedPlayoffs: 2,
-          regularGames: 240,
-          playoffGames: 28,
-        },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotList);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/goalies",
-      });
-      const res = createResponse();
-
-      await getCareerGoalies(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("career/goalies");
-      expect(getCareerGoaliesData).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotList);
-    });
   });
 
   describe("getLastModified", () => {
@@ -1019,36 +813,6 @@ describe("routes", () => {
   });
 
   describe("getPlayoffsLeaderboard", () => {
-    test("returns snapshot data when available", async () => {
-      const snapshotData = [
-        {
-          teamId: "2",
-          teamName: "Snapshot Team",
-          appearances: 8,
-          championships: 1,
-          finals: 2,
-          conferenceFinals: 1,
-          secondRound: 2,
-          firstRound: 2,
-          seasons: [{ season: 2025, round: 4, key: "final" }],
-          tieRank: false,
-        },
-      ];
-      (loadSnapshot as jest.Mock).mockResolvedValue(snapshotData);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/leaderboard/playoffs",
-      });
-      const res = createResponse();
-
-      await getPlayoffsLeaderboard(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/playoffs");
-      expect(getPlayoffLeaderboardData).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, snapshotData);
-    });
-
     test("returns 200 with empty array when no data", async () => {
       (getPlayoffLeaderboardData as jest.Mock).mockResolvedValue([]);
 

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -461,29 +461,6 @@ describe("routes", () => {
   });
 
   describe("getPlayersSeason", () => {
-    test("returns 200 with player stats", async () => {
-      const mockPlayers = [{ name: "Test Player", goals: 50 }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(true);
-      (parseSeasonParam as jest.Mock).mockReturnValue(2024);
-      (getPlayersStatsSeason as jest.Mock).mockResolvedValue(mockPlayers);
-
-      const req = createRequest({
-        params: {
-          reportType: "regular",
-          season: "2024",
-        },
-      });
-      const res = createResponse();
-
-      await getPlayersSeason(asRouteReq(req), res);
-
-      expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(seasonAvailable).toHaveBeenCalledWith(2024, "1", "regular");
-      expect(getPlayersStatsSeason).toHaveBeenCalledWith("regular", 2024, "1");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockPlayers);
-    });
-
     test("returns 400 for invalid report type", async () => {
       (reportTypeAvailable as jest.Mock).mockReturnValue(false);
       (seasonAvailable as jest.Mock).mockResolvedValue(true);
@@ -499,24 +476,6 @@ describe("routes", () => {
         res,
         HTTP_STATUS.BAD_REQUEST,
         ERROR_MESSAGES.INVALID_REPORT_TYPE,
-      );
-    });
-
-    test("returns 400 for unavailable season", async () => {
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (seasonAvailable as jest.Mock).mockResolvedValue(false);
-
-      const req = createRequest({
-        params: { reportType: "regular", season: "2030" },
-      });
-      const res = createResponse();
-
-      await getPlayersSeason(asRouteReq(req), res);
-
-      expect(send).toHaveBeenCalledWith(
-        res,
-        HTTP_STATUS.BAD_REQUEST,
-        ERROR_MESSAGES.SEASON_NOT_AVAILABLE,
       );
     });
 
@@ -778,31 +737,6 @@ describe("routes", () => {
   });
 
   describe("getGoaliesCombined", () => {
-    test("returns 200 with combined goalie stats", async () => {
-      const mockGoalies = [{ name: "Test Goalie", wins: 100, seasons: [] }];
-      (reportTypeAvailable as jest.Mock).mockReturnValue(true);
-      (getGoaliesStatsCombined as jest.Mock).mockResolvedValue(mockGoalies);
-
-      const req = createRequest({
-        params: { reportType: "regular" },
-      });
-      const res = createResponse();
-
-      await getGoaliesCombined(asRouteReq(req), res);
-
-      expect(reportTypeAvailable).toHaveBeenCalledWith("regular");
-      expect(loadSnapshot).toHaveBeenCalledWith(
-        "goalies/combined/regular/team-1",
-      );
-      expect(res.getHeader("x-stats-data-source")).toBe("db");
-      expect(getGoaliesStatsCombined).toHaveBeenCalledWith(
-        "regular",
-        "1",
-        undefined,
-      );
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockGoalies);
-    });
-
     test("returns snapshot data when available", async () => {
       const snapshotGoalies = [
         { name: "Snapshot Goalie", wins: 44, seasons: [] },
@@ -934,85 +868,6 @@ describe("routes", () => {
   });
 
   describe("getCareerPlayer", () => {
-    test("returns 200 with player career data", async () => {
-      const mockCareer = {
-        id: "p001",
-        name: "Career Skater",
-        position: "F",
-        summary: {
-          firstSeason: 2022,
-          lastSeason: 2024,
-          seasonCount: { owned: 3, played: 2 },
-          teamCount: { owned: 2, played: 1 },
-          teams: [],
-        },
-        totals: {
-          career: {
-            seasonCount: { owned: 3, played: 2 },
-            teamCount: { owned: 2, played: 1 },
-            teams: [],
-            games: 87,
-            goals: 32,
-            assists: 54,
-            points: 86,
-            plusMinus: 15,
-            penalties: 20,
-            shots: 255,
-            ppp: 21,
-            shp: 1,
-            hits: 45,
-            blocks: 34,
-          },
-          regular: {
-            seasonCount: { owned: 2, played: 1 },
-            teamCount: { owned: 2, played: 1 },
-            teams: [],
-            games: 82,
-            goals: 30,
-            assists: 50,
-            points: 80,
-            plusMinus: 12,
-            penalties: 18,
-            shots: 240,
-            ppp: 20,
-            shp: 1,
-            hits: 40,
-            blocks: 30,
-          },
-          playoffs: {
-            seasonCount: { owned: 2, played: 1 },
-            teamCount: { owned: 1, played: 1 },
-            teams: [],
-            games: 5,
-            goals: 2,
-            assists: 4,
-            points: 6,
-            plusMinus: 3,
-            penalties: 2,
-            shots: 15,
-            ppp: 1,
-            shp: 0,
-            hits: 5,
-            blocks: 4,
-          },
-        },
-        seasons: [],
-      };
-      (getPlayerCareerData as jest.Mock).mockResolvedValue(mockCareer);
-
-      const req = createRequest({
-        method: "GET",
-        url: "/career/player/p001",
-        params: { id: "p001" },
-      });
-      const res = createResponse();
-
-      await getCareerPlayer(asRouteReq(req), res);
-
-      expect(getPlayerCareerData).toHaveBeenCalledWith("p001");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockCareer);
-    });
-
     test("returns 404 with string body when player is missing", async () => {
       (getPlayerCareerData as jest.Mock).mockRejectedValue({
         statusCode: HTTP_STATUS.NOT_FOUND,
@@ -1270,21 +1125,6 @@ describe("routes", () => {
   });
 
   describe("getLastModified", () => {
-    test("returns 200 with timestamp from DB", async () => {
-      const mockTimestamp = "2026-01-30T15:30:00.000Z";
-      (getLastModifiedFromDb as jest.Mock).mockResolvedValue(mockTimestamp);
-
-      const req = createRequest({ url: "/last-modified" });
-      const res = createResponse();
-
-      await getLastModified(asRouteReq(req), res);
-
-      expect(getLastModifiedFromDb).toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, {
-        lastModified: "2026-01-30T15:30:00.000Z",
-      });
-    });
-
     test("returns null when no metadata row exists", async () => {
       (getLastModifiedFromDb as jest.Mock).mockResolvedValue(null);
 
@@ -1296,53 +1136,6 @@ describe("routes", () => {
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, {
         lastModified: null,
       });
-    });
-
-    test("memoizes successful responses and avoids re-querying DB", async () => {
-      const mockTimestamp = "2026-01-28T10:00:00.000Z";
-      (getLastModifiedFromDb as jest.Mock).mockResolvedValue(mockTimestamp);
-
-      const req1 = createRequest({ url: "/last-modified" });
-      const res1 = createResponse();
-      await getLastModified(asRouteReq(req1), res1);
-
-      jest.clearAllMocks();
-      (send as jest.Mock).mockClear();
-
-      const req2 = createRequest({ url: "/last-modified" });
-      const res2 = createResponse();
-      await getLastModified(asRouteReq(req2), res2);
-
-      expect(getLastModifiedFromDb).not.toHaveBeenCalled();
-      expect(send).toHaveBeenCalledWith(res2, HTTP_STATUS.OK, {
-        lastModified: "2026-01-28T10:00:00.000Z",
-      });
-    });
-
-    test("returns 304 for matching If-None-Match", async () => {
-      const mockTimestamp = "2026-01-28T10:00:00.000Z";
-      const mockResponse = { lastModified: mockTimestamp };
-      (getLastModifiedFromDb as jest.Mock).mockResolvedValue(mockTimestamp);
-
-      const req1 = createRequest({ url: "/last-modified", method: "GET" });
-      const res1 = createResponse();
-      await getLastModified(asRouteReq(req1), res1);
-
-      (send as jest.Mock).mockClear();
-      const etag = makeEtagForJson(mockResponse);
-      const req2 = {
-        method: "GET",
-        url: "/last-modified",
-        headers: { host: "localhost", "if-none-match": etag },
-      } as unknown as ReturnType<typeof createRequest>;
-      const res2 = createResponse();
-      const endSpy = jest.spyOn(res2, "end");
-
-      await getLastModified(asRouteReq(req2), res2);
-
-      expect(send).toHaveBeenCalledTimes(0);
-      expect(res2.statusCode).toBe(304);
-      expect(endSpy).toHaveBeenCalled();
     });
 
     test("returns 304 on first request when If-None-Match matches freshly computed etag", async () => {
@@ -1477,52 +1270,6 @@ describe("routes", () => {
   });
 
   describe("getRegularLeaderboard", () => {
-    test("returns 200 with leaderboard data", async () => {
-      const mockData = [
-        {
-          teamId: "1",
-          teamName: "Colorado Avalanche",
-          wins: 355,
-          losses: 79,
-          ties: 46,
-          points: 756,
-          divWins: 86,
-          divLosses: 24,
-          divTies: 10,
-          winPercent: 0.74,
-          divWinPercent: 0.717,
-          pointsPercent: 0.788,
-          regularTrophies: 2,
-          seasons: [
-            {
-              season: 2024,
-              regularTrophy: true,
-              wins: 35,
-              losses: 7,
-              ties: 6,
-              points: 76,
-              divWins: 8,
-              divLosses: 2,
-              divTies: 2,
-              winPercent: 0.729,
-              divWinPercent: 0.667,
-              pointsPercent: 0.792,
-            },
-          ],
-          tieRank: false,
-        },
-      ];
-      (getRegularLeaderboardData as jest.Mock).mockResolvedValue(mockData);
-
-      const req = createRequest({ method: "GET", url: "/leaderboard/regular" });
-      const res = createResponse();
-
-      await getRegularLeaderboard(asRouteReq(req), res);
-
-      expect(loadSnapshot).toHaveBeenCalledWith("leaderboard/regular");
-      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, mockData);
-    });
-
     test("returns 200 with empty array when no data", async () => {
       (getRegularLeaderboardData as jest.Mock).mockResolvedValue([]);
 

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -48,7 +48,7 @@ describe("services", () => {
   });
 
   describe("getAvailableSeasons", () => {
-    test("calls and returns mapAvailableSeasons result", async () => {
+    test("uses default team and report when optional params are omitted", async () => {
       const mockSeasons = [
         { season: 2012, text: "2012-2013" },
         { season: 2013, text: "2013-2014" },
@@ -72,21 +72,6 @@ describe("services", () => {
 
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(mapAvailableSeasons).toHaveBeenCalledWith([2020]);
-      expect(result).toEqual(mockSeasons);
-    });
-
-    test("returns all seasons when startFrom is undefined", async () => {
-      const mockSeasons = [
-        { season: 2012, text: "2012-2013" },
-        { season: 2013, text: "2013-2014" },
-      ];
-      (availableSeasons as jest.Mock).mockReturnValue([2012, 2013]);
-      (mapAvailableSeasons as jest.Mock).mockReturnValue(mockSeasons);
-
-      const result = await getAvailableSeasons("1", "regular", undefined);
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(mapAvailableSeasons).toHaveBeenCalledWith([2012, 2013]);
       expect(result).toEqual(mockSeasons);
     });
 
@@ -206,24 +191,6 @@ describe("services", () => {
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
     });
 
-    test("fetches player stats for all available seasons", async () => {
-      const result = await getPlayersStatsCombined("regular");
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(getPlayersFromDb).toHaveBeenCalledTimes(3);
-      expect(mapCombinedPlayerDataFromPlayersWithSeason).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayer], "players");
-      expect(result).toEqual([mockPlayer]);
-    });
-
-    test("queries DB for each season", async () => {
-      await getPlayersStatsCombined("regular");
-
-      expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2012, "regular");
-      expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2013, "regular");
-      expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2014, "regular");
-    });
-
     test("returns empty array when no seasons are available", async () => {
       (availableSeasons as jest.Mock).mockReturnValue([]);
       (mapCombinedPlayerDataFromPlayersWithSeason as jest.Mock).mockReturnValue([]);
@@ -244,14 +211,6 @@ describe("services", () => {
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(getPlayersFromDb).toHaveBeenCalledTimes(1);
       expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2020, "regular");
-      expect(result).toEqual([mockPlayer]);
-    });
-
-    test("returns all seasons when startFrom is undefined", async () => {
-      const result = await getPlayersStatsCombined("regular", "1", undefined);
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(getPlayersFromDb).toHaveBeenCalledTimes(3);
       expect(result).toEqual([mockPlayer]);
     });
 
@@ -300,6 +259,7 @@ describe("services", () => {
       expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2024, "regular");
       expect(result).toEqual([mockPlayer]);
     });
+
   });
 
   describe("getGoaliesStatsCombined", () => {
@@ -311,7 +271,7 @@ describe("services", () => {
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
     });
 
-    test("uses the default team and all seasons when startFrom is omitted", async () => {
+    test("uses the default team and full season list when startFrom is omitted", async () => {
       const result = await getGoaliesStatsCombined("regular");
 
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -62,41 +62,6 @@ describe("services", () => {
       expect(mapAvailableSeasons).toHaveBeenCalledWith([2012, 2013]);
       expect(result).toEqual(mockSeasons);
     });
-
-    test("filters seasons when startFrom is provided", async () => {
-      const mockSeasons = [{ season: 2020, text: "2020-2021" }];
-      (availableSeasons as jest.Mock).mockReturnValue([2012, 2013, 2020]);
-      (mapAvailableSeasons as jest.Mock).mockReturnValue(mockSeasons);
-
-      const result = await getAvailableSeasons("1", "regular", 2020);
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(mapAvailableSeasons).toHaveBeenCalledWith([2020]);
-      expect(result).toEqual(mockSeasons);
-    });
-
-    test("returns empty array when startFrom is after all available seasons", async () => {
-      const mockSeasons: Array<{ season: number; text: string }> = [];
-      (availableSeasons as jest.Mock).mockReturnValue([2012, 2013]);
-      (mapAvailableSeasons as jest.Mock).mockReturnValue(mockSeasons);
-
-      const result = await getAvailableSeasons("1", "regular", 2025);
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(mapAvailableSeasons).toHaveBeenCalledWith([]);
-      expect(result).toEqual(mockSeasons);
-    });
-
-    test("uses regular report type when reportType is both", async () => {
-      const mockSeasons = [{ season: 2012, text: "2012-2013" }];
-      (availableSeasons as jest.Mock).mockReturnValue([2012]);
-      (mapAvailableSeasons as jest.Mock).mockReturnValue(mockSeasons);
-
-      const result = await getAvailableSeasons("1", "both");
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(result).toEqual(mockSeasons);
-    });
   });
 
   describe("getPlayersStatsSeason", () => {

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -123,15 +123,6 @@ describe("services", () => {
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
     });
 
-    test("fetches player stats from DB and sorts", async () => {
-      const result = await getPlayersStatsSeason("regular", 2024);
-
-      expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2024, "regular");
-      expect(applyPlayerScores).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockPlayerWithSeason], "players");
-      expect(result).toEqual([mockPlayerWithSeason]);
-    });
-
     test("uses max season when season is undefined", async () => {
       await getPlayersStatsSeason("regular", undefined);
 
@@ -147,12 +138,6 @@ describe("services", () => {
 
       expect(result).toEqual([]);
       expect(getPlayersFromDb).not.toHaveBeenCalled();
-    });
-
-    test("queries correct report type", async () => {
-      await getPlayersStatsSeason("playoffs", 2023);
-
-      expect(getPlayersFromDb).toHaveBeenCalledWith("1", 2023, "playoffs");
     });
 
     test("when reportType is both, queries regular+playoffs and merges before scoring", async () => {
@@ -180,15 +165,6 @@ describe("services", () => {
       (getGoaliesFromDb as jest.Mock).mockResolvedValue([mockGoalieWithSeason]);
       (applyGoalieScores as jest.Mock).mockImplementation((data) => data);
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
-    });
-
-    test("fetches goalie stats from DB and sorts", async () => {
-      const result = await getGoaliesStatsSeason("regular", 2024);
-
-      expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2024, "regular");
-      expect(applyGoalieScores).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalieWithSeason], "goalies");
-      expect(result).toEqual([mockGoalieWithSeason]);
     });
 
     test("uses max season when season is undefined", async () => {
@@ -335,22 +311,12 @@ describe("services", () => {
       (sortItemsByStatField as jest.Mock).mockImplementation((data) => data);
     });
 
-    test("fetches goalie stats for all available seasons", async () => {
+    test("uses the default team and all seasons when startFrom is omitted", async () => {
       const result = await getGoaliesStatsCombined("regular");
 
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(getGoaliesFromDb).toHaveBeenCalledTimes(3);
-      expect(mapCombinedGoalieDataFromGoaliesWithSeason).toHaveBeenCalled();
-      expect(sortItemsByStatField).toHaveBeenCalledWith([mockGoalie], "goalies");
       expect(result).toEqual([mockGoalie]);
-    });
-
-    test("queries DB for each season", async () => {
-      await getGoaliesStatsCombined("regular");
-
-      expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2012, "regular");
-      expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2013, "regular");
-      expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2014, "regular");
     });
 
     test("filters seasons when startFrom is provided", async () => {
@@ -361,14 +327,6 @@ describe("services", () => {
       expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
       expect(getGoaliesFromDb).toHaveBeenCalledTimes(1);
       expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2020, "regular");
-      expect(result).toEqual([mockGoalie]);
-    });
-
-    test("returns all seasons when startFrom is undefined", async () => {
-      const result = await getGoaliesStatsCombined("regular", "1", undefined);
-
-      expect(availableSeasons).toHaveBeenCalledWith("1", "regular");
-      expect(getGoaliesFromDb).toHaveBeenCalledTimes(3);
       expect(result).toEqual([mockGoalie]);
     });
 
@@ -424,6 +382,7 @@ describe("services", () => {
       expect(getGoaliesFromDb).toHaveBeenCalledWith("1", 2024, "regular");
       expect(result).toEqual([mockGoalie]);
     });
+
   });
 
   describe("getPlayerCareerData", () => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,95 @@
+import type { Client } from "@libsql/client";
+
+const DB_SCHEMA_VERSION = "4";
+
+const SCHEMA_SQL = [
+  `CREATE TABLE IF NOT EXISTS players (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id TEXT NOT NULL,
+    season INTEGER NOT NULL,
+    report_type TEXT NOT NULL,
+    player_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    position TEXT,
+    games INTEGER NOT NULL DEFAULT 0,
+    goals INTEGER NOT NULL DEFAULT 0,
+    assists INTEGER NOT NULL DEFAULT 0,
+    points INTEGER NOT NULL DEFAULT 0,
+    plus_minus INTEGER NOT NULL DEFAULT 0,
+    penalties INTEGER NOT NULL DEFAULT 0,
+    shots INTEGER NOT NULL DEFAULT 0,
+    ppp INTEGER NOT NULL DEFAULT 0,
+    shp INTEGER NOT NULL DEFAULT 0,
+    hits INTEGER NOT NULL DEFAULT 0,
+    blocks INTEGER NOT NULL DEFAULT 0
+  )`,
+  `CREATE TABLE IF NOT EXISTS goalies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id TEXT NOT NULL,
+    season INTEGER NOT NULL,
+    report_type TEXT NOT NULL,
+    goalie_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    games INTEGER NOT NULL DEFAULT 0,
+    wins INTEGER NOT NULL DEFAULT 0,
+    saves INTEGER NOT NULL DEFAULT 0,
+    shutouts INTEGER NOT NULL DEFAULT 0,
+    goals INTEGER NOT NULL DEFAULT 0,
+    assists INTEGER NOT NULL DEFAULT 0,
+    points INTEGER NOT NULL DEFAULT 0,
+    penalties INTEGER NOT NULL DEFAULT 0,
+    ppp INTEGER NOT NULL DEFAULT 0,
+    shp INTEGER NOT NULL DEFAULT 0,
+    gaa REAL,
+    save_percent REAL
+  )`,
+  `CREATE TABLE IF NOT EXISTS import_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_players_lookup ON players(team_id, season, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_goalies_lookup ON goalies(team_id, season, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_players_career_id
+    ON players(player_id, season DESC, team_id, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_goalies_career_id
+    ON goalies(goalie_id, season DESC, team_id, report_type)`,
+  `CREATE INDEX IF NOT EXISTS idx_players_name ON players(name)`,
+  `CREATE INDEX IF NOT EXISTS idx_goalies_name ON goalies(name)`,
+  `CREATE TABLE IF NOT EXISTS playoff_results (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id TEXT    NOT NULL,
+    season  INTEGER NOT NULL,
+    round   INTEGER NOT NULL,
+    UNIQUE(team_id, season)
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_playoff_results_season
+    ON playoff_results(season)`,
+  `CREATE TABLE IF NOT EXISTS regular_results (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id             TEXT    NOT NULL,
+    season              INTEGER NOT NULL,
+    wins                INTEGER NOT NULL,
+    losses              INTEGER NOT NULL,
+    ties                INTEGER NOT NULL,
+    points              INTEGER NOT NULL,
+    div_wins            INTEGER NOT NULL,
+    div_losses          INTEGER NOT NULL,
+    div_ties            INTEGER NOT NULL,
+    is_regular_champion INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(team_id, season)
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_regular_results_season ON regular_results(season)`,
+] as const;
+
+type DbExecutor = Pick<Client, "execute">;
+
+export const migrateDb = async (db: DbExecutor): Promise<void> => {
+  for (const sql of SCHEMA_SQL) {
+    await db.execute(sql);
+  }
+
+  await db.execute({
+    sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
+    args: ["schema_version", DB_SCHEMA_VERSION],
+  });
+};


### PR DESCRIPTION

## Summary:
- added a DB-backed integration test foundation with a shared schema source
- moved high-signal route behavior to real temp-SQLite integration tests instead of mocked route/service/query chains
- pruned overlapping mocked happy-path and wiring tests from route and service suites
- consolidated duplicated route guard/error tests into shared assertions
- simplified low-signal helper utility tests while keeping scoring-heavy helper coverage intact
- updated testing docs to prefer DB-backed integration coverage for cross-layer behavior and to remove overlapping mocked happy-path tests once integration coverage exists

### Key implementation changes:
- added shared DB schema module in src/db/schema.ts and reused it from scripts/db-migrate.ts
- added temp DB + env isolation harness in src/__tests__/integration-db.ts
- added broad route integration coverage in src/__tests__/routes.integration.test.ts for:
  - seasons
  - player/goalie season and combined routes
  - career player/goalie detail and list routes
  - playoff and regular leaderboards
  - snapshot-backed responses
  - malformed snapshot fallback
  - last-modified ETag/304 flow
- added npm run test:integration and excluded test-only helpers from coverage collection
- updated README.md, docs/DEVELOPMENT.md, and docs/TESTING.md to document the integration-first testing direction

### Testing impact:
- kept global coverage at 100%
- reduced the suite from the earlier mock-heavy shape to 292 tests
- route unit tests now focus mainly on parsing, cache behavior, undefined-request handling, and schema conformance
- real endpoint behavior is now primarily owned by the DB-backed integration suite

### Verification:
- npm run verify
