### PR TITLE
Fix: Stabilize games-adjusted pace scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,17 +656,20 @@ Scoring is calculated in three steps:
    - All other positive `score` values are scaled proportionally relative to that best score, preserving ordering (for example, if one player originally scored 80 and the best scored 90, they end up at roughly 88.89 after normalization).
 
 4. **Games‑adjusted score (`scoreAdjustedByGames`)**
-   - `scoreAdjustedByGames` uses the same scoring fields and weights as the main `score`, but works on per‑game values instead of totals (for example, `goalsPerGame = goals / games`).
-   - Players and goalies with fewer than `MIN_GAMES_FOR_ADJUSTED_SCORE` games (configured in `src/constants.ts`, default 1) always get `scoreAdjustedByGames = 0` to avoid one‑game outliers appearing at the top.
-   - For eligible players, per‑game values for each stat are normalized in the same way as totals (including per‑game plusMinus), then averaged into a 0–100 score.
-   - For eligible goalies, only per‑game `wins`, `saves`, and `shutouts` are used; advanced stats (`gaa`, `savePercent`) do not contribute to `scoreAdjustedByGames`.
-   - Finally, among all eligible players or goalies in the result set, the best `scoreAdjustedByGames` is normalized to exactly 100, and all other positive `scoreAdjustedByGames` values are scaled proportionally relative to that best per‑game score. Items below the minimum games threshold always remain at 0.
+   - `scoreAdjustedByGames` is a pace metric. It uses per-game values instead of totals.
+   - Players and goalies with fewer than `MIN_GAMES_FOR_ADJUSTED_SCORE` games (configured in `src/constants.ts`, default 1) still get `scoreAdjustedByGames = 0`.
+   - To avoid one-game spikes dominating rare categories, each eligible per-game stat is stabilized toward the pool-average rate for that category before scoring. The pool-average rate is weighted by total games in the current result set.
+   - Stabilization strength is controlled by category-specific prior-game constants in `src/constants.ts`:
+     `PLAYER_ADJUSTED_SCORE_PRIOR_GAMES` for skaters and `GOALIE_ADJUSTED_SCORE_PRIOR_GAMES` for goalies.
+   - Rare stats such as `shp` use a stronger prior than common stats such as `shots`, so short-sample spikes are dampened more aggressively while real pace over larger samples still shows through.
+   - For players, stabilized per-game values are normalized using the same stat rules as the main score (including `plusMinus` range scoring). For goalies, `scoreAdjustedByGames` uses stabilized per-game `wins`, `saves`, and `shutouts`; advanced stats (`gaa`, `savePercent`) still do not contribute.
+   - Finally, among all eligible players or goalies in the result set, the best stabilized `scoreAdjustedByGames` is normalized to exactly 100, and all other positive adjusted scores are scaled proportionally relative to that best stabilized pace score. Items below the minimum games threshold always remain at 0.
 
 5. **Position‑based scoring (players only)**
    - In addition to the overall `score`, players also receive position-based scores where they are compared only against players of the same position (Forward "F" or Defenseman "D").
    - `position`: The player's position ("F" or "D").
    - `scoreByPosition`: Overall score compared to same position only (0–100 scale).
-   - `scoreByPositionAdjustedByGames`: Per-game adjusted score compared to same position only.
+   - `scoreByPositionAdjustedByGames`: Stabilized per-game pace score compared to the same position only.
    - `scoresByPosition`: Per-stat breakdown (e.g., `scoresByPosition.goals`) compared to same position only.
    - This allows fairer comparisons since forwards and defensemen typically have different stat profiles.
    - Position-based scores are included in both single-season and combined endpoints, including each entry in the `seasons` array for combined data.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -502,7 +502,7 @@ components:
           description: Composite score (0-100 range).
         scoreAdjustedByGames:
           type: number
-          description: Score adjusted by games played.
+          description: Stabilized per-game pace score.
         scores:
           type: object
           additionalProperties:
@@ -512,6 +512,7 @@ components:
           type: number
         scoreByPositionAdjustedByGames:
           type: number
+          description: Stabilized per-game pace score compared to the same position only.
         scoresByPosition:
           type: object
           additionalProperties:
@@ -572,6 +573,7 @@ components:
           type: number
         scoreAdjustedByGames:
           type: number
+          description: Stabilized per-game pace score.
         scores:
           type: object
           additionalProperties:
@@ -580,6 +582,7 @@ components:
           type: number
         scoreByPositionAdjustedByGames:
           type: number
+          description: Stabilized per-game pace score compared to the same position only.
         scoresByPosition:
           type: object
           additionalProperties:

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -339,6 +339,52 @@ describe("helpers", () => {
       expect(result.every((p) => p.scoreAdjustedByGames === 0)).toBe(true);
     });
 
+    test("keeps pace scoring for lower-game players with better rates", () => {
+      const testPlayers: Player[] = [
+        {
+          id: "id",
+          name: "Higher Pace",
+          games: 20,
+          goals: 10,
+          assists: 14,
+          points: 24,
+          plusMinus: 6,
+          penalties: 20,
+          shots: 70,
+          ppp: 6,
+          shp: 0,
+          hits: 20,
+          blocks: 14,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+        {
+          id: "id",
+          name: "Higher Totals",
+          games: 40,
+          goals: 14,
+          assists: 18,
+          points: 32,
+          plusMinus: 8,
+          penalties: 24,
+          shots: 100,
+          ppp: 8,
+          shp: 0,
+          hits: 28,
+          blocks: 20,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+      ];
+
+      const [higherPace, higherTotals] = applyPlayerScores(testPlayers);
+
+      expect(higherPace.score).toBeLessThan(higherTotals.score);
+      expect(higherPace.scoreAdjustedByGames).toBeGreaterThan(
+        higherTotals.scoreAdjustedByGames,
+      );
+    });
+
     test("uses 0 baseline for always-positive stats", () => {
       const testPlayers: Player[] = [
         {
@@ -568,7 +614,7 @@ describe("helpers", () => {
       expect(result[1].score).toBeDefined();
     });
 
-    test("uses per-game plusMinus in scoreAdjustedByGames", () => {
+    test("uses stabilized per-game plusMinus in scoreAdjustedByGames", () => {
       const minGames = MIN_GAMES_FOR_ADJUSTED_SCORE;
 
       const testPlayers: Player[] = [
@@ -645,7 +691,69 @@ describe("helpers", () => {
       expect(bestAdj).toBe(100);
     });
 
-    test("keeps scoreAdjustedByGames at 0 when all per-game stats are zero", () => {
+    test("dampens one-game SHP spikes in scoreAdjustedByGames", () => {
+      const testPlayers: Player[] = [
+        {
+          id: "id",
+          name: "One Game Hero",
+          games: 1,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 1,
+          hits: 0,
+          blocks: 0,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+        {
+          id: "id",
+          name: "Steady Producer",
+          games: 20,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 2,
+          hits: 0,
+          blocks: 0,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+        {
+          id: "id",
+          name: "No SHP",
+          games: 20,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 0,
+          hits: 0,
+          blocks: 0,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+      ];
+
+      const [oneGameHero, steadyProducer, noShp] = applyPlayerScores(testPlayers);
+
+      expect(oneGameHero.scoreAdjustedByGames).toBe(100);
+      expect(steadyProducer.scoreAdjustedByGames).toBeGreaterThan(50);
+      expect(noShp.scoreAdjustedByGames).toBe(0);
+    });
+
+    test("keeps scoreAdjustedByGames at 0 when all base stats are zero", () => {
       const minGames = MIN_GAMES_FOR_ADJUSTED_SCORE;
 
       const testPlayers: Player[] = [
@@ -896,6 +1004,56 @@ describe("helpers", () => {
       );
     });
 
+    test("keeps pace scoring within the same position group", () => {
+      const testPlayers: Player[] = [
+        {
+          id: "id",
+          name: "Higher Pace Forward",
+          position: "F",
+          games: 20,
+          goals: 10,
+          assists: 14,
+          points: 24,
+          plusMinus: 6,
+          penalties: 20,
+          shots: 70,
+          ppp: 6,
+          shp: 0,
+          hits: 20,
+          blocks: 14,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+        {
+          id: "id",
+          name: "Higher Totals Forward",
+          position: "F",
+          games: 40,
+          goals: 14,
+          assists: 18,
+          points: 32,
+          plusMinus: 8,
+          penalties: 24,
+          shots: 100,
+          ppp: 8,
+          shp: 0,
+          hits: 28,
+          blocks: 20,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+      ];
+
+      const [higherPace, higherTotals] = applyPlayerScoresByPosition(testPlayers);
+
+      expect(higherPace.scoreByPosition).toBeLessThan(
+        higherTotals.scoreByPosition as number,
+      );
+      expect(higherPace.scoreByPositionAdjustedByGames).toBeGreaterThan(
+        higherTotals.scoreByPositionAdjustedByGames as number,
+      );
+    });
+
     test("handles all players below minimum games in position group", () => {
       const belowMinGames = Math.max(MIN_GAMES_FOR_ADJUSTED_SCORE - 1, 0);
 
@@ -1037,7 +1195,7 @@ describe("helpers", () => {
       expect((result[0].scoreByPosition as number) >= 0).toBe(true);
     });
 
-    test("handles negative plusMinus per game in position scoring", () => {
+    test("handles negative plusMinus in games-adjusted position scoring", () => {
       const testPlayers: Player[] = [
         {
           id: "id",
@@ -1199,8 +1357,6 @@ describe("helpers", () => {
     });
 
     test("sets scoreAdjustedByGames to 0 for eligible goalie with all-zero base stats", () => {
-      // When all eligible goalies have 0 for every base field, maxPerGameByField[field] = 0
-      // so the if (max > 0) branch is never taken and scoreAdjustedByGames stays 0
       const testGoalies: Goalie[] = [
         {
           id: "id",
@@ -1268,6 +1424,50 @@ describe("helpers", () => {
 
       expect(fewGames.scoreAdjustedByGames).toBe(0);
       expect(eligible.scoreAdjustedByGames).toBeGreaterThan(0);
+    });
+
+    test("keeps pace scoring for goalies with better per-game results", () => {
+      const testGoalies: Goalie[] = [
+        {
+          id: "id",
+          name: "Higher Pace Goalie",
+          games: 20,
+          wins: 10,
+          saves: 600,
+          shutouts: 2,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          penalties: 0,
+          ppp: 0,
+          shp: 0,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+        {
+          id: "id",
+          name: "Higher Totals Goalie",
+          games: 40,
+          wins: 14,
+          saves: 1000,
+          shutouts: 3,
+          goals: 0,
+          assists: 0,
+          points: 0,
+          penalties: 0,
+          ppp: 0,
+          shp: 0,
+          score: 0,
+          scoreAdjustedByGames: 0,
+        },
+      ];
+
+      const [higherPace, higherTotals] = applyGoalieScores(testGoalies);
+
+      expect(higherPace.score).toBeLessThan(higherTotals.score);
+      expect(higherPace.scoreAdjustedByGames).toBeGreaterThan(
+        higherTotals.scoreAdjustedByGames,
+      );
     });
 
     test("sets scoreAdjustedByGames to 0 when no goalies meet minimum games", () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -174,6 +174,27 @@ export const GOALIE_SAVE_PERCENT_BASELINE = 0.85; // .850
 // Minimum games required for games-adjusted scoring (players and goalies)
 export const MIN_GAMES_FOR_ADJUSTED_SCORE = 1;
 
+// Games-adjusted scores use stabilized per-game pace. Higher values pull short
+// samples more strongly toward the pool-average rate for that category.
+export const PLAYER_ADJUSTED_SCORE_PRIOR_GAMES: Record<PlayerScoreField, number> = {
+  goals: 8,
+  assists: 8,
+  points: 8,
+  plusMinus: 12,
+  penalties: 6,
+  shots: 5,
+  ppp: 12,
+  shp: 30,
+  hits: 6,
+  blocks: 6,
+};
+
+export const GOALIE_ADJUSTED_SCORE_PRIOR_GAMES: Record<GoalieScoreField, number> = {
+  wins: 8,
+  saves: 5,
+  shutouts: 30,
+};
+
 // Default CSV directory for Playwright imports
 export const DEFAULT_CSV_OUT_DIR = "./csv/temp/";
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,5 @@
 import {
   Player,
-  PlayerFields,
   Goalie,
   Report,
   CsvReport,
@@ -16,6 +15,8 @@ import {
   GOALIE_SAVE_PERCENT_BASELINE,
   GOALIE_SCORING_DAMPENING_EXPONENT,
   MIN_GAMES_FOR_ADJUSTED_SCORE,
+  PLAYER_ADJUSTED_SCORE_PRIOR_GAMES,
+  GOALIE_ADJUSTED_SCORE_PRIOR_GAMES,
   CURRENT_SEASON,
   DEFAULT_TEAM_ID,
   START_SEASON,
@@ -144,12 +145,13 @@ const applyScoresInternal = <
   items: T[],
   fields: K[],
   weights: Record<K, number>,
-): T[] => {
-  if (!items.length) return items;
+): number[] => {
+  if (!items.length) return [];
 
   const maxByField = getMaxByField(items, fields);
   const minByField = getMinByField(items, fields);
   const fieldCount = fields.length;
+  const rawScores: number[] = [];
 
   for (const item of items) {
     let total = 0;
@@ -185,10 +187,206 @@ const applyScoresInternal = <
 
     const average = total / fieldCount;
     item.score = toTwoDecimals(Math.min(Math.max(average, 0), 100));
+    rawScores.push(item.score);
   }
 
   normalizeFieldToBest(items, "score");
-  return items;
+  return rawScores;
+};
+
+const getStabilizedRate = (
+  value: number,
+  games: number,
+  priorRate: number,
+  priorGames: number,
+): number => {
+  return (value + priorRate * priorGames) / (games + priorGames);
+};
+
+const getAdjustedObservedRate = (
+  value: number,
+  games: number,
+  priorRate: number,
+  priorGames: number,
+): number => {
+  if (value === 0) return 0;
+  return getStabilizedRate(value, games, priorRate, priorGames);
+};
+
+const getPriorRatesByField = <
+  T extends { games: number } & Record<K, number>,
+  K extends keyof T & string,
+>(
+  items: readonly T[],
+  fields: readonly K[],
+  negativeField?: K,
+): Record<K, number> => {
+  const totals = fields.reduce(
+    (acc, field) => {
+      acc[field] = 0;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
+  let totalGames = 0;
+
+  for (const item of items) {
+    const games = item.games;
+    totalGames += games;
+
+    for (const field of fields) {
+      const raw = Number(item[field]);
+      const safeRaw = Number.isFinite(raw) ? raw : 0;
+      totals[field] +=
+        field === negativeField ? safeRaw : Math.max(0, safeRaw);
+    }
+  }
+
+  return fields.reduce(
+    (acc, field) => {
+      acc[field] = totals[field] / totalGames;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
+};
+
+const getStabilizedRateBounds = <
+  T extends { games: number } & Record<K, number>,
+  K extends keyof T & string,
+>(
+  items: readonly T[],
+  fields: readonly K[],
+  priorRates: Record<K, number>,
+  priorGamesByField: Record<K, number>,
+  negativeField?: K,
+): { maxByField: Record<K, number>; minByField: Record<K, number> } => {
+  const maxByField = fields.reduce(
+    (acc, field) => {
+      acc[field] = 0;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
+  const minByField = fields.reduce(
+    (acc, field) => {
+      acc[field] = 0;
+      return acc;
+    },
+    {} as Record<K, number>,
+  );
+
+  for (const item of items) {
+    const games = item.games;
+
+    for (const field of fields) {
+      const raw = Number(item[field]);
+      const safeRaw = Number.isFinite(raw) ? raw : 0;
+      const value =
+        field === negativeField ? safeRaw : Math.max(0, safeRaw);
+      const stabilizedRate = getAdjustedObservedRate(
+        value,
+        games,
+        priorRates[field],
+        priorGamesByField[field],
+      );
+
+      if (field === negativeField) {
+        if (stabilizedRate > maxByField[field]) {
+          maxByField[field] = stabilizedRate;
+        }
+        if (stabilizedRate < minByField[field]) {
+          minByField[field] = stabilizedRate;
+        }
+      } else if (stabilizedRate > maxByField[field]) {
+        maxByField[field] = stabilizedRate;
+      }
+    }
+  }
+
+  return { maxByField, minByField };
+};
+
+const applyStabilizedAdjustedScores = <
+  T extends { games: number } & Record<K, number> & Partial<Record<S, number>>,
+  K extends keyof T & string,
+  S extends keyof T & string,
+>(
+  items: T[],
+  fields: readonly K[],
+  weights: Record<K, number>,
+  priorGamesByField: Record<K, number>,
+  outputField: S,
+  negativeField?: K,
+): void => {
+  if (!items.length) return;
+
+  const eligible = items.filter(
+    (item) => item.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  );
+
+  if (!eligible.length) {
+    for (const item of items) {
+      item[outputField] = 0 as T[S];
+    }
+    return;
+  }
+
+  const priorRates = getPriorRatesByField(eligible, fields, negativeField);
+  const { maxByField, minByField } = getStabilizedRateBounds(
+    eligible,
+    fields,
+    priorRates,
+    priorGamesByField,
+    negativeField,
+  );
+  const fieldCount = fields.length;
+
+  for (const item of items) {
+    if (item.games < MIN_GAMES_FOR_ADJUSTED_SCORE) {
+      item[outputField] = 0 as T[S];
+      continue;
+    }
+
+    const games = item.games;
+    let total = 0;
+
+    for (const field of fields) {
+      const raw = Number(item[field]);
+      const safeRaw = Number.isFinite(raw) ? raw : 0;
+      const value =
+        field === negativeField ? safeRaw : Math.max(0, safeRaw);
+      const stabilizedRate = getAdjustedObservedRate(
+        value,
+        games,
+        priorRates[field],
+        priorGamesByField[field],
+      );
+
+      let relative = 0;
+
+      if (field === negativeField) {
+        const range = maxByField[field] - minByField[field];
+        if (range > 0) {
+          relative =
+            ((stabilizedRate - minByField[field]) / range) * 100;
+        }
+      } else {
+        const max = maxByField[field];
+        if (max > 0) {
+          relative = (Math.max(0, stabilizedRate) / max) * 100;
+        }
+      }
+
+      total += relative * weights[field];
+    }
+
+    item[outputField] = toTwoDecimals(
+      Math.min(Math.max(total / fieldCount, 0), 100),
+    ) as T[S];
+  }
+
+  normalizeFieldToBest(items, outputField);
 };
 
 export const sortItemsByStatField = (
@@ -204,88 +402,14 @@ export const sortItemsByStatField = (
 };
 
 const applyPlayerScoresByGames = (players: Player[]): void => {
-  if (!players.length) return;
-
-  const eligible = players.filter(
-    (player) => player.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  applyStabilizedAdjustedScores(
+    players,
+    PLAYER_SCORE_FIELDS,
+    PLAYER_SCORE_WEIGHTS,
+    PLAYER_ADJUSTED_SCORE_PRIOR_GAMES,
+    "scoreAdjustedByGames",
+    "plusMinus",
   );
-
-  if (!eligible.length) {
-    for (const player of players) {
-      player.scoreAdjustedByGames = 0;
-    }
-    return;
-  }
-
-  const fieldCount = PLAYER_SCORE_FIELDS.length;
-  const maxPerGameByField = PLAYER_SCORE_FIELDS.reduce(
-    (acc, field) => {
-      acc[field as PlayerFields] = 0;
-      return acc;
-    },
-    {} as Record<PlayerFields, number>,
-  );
-
-  let minPlusMinusPerGame = 0;
-  let maxPlusMinusPerGame = 0;
-
-  for (const player of eligible) {
-    const games = player.games;
-
-    for (const field of PLAYER_SCORE_FIELDS) {
-      const raw = Number(player[field]);
-      const perGame = raw / games;
-
-      if (field === "plusMinus") {
-        if (perGame > maxPlusMinusPerGame) maxPlusMinusPerGame = perGame;
-        if (perGame < minPlusMinusPerGame) minPlusMinusPerGame = perGame;
-      } else {
-        const value = Math.max(0, perGame);
-        if (value > maxPerGameByField[field]) {
-          maxPerGameByField[field] = value;
-        }
-      }
-    }
-  }
-
-  for (const player of players) {
-    if (player.games < MIN_GAMES_FOR_ADJUSTED_SCORE) {
-      player.scoreAdjustedByGames = 0;
-      continue;
-    }
-
-    const games = player.games;
-    let total = 0;
-
-    for (const field of PLAYER_SCORE_FIELDS) {
-      const raw = Number(player[field]);
-      const perGame = raw / games;
-      let relative = 0;
-
-      if (field === "plusMinus") {
-        const range = maxPlusMinusPerGame - minPlusMinusPerGame;
-        if (range > 0) {
-          relative = ((perGame - minPlusMinusPerGame) / range) * 100;
-        }
-      } else {
-        const max = maxPerGameByField[field];
-        if (max > 0) {
-          const value = Math.max(0, perGame);
-          relative = (value / max) * 100;
-        }
-      }
-
-      const weight = PLAYER_SCORE_WEIGHTS[field];
-      total += relative * weight;
-    }
-
-    const average = total / fieldCount;
-    player.scoreAdjustedByGames = toTwoDecimals(
-      Math.min(Math.max(average, 0), 100),
-    );
-  }
-
-  normalizeFieldToBest(players, "scoreAdjustedByGames");
 };
 
 export const applyPlayerScores = (players: Player[]): Player[] => {
@@ -344,83 +468,14 @@ const applyPositionScoresForGroup = (players: Player[]): void => {
   }
 
   normalizeFieldToBest(players, "scoreByPosition");
-
-  // Calculate scoreByPositionAdjustedByGames
-  const eligible = players.filter(
-    (p) => p.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  applyStabilizedAdjustedScores(
+    players,
+    fields,
+    weights,
+    PLAYER_ADJUSTED_SCORE_PRIOR_GAMES,
+    "scoreByPositionAdjustedByGames",
+    "plusMinus",
   );
-
-  if (!eligible.length) {
-    for (const player of players) {
-      player.scoreByPositionAdjustedByGames = 0;
-    }
-    return;
-  }
-
-  const maxPerGameByField: Record<string, number> = {};
-  let minPlusMinusPerGame = 0;
-  let maxPlusMinusPerGame = 0;
-
-  for (const field of fields) {
-    maxPerGameByField[field] = 0;
-  }
-
-  for (const player of eligible) {
-    const games = player.games;
-    for (const field of fields) {
-      const raw = Number(player[field]);
-      const perGame = raw / games;
-
-      if (field === "plusMinus") {
-        if (perGame > maxPlusMinusPerGame) maxPlusMinusPerGame = perGame;
-        if (perGame < minPlusMinusPerGame) minPlusMinusPerGame = perGame;
-      } else {
-        const value = Math.max(0, perGame);
-        if (value > maxPerGameByField[field]) {
-          maxPerGameByField[field] = value;
-        }
-      }
-    }
-  }
-
-  for (const player of players) {
-    if (player.games < MIN_GAMES_FOR_ADJUSTED_SCORE) {
-      player.scoreByPositionAdjustedByGames = 0;
-      continue;
-    }
-
-    const games = player.games;
-    let total = 0;
-
-    for (const field of fields) {
-      const raw = Number(player[field]);
-      const perGame = raw / games;
-      let relative = 0;
-
-      if (field === "plusMinus") {
-        const range = maxPlusMinusPerGame - minPlusMinusPerGame;
-        if (range > 0) {
-          relative = ((perGame - minPlusMinusPerGame) / range) * 100;
-        }
-      } else {
-        const max = maxPerGameByField[field];
-        if (max > 0) {
-          const value = Math.max(0, perGame);
-          relative = (value / max) * 100;
-        }
-      }
-
-      const weight = weights[field];
-      total += relative * weight;
-    }
-
-    const average = total / fieldCount;
-    player.scoreByPositionAdjustedByGames = toTwoDecimals(
-      Math.min(Math.max(average, 0), 100),
-    );
-  }
-
-  normalizeFieldToBest(players, "scoreByPositionAdjustedByGames");
 };
 
 export const applyPlayerScoresByPosition = (players: Player[]): Player[] => {
@@ -554,66 +609,13 @@ export const applyGoalieScores = (goalies: Goalie[]): Goalie[] => {
   }
 
   normalizeFieldToBest(goalies, "score");
-  const eligible = goalies.filter(
-    (goalie) => goalie.games >= MIN_GAMES_FOR_ADJUSTED_SCORE,
+  applyStabilizedAdjustedScores(
+    goalies,
+    baseFields,
+    GOALIE_SCORE_WEIGHTS,
+    GOALIE_ADJUSTED_SCORE_PRIOR_GAMES,
+    "scoreAdjustedByGames",
   );
-
-  if (!eligible.length) {
-    for (const goalie of goalies) {
-      goalie.scoreAdjustedByGames = 0;
-    }
-    return goalies;
-  }
-
-  const fieldCount = baseFields.length;
-  const maxPerGameByField = baseFields.reduce(
-    (acc, field) => {
-      acc[field] = 0;
-      return acc;
-    },
-    {} as Record<GoalieScoreField, number>,
-  );
-
-  for (const goalie of eligible) {
-    const games = goalie.games;
-    for (const field of baseFields) {
-      const raw = Number(goalie[field]);
-      const perGame = raw / games;
-      const value = Math.max(0, perGame);
-      if (value > maxPerGameByField[field]) {
-        maxPerGameByField[field] = value;
-      }
-    }
-  }
-
-  for (const goalie of goalies) {
-    if (goalie.games < MIN_GAMES_FOR_ADJUSTED_SCORE) {
-      goalie.scoreAdjustedByGames = 0;
-      continue;
-    }
-
-    const games = goalie.games;
-    let total = 0;
-
-    for (const field of baseFields) {
-      const max = maxPerGameByField[field];
-      if (max > 0) {
-        const raw = Number(goalie[field]);
-        const perGame = raw / games;
-        const value = Math.max(0, perGame);
-        const relative = (value / max) * 100;
-        const weight = GOALIE_SCORE_WEIGHTS[field];
-        total += relative * weight;
-      }
-    }
-
-    const average = total / fieldCount;
-    goalie.scoreAdjustedByGames = toTwoDecimals(
-      Math.min(Math.max(average, 0), 100),
-    );
-  }
-
-  normalizeFieldToBest(goalies, "scoreAdjustedByGames");
 
   return goalies;
 };


### PR DESCRIPTION
## Summary
- keep `scoreAdjustedByGames` as a true per-game pace metric
- fix the original issue where rare low-sample stats, especially `SHP`, could distort pace rankings and create unintuitive comparisons
- stabilize adjusted scoring with category-specific prior games so short-sample spikes are dampened without heavily penalizing players who missed time
- apply the same stabilized pace logic to player position-adjusted scoring and goalie adjusted scoring
- update scoring docs and add regression coverage for the original edge cases

## Original problem 
- `scoreAdjustedByGames` recalculated each category directly from raw per-game rates
- rare-event categories could swing too hard in small samples
- this made some pace rankings look unreasonable even when the overall player profile suggested otherwise
- players with fewer games but strong pace could also get noisy results rather than a stable pace score

## Fix
- compute adjusted scores from stabilized per-game rates instead of raw per-game rates
- shrink each category toward the pool-average per-game rate using category-specific prior-game values
- use stronger shrinkage for noisy categories like `SHP` and lighter shrinkage for common categories like `shots`
- preserve `plusMinus` as a ranged category in adjusted scoring
- keep zero-category production at zero so players do not receive credit for stats they did not produce

## Result
- adjusted scores now read as pace scores again
- small-sample category spikes are much less likely to hijack the ranking
- players who missed games but produced strong pace retain stronger adjusted scores
- the original SHP-driven distortion is fixed without replacing pace scoring with a totals-based bonus model

## Testing
- `npm run verify`
