### PR TITLE
Feature: Add new career highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The OpenAPI spec is also available as JSON at [https://ffhl-stats-api.vercel.app
 
 The API includes team-scoped season/combined leaderboards plus career endpoints for list, detail, and highlight lookups:
 `/career/players`, `/career/goalies`, `/career/player/{id}`, `/career/goalie/{id}`, and `/career/highlights/{type}`.
-The highlights route supports `skip` / `take` paging and the four route tokens `most-teams-played`, `most-teams-owned`, `same-team-seasons-played`, and `same-team-seasons-owned`.
-Current highlight minimums are stricter than before: `most-teams-played` requires 4 played teams, `most-teams-owned` requires 5 owned teams, `same-team-seasons-played` requires 8 played seasons with one team, and `same-team-seasons-owned` requires 10 owned seasons with one team.
+The highlights route supports `skip` / `take` paging and the route tokens `most-teams-played`, `most-teams-owned`, `same-team-seasons-played`, `same-team-seasons-owned`, `most-stanley-cups`, `reunion-king`, `stash-king`, and `regular-grinder-without-playoffs`.
+`reunion-king` items include stint ranges as `fromSeason` / `toSeason` pairs for each return stint.
+Current highlight minimums are: `most-teams-played` 4, `most-teams-owned` 5, `same-team-seasons-played` 8, `same-team-seasons-owned` 10, `most-stanley-cups` 2, `reunion-king` 2, `stash-king` 10, and `regular-grinder-without-playoffs` 60.
 
 ### Viewing docs locally
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -450,6 +450,10 @@ components:
         - most-teams-owned
         - same-team-seasons-played
         - same-team-seasons-owned
+        - most-stanley-cups
+        - reunion-king
+        - stash-king
+        - regular-grinder-without-playoffs
 
     CareerHighlightTeam:
       type: object
@@ -492,6 +496,88 @@ components:
         team:
           $ref: "#/components/schemas/CareerHighlightTeam"
 
+    CareerStanleyCupHighlightCup:
+      type: object
+      required: [season, team]
+      properties:
+        season:
+          type: integer
+        team:
+          $ref: "#/components/schemas/CareerHighlightTeam"
+
+    CareerStanleyCupHighlightItem:
+      type: object
+      required: [id, name, position, cupCount, cups]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        position:
+          type: string
+        cupCount:
+          type: integer
+        cups:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerStanleyCupHighlightCup"
+
+    CareerReunionHighlightItem:
+      type: object
+      required: [id, name, position, reunionCount, team, stints]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        position:
+          type: string
+        reunionCount:
+          type: integer
+        team:
+          $ref: "#/components/schemas/CareerHighlightTeam"
+        stints:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerReunionHighlightStint"
+
+    CareerReunionHighlightStint:
+      type: object
+      required: [fromSeason, toSeason]
+      properties:
+        fromSeason:
+          type: integer
+        toSeason:
+          type: integer
+
+    CareerStashHighlightItem:
+      type: object
+      required: [id, name, position, seasonCount, team]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        position:
+          type: string
+        seasonCount:
+          type: integer
+        team:
+          $ref: "#/components/schemas/CareerHighlightTeam"
+
+    CareerRegularGrinderHighlightItem:
+      type: object
+      required: [id, name, position, regularGames]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        position:
+          type: string
+        regularGames:
+          type: integer
+
     CareerTeamCountHighlightPage:
       type: object
       required: [type, skip, take, total, items]
@@ -527,6 +613,78 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CareerSameTeamHighlightItem"
+
+    CareerStanleyCupHighlightPage:
+      type: object
+      required: [type, skip, take, total, items]
+      properties:
+        type:
+          type: string
+          enum: [most-stanley-cups]
+        skip:
+          type: integer
+        take:
+          type: integer
+        total:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerStanleyCupHighlightItem"
+
+    CareerReunionHighlightPage:
+      type: object
+      required: [type, skip, take, total, items]
+      properties:
+        type:
+          type: string
+          enum: [reunion-king]
+        skip:
+          type: integer
+        take:
+          type: integer
+        total:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerReunionHighlightItem"
+
+    CareerStashHighlightPage:
+      type: object
+      required: [type, skip, take, total, items]
+      properties:
+        type:
+          type: string
+          enum: [stash-king]
+        skip:
+          type: integer
+        take:
+          type: integer
+        total:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerStashHighlightItem"
+
+    CareerRegularGrinderHighlightPage:
+      type: object
+      required: [type, skip, take, total, items]
+      properties:
+        type:
+          type: string
+          enum: [regular-grinder-without-playoffs]
+        skip:
+          type: integer
+        take:
+          type: integer
+        total:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerRegularGrinderHighlightItem"
 
     CareerGoalie:
       type: object
@@ -1388,9 +1546,19 @@ paths:
         Returns a paged mixed skater + goalie career highlights leaderboard.
         `most-teams-played` and `most-teams-owned` return team-count rows.
         `same-team-seasons-played` and `same-team-seasons-owned` return one row per top team, so the same person can appear multiple times on tied same-team results.
+        `most-stanley-cups` returns one row per player/goalie with cup seasons and fantasy teams.
+        `reunion-king` returns one row per top reunion team, so the same person can appear multiple
+        times on tied reunion results, and includes stint ranges for each return.
+        `stash-king` returns the top same-team zero-game season counts, similar to
+        `same-team-seasons-owned` but counting only team seasons where both regular and playoff
+        games stayed at zero.
+        `regular-grinder-without-playoffs` returns total regular-season games for players/goalies who
+        never recorded a playoff appearance.
         Minimum cutoffs are 4 teams for `most-teams-played`, 5 teams for `most-teams-owned`,
-        8 same-team seasons for `same-team-seasons-played`, and 10 same-team seasons for
-        `same-team-seasons-owned`.
+        8 same-team seasons for `same-team-seasons-played`, 10 same-team seasons for
+        `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunion stints for
+        `reunion-king`, 10 stash counts for `stash-king`, and 60 games for
+        `regular-grinder-without-playoffs`.
       parameters:
         - name: type
           in: path
@@ -1409,6 +1577,10 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/CareerTeamCountHighlightPage"
                   - $ref: "#/components/schemas/CareerSameTeamHighlightPage"
+                  - $ref: "#/components/schemas/CareerStanleyCupHighlightPage"
+                  - $ref: "#/components/schemas/CareerReunionHighlightPage"
+                  - $ref: "#/components/schemas/CareerStashHighlightPage"
+                  - $ref: "#/components/schemas/CareerRegularGrinderHighlightPage"
         "400":
           description: Invalid highlight type or paging params.
         "401":

--- a/src/__tests__/routes.integration.career.ts
+++ b/src/__tests__/routes.integration.career.ts
@@ -829,6 +829,452 @@ export const registerCareerRouteIntegrationTests = (): void => {
       }
     });
 
+    test("returns most-stanley-cups highlights with cup seasons and fantasy teams", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertPlayers([
+          {
+            teamId: "1",
+            season: 2021,
+            reportType: "playoffs",
+            playerId: "p-cups",
+            name: "Cup Skater",
+            position: "F",
+            games: 8,
+          },
+          {
+            teamId: "2",
+            season: 2023,
+            reportType: "playoffs",
+            playerId: "p-cups",
+            name: "Cup Skater",
+            position: "F",
+            games: 12,
+          },
+          {
+            teamId: "4",
+            season: 2024,
+            reportType: "playoffs",
+            playerId: "p-one",
+            name: "One Cup Skater",
+            position: "D",
+            games: 6,
+          },
+        ]);
+        await db.insertGoalies([
+          {
+            teamId: "3",
+            season: 2020,
+            reportType: "playoffs",
+            goalieId: "g-cups",
+            name: "Cup Goalie",
+            games: 4,
+          },
+          {
+            teamId: "3",
+            season: 2022,
+            reportType: "playoffs",
+            goalieId: "g-cups",
+            name: "Cup Goalie",
+            games: 4,
+          },
+          {
+            teamId: "3",
+            season: 2024,
+            reportType: "playoffs",
+            goalieId: "g-cups",
+            name: "Cup Goalie",
+            games: 5,
+          },
+        ]);
+        await db.insertPlayoffResults([
+          { teamId: "3", season: 2020, round: 5 },
+          { teamId: "1", season: 2021, round: 5 },
+          { teamId: "3", season: 2022, round: 5 },
+          { teamId: "2", season: 2023, round: 5 },
+          { teamId: "3", season: 2024, round: 5 },
+          { teamId: "4", season: 2024, round: 4 },
+        ]);
+
+        const req = createRequest({
+          method: "GET",
+          url: "/career/highlights/most-stanley-cups",
+          params: { type: "most-stanley-cups" },
+        });
+        const res = createResponse();
+
+        await getCareerHighlights(asRouteReq<CareerHighlightsReq>(req), res);
+
+        const body = getJsonBody<Record<string, unknown>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(body).toEqual({
+          type: "most-stanley-cups",
+          skip: 0,
+          take: 10,
+          total: 2,
+          items: [
+            {
+              id: "g-cups",
+              name: "Cup Goalie",
+              position: "G",
+              cupCount: 3,
+              cups: [
+                {
+                  season: 2020,
+                  team: { id: "3", name: "Calgary Flames" },
+                },
+                {
+                  season: 2022,
+                  team: { id: "3", name: "Calgary Flames" },
+                },
+                {
+                  season: 2024,
+                  team: { id: "3", name: "Calgary Flames" },
+                },
+              ],
+            },
+            {
+              id: "p-cups",
+              name: "Cup Skater",
+              position: "F",
+              cupCount: 2,
+              cups: [
+                {
+                  season: 2021,
+                  team: { id: "1", name: "Colorado Avalanche" },
+                },
+                {
+                  season: 2023,
+                  team: { id: "2", name: "Carolina Hurricanes" },
+                },
+              ],
+            },
+          ],
+        });
+        expectObjectSchema("CareerStanleyCupHighlightPage", body);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
+    test("returns reunion-king highlights from separated same-team season blocks", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertPlayers([
+          ...[2018, 2020, 2022].map((season) => ({
+            teamId: "7",
+            season,
+            reportType: "regular" as const,
+            playerId: "p-reunion",
+            name: "Reunion Skater",
+            position: "F",
+            games: 0,
+          })),
+          ...[2019, 2020, 2022, 2024].map((season) => ({
+            teamId: "19",
+            season,
+            reportType: "regular" as const,
+            playerId: "p-reunion",
+            name: "Reunion Skater",
+            position: "F",
+            games: 0,
+          })),
+          ...[2020, 2022].map((season) => ({
+            teamId: "1",
+            season,
+            reportType: "regular" as const,
+            playerId: "p-two",
+            name: "Two Reunion",
+            position: "D",
+            games: 0,
+          })),
+        ]);
+        await db.insertGoalies(
+          [2017, 2019, 2021, 2023].map((season) => ({
+            teamId: "3",
+            season,
+            reportType: "regular" as const,
+            goalieId: "g-reunion",
+            name: "Reunion Goalie",
+            games: 0,
+          })),
+        );
+
+        const req = createRequest({
+          method: "GET",
+          url: "/career/highlights/reunion-king",
+          params: { type: "reunion-king" },
+        });
+        const res = createResponse();
+
+        await getCareerHighlights(asRouteReq<CareerHighlightsReq>(req), res);
+
+        const body = getJsonBody<Record<string, unknown>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(body).toEqual({
+          type: "reunion-king",
+          skip: 0,
+          take: 10,
+          total: 4,
+          items: [
+            {
+              id: "g-reunion",
+              name: "Reunion Goalie",
+              position: "G",
+              reunionCount: 4,
+              team: { id: "3", name: "Calgary Flames" },
+              stints: [
+                { fromSeason: 2017, toSeason: 2017 },
+                { fromSeason: 2019, toSeason: 2019 },
+                { fromSeason: 2021, toSeason: 2021 },
+                { fromSeason: 2023, toSeason: 2023 },
+              ],
+            },
+            {
+              id: "p-reunion",
+              name: "Reunion Skater",
+              position: "F",
+              reunionCount: 3,
+              team: { id: "7", name: "Edmonton Oilers" },
+              stints: [
+                { fromSeason: 2018, toSeason: 2018 },
+                { fromSeason: 2020, toSeason: 2020 },
+                { fromSeason: 2022, toSeason: 2022 },
+              ],
+            },
+            {
+              id: "p-reunion",
+              name: "Reunion Skater",
+              position: "F",
+              reunionCount: 3,
+              team: { id: "19", name: "Toronto Maple Leafs" },
+              stints: [
+                { fromSeason: 2019, toSeason: 2020 },
+                { fromSeason: 2022, toSeason: 2022 },
+                { fromSeason: 2024, toSeason: 2024 },
+              ],
+            },
+            {
+              id: "p-two",
+              name: "Two Reunion",
+              position: "D",
+              reunionCount: 2,
+              team: { id: "1", name: "Colorado Avalanche" },
+              stints: [
+                { fromSeason: 2020, toSeason: 2020 },
+                { fromSeason: 2022, toSeason: 2022 },
+              ],
+            },
+          ],
+        });
+        expectObjectSchema("CareerReunionHighlightPage", body);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
+    test("returns same-team zero-game season counts for stash-king", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertPlayers([
+          ...Array.from({ length: 10 }, (_, index) => ({
+            teamId: "1",
+            season: 2015 + index,
+            reportType: "regular" as const,
+            playerId: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            games: 0,
+          })),
+          {
+            teamId: "1",
+            season: 2015,
+            reportType: "playoffs",
+            playerId: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            games: 0,
+          },
+          {
+            teamId: "11",
+            season: 2025,
+            reportType: "regular",
+            playerId: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            games: 0,
+          },
+          {
+            teamId: "11",
+            season: 2025,
+            reportType: "playoffs",
+            playerId: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            games: 1,
+          },
+          ...Array.from({ length: 10 }, (_, index) => ({
+            teamId: String(index + 20),
+            season: 2012 + index,
+            reportType: "regular" as const,
+            playerId: "p-transfer-stash",
+            name: "Transfer Stash",
+            position: "D",
+            games: 0,
+          })),
+        ]);
+        await db.insertGoalies(
+          Array.from({ length: 11 }, (_, index) => ({
+            teamId: "20",
+            season: 2014 + index,
+            reportType: "regular" as const,
+            goalieId: "g-stash",
+            name: "Stash Goalie",
+            games: 0,
+          })),
+        );
+
+        const req = createRequest({
+          method: "GET",
+          url: "/career/highlights/stash-king",
+          params: { type: "stash-king" },
+        });
+        const res = createResponse();
+
+        await getCareerHighlights(asRouteReq<CareerHighlightsReq>(req), res);
+
+        const body = getJsonBody<Record<string, unknown>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(body).toEqual({
+          type: "stash-king",
+          skip: 0,
+          take: 10,
+          total: 2,
+          items: [
+            {
+              id: "g-stash",
+              name: "Stash Goalie",
+              position: "G",
+              seasonCount: 11,
+              team: { id: "20", name: "Ottawa Senators" },
+            },
+            {
+              id: "p-stash",
+              name: "Stash Skater",
+              position: "F",
+              seasonCount: 10,
+              team: { id: "1", name: "Colorado Avalanche" },
+            },
+          ],
+        });
+        expectObjectSchema("CareerStashHighlightPage", body);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
+    test("returns regular-grinder-without-playoffs highlights from regular-season max games", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertPlayers([
+          {
+            teamId: "1",
+            season: 2023,
+            reportType: "regular",
+            playerId: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            games: 30,
+          },
+          {
+            teamId: "2",
+            season: 2023,
+            reportType: "regular",
+            playerId: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            games: 40,
+          },
+          {
+            teamId: "2",
+            season: 2024,
+            reportType: "regular",
+            playerId: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            games: 25,
+          },
+          {
+            teamId: "3",
+            season: 2024,
+            reportType: "regular",
+            playerId: "p-playoffs",
+            name: "Playoff Skater",
+            position: "D",
+            games: 82,
+          },
+          {
+            teamId: "3",
+            season: 2024,
+            reportType: "playoffs",
+            playerId: "p-playoffs",
+            name: "Playoff Skater",
+            position: "D",
+            games: 8,
+          },
+        ]);
+        await db.insertGoalies([
+          {
+            teamId: "5",
+            season: 2023,
+            reportType: "regular",
+            goalieId: "g-grinder",
+            name: "Goalie Grinder",
+            games: 70,
+          },
+        ]);
+
+        const req = createRequest({
+          method: "GET",
+          url: "/career/highlights/regular-grinder-without-playoffs",
+          params: { type: "regular-grinder-without-playoffs" },
+        });
+        const res = createResponse();
+
+        await getCareerHighlights(asRouteReq<CareerHighlightsReq>(req), res);
+
+        const body = getJsonBody<Record<string, unknown>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(body).toEqual({
+          type: "regular-grinder-without-playoffs",
+          skip: 0,
+          take: 10,
+          total: 2,
+          items: [
+            {
+              id: "g-grinder",
+              name: "Goalie Grinder",
+              position: "G",
+              regularGames: 70,
+            },
+            {
+              id: "p-grinder",
+              name: "Grinder Skater",
+              position: "F",
+              regularGames: 65,
+            },
+          ],
+        });
+        expectObjectSchema("CareerRegularGrinderHighlightPage", body);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
     test("serves career highlight snapshots and applies paging after loading the snapshot", async () => {
       const db = await createIntegrationDb();
 

--- a/src/__tests__/services.career.list.test.ts
+++ b/src/__tests__/services.career.list.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   getAllGoalieCareerRowsFromDb,
   getAllPlayerCareerRowsFromDb,
+  getPlayoffSeasons,
 } from "../db/queries";
 import {
   createGoalieCareerRow,
@@ -256,6 +257,8 @@ describe("services", () => {
         getAllGoalieCareerRowsFromDb as jest.MockedFunction<
           typeof getAllGoalieCareerRowsFromDb
         >;
+      const mockGetPlayoffSeasons =
+        getPlayoffSeasons as jest.MockedFunction<typeof getPlayoffSeasons>;
 
       test("builds most-teams-played highlights with mixed skater and goalie entries", async () => {
         mockGetAllPlayerCareerRowsFromDb.mockResolvedValue([
@@ -839,6 +842,496 @@ describe("services", () => {
             position: "F",
             seasonCount: 10,
             team: { id: "1", name: "Colorado Avalanche" },
+          },
+        ]);
+      });
+
+      test("builds most-stanley-cups highlights with fantasy team and season info", async () => {
+        mockGetAllPlayerCareerRowsFromDb.mockResolvedValue([
+          createPlayerCareerRow({
+            player_id: "p-alpha-cups",
+            name: "Alpha Cup Skater",
+            position: "D",
+            team_id: "1",
+            season: 2023,
+            report_type: "playoffs",
+            games: 6,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-alpha-cups",
+            name: "Alpha Cup Skater",
+            position: "D",
+            team_id: "2",
+            season: 2023,
+            report_type: "playoffs",
+            games: 4,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-alpha-cups",
+            name: "Alpha Cup Skater",
+            position: "D",
+            team_id: "9",
+            season: 2023,
+            report_type: "regular",
+            games: 82,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-cups",
+            name: "Cup Skater",
+            position: "F",
+            team_id: "1",
+            season: 2021,
+            report_type: "playoffs",
+            games: 8,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-cups",
+            name: "Cup Skater",
+            position: "F",
+            team_id: "2",
+            season: 2023,
+            report_type: "playoffs",
+            games: 12,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-one",
+            name: "One Cup Skater",
+            position: "D",
+            team_id: "4",
+            season: 2024,
+            report_type: "playoffs",
+            games: 6,
+          }),
+        ]);
+        mockGetAllGoalieCareerRowsFromDb.mockResolvedValue([
+          createGoalieCareerRow({
+            goalie_id: "g-cups",
+            name: "Cup Goalie",
+            team_id: "3",
+            season: 2020,
+            report_type: "playoffs",
+            games: 4,
+          }),
+          createGoalieCareerRow({
+            goalie_id: "g-cups",
+            name: "Cup Goalie",
+            team_id: "3",
+            season: 2022,
+            report_type: "playoffs",
+            games: 4,
+          }),
+          createGoalieCareerRow({
+            goalie_id: "g-cups",
+            name: "Cup Goalie",
+            team_id: "3",
+            season: 2024,
+            report_type: "playoffs",
+            games: 5,
+          }),
+        ]);
+        mockGetPlayoffSeasons.mockResolvedValue([
+          { teamId: "3", season: 2020, round: 5 },
+          { teamId: "1", season: 2021, round: 5 },
+          { teamId: "3", season: 2022, round: 5 },
+          { teamId: "1", season: 2023, round: 5 },
+          { teamId: "2", season: 2023, round: 5 },
+          { teamId: "3", season: 2024, round: 5 },
+          { teamId: "4", season: 2024, round: 4 },
+        ]);
+
+        const result = await getCareerHighlightsData("most-stanley-cups");
+
+        expect(result).toEqual([
+          {
+            id: "g-cups",
+            name: "Cup Goalie",
+            position: "G",
+            cupCount: 3,
+            cups: [
+              {
+                season: 2020,
+                team: { id: "3", name: "Calgary Flames" },
+              },
+              {
+                season: 2022,
+                team: { id: "3", name: "Calgary Flames" },
+              },
+              {
+                season: 2024,
+                team: { id: "3", name: "Calgary Flames" },
+              },
+            ],
+          },
+          {
+            id: "p-alpha-cups",
+            name: "Alpha Cup Skater",
+            position: "D",
+            cupCount: 2,
+            cups: [
+              {
+                season: 2023,
+                team: { id: "2", name: "Carolina Hurricanes" },
+              },
+              {
+                season: 2023,
+                team: { id: "1", name: "Colorado Avalanche" },
+              },
+            ],
+          },
+          {
+            id: "p-cups",
+            name: "Cup Skater",
+            position: "F",
+            cupCount: 2,
+            cups: [
+              {
+                season: 2021,
+                team: { id: "1", name: "Colorado Avalanche" },
+              },
+              {
+                season: 2023,
+                team: { id: "2", name: "Carolina Hurricanes" },
+              },
+            ],
+          },
+        ]);
+      });
+
+      test("builds reunion-king highlights from separate same-team season blocks", async () => {
+        mockGetAllPlayerCareerRowsFromDb.mockResolvedValue([
+          ...[2018, 2020, 2022].map((season) =>
+            createPlayerCareerRow({
+              player_id: "p-reunion",
+              name: "Reunion Skater",
+              position: "F",
+              team_id: "7",
+              season,
+              games: 0,
+            }),
+          ),
+          ...[2019, 2020, 2022, 2024].map((season) =>
+            createPlayerCareerRow({
+              player_id: "p-reunion",
+              name: "Reunion Skater",
+              position: "F",
+              team_id: "19",
+              season,
+              games: 0,
+            }),
+          ),
+          ...[2020, 2022].map((season) =>
+            createPlayerCareerRow({
+              player_id: "p-two",
+              name: "Two Reunion",
+              position: "D",
+              team_id: "1",
+              season,
+              games: 0,
+            }),
+          ),
+          ...[2020, 2021, 2022].map((season) =>
+            createPlayerCareerRow({
+              player_id: "p-short",
+              name: "Short Reunion",
+              position: "D",
+              team_id: "1",
+              season,
+              games: 0,
+            }),
+          ),
+        ]);
+        mockGetAllGoalieCareerRowsFromDb.mockResolvedValue([]);
+
+        const result = await getCareerHighlightsData("reunion-king");
+
+        expect(result).toEqual([
+          {
+            id: "p-reunion",
+            name: "Reunion Skater",
+            position: "F",
+            reunionCount: 3,
+            team: { id: "7", name: "Edmonton Oilers" },
+            stints: [
+              { fromSeason: 2018, toSeason: 2018 },
+              { fromSeason: 2020, toSeason: 2020 },
+              { fromSeason: 2022, toSeason: 2022 },
+            ],
+          },
+          {
+            id: "p-reunion",
+            name: "Reunion Skater",
+            position: "F",
+            reunionCount: 3,
+            team: { id: "19", name: "Toronto Maple Leafs" },
+            stints: [
+              { fromSeason: 2019, toSeason: 2020 },
+              { fromSeason: 2022, toSeason: 2022 },
+              { fromSeason: 2024, toSeason: 2024 },
+            ],
+          },
+          {
+            id: "p-two",
+            name: "Two Reunion",
+            position: "D",
+            reunionCount: 2,
+            team: { id: "1", name: "Colorado Avalanche" },
+            stints: [
+              { fromSeason: 2020, toSeason: 2020 },
+              { fromSeason: 2022, toSeason: 2022 },
+            ],
+          },
+        ]);
+      });
+
+      test("builds stash-king highlights from same-team zero-game seasons and ignores transfer accumulation", async () => {
+        mockGetAllPlayerCareerRowsFromDb.mockResolvedValue([
+          ...Array.from({ length: 10 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-alpha-stash",
+              name: "Alpha Stash",
+              position: "D",
+              team_id: "4",
+              season: 2010 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+          ...Array.from({ length: 10 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-stash",
+              name: "Stash Skater",
+              position: "F",
+              team_id: "1",
+              season: 2015 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+          createPlayerCareerRow({
+            player_id: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            team_id: "1",
+            season: 2015,
+            report_type: "playoffs",
+            games: 0,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            team_id: "11",
+            season: 2025,
+            report_type: "regular",
+            games: 0,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            team_id: "11",
+            season: 2025,
+            report_type: "playoffs",
+            games: 1,
+          }),
+          ...Array.from({ length: 10 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-transfer-stash",
+              name: "Transfer Stash",
+              position: "F",
+              team_id: String(index + 20),
+              season: 2012 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+          ...Array.from({ length: 10 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-tie-stash",
+              name: "Tie Stash",
+              position: "F",
+              team_id: "2",
+              season: 2010 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+          ...Array.from({ length: 10 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-tie-stash",
+              name: "Tie Stash",
+              position: "F",
+              team_id: "3",
+              season: 2010 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+          ...Array.from({ length: 9 }, (_, index) =>
+            createPlayerCareerRow({
+              player_id: "p-short-stash",
+              name: "Short Stash",
+              position: "D",
+              team_id: "8",
+              season: 2016 + index,
+              report_type: "regular",
+              games: 0,
+            }),
+          ),
+        ]);
+        mockGetAllGoalieCareerRowsFromDb.mockResolvedValue([]);
+
+        const result = await getCareerHighlightsData("stash-king");
+
+        expect(result).toEqual([
+          {
+            id: "p-alpha-stash",
+            name: "Alpha Stash",
+            position: "D",
+            seasonCount: 10,
+            team: { id: "4", name: "Vancouver Canucks" },
+          },
+          {
+            id: "p-stash",
+            name: "Stash Skater",
+            position: "F",
+            seasonCount: 10,
+            team: { id: "1", name: "Colorado Avalanche" },
+          },
+          {
+            id: "p-tie-stash",
+            name: "Tie Stash",
+            position: "F",
+            seasonCount: 10,
+            team: { id: "3", name: "Calgary Flames" },
+          },
+          {
+            id: "p-tie-stash",
+            name: "Tie Stash",
+            position: "F",
+            seasonCount: 10,
+            team: { id: "2", name: "Carolina Hurricanes" },
+          },
+        ]);
+      });
+
+      test("builds regular-grinder-without-playoffs from regular-season max games per season", async () => {
+        mockGetAllPlayerCareerRowsFromDb.mockResolvedValue([
+          createPlayerCareerRow({
+            player_id: "p-alpha-grinder",
+            name: "Alpha Grinder",
+            position: "D",
+            team_id: "6",
+            season: 2023,
+            report_type: "regular",
+            games: 30,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-alpha-grinder",
+            name: "Alpha Grinder",
+            position: "D",
+            team_id: "7",
+            season: 2024,
+            report_type: "regular",
+            games: 35,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-alpha-grinder",
+            name: "Alpha Grinder",
+            position: "D",
+            team_id: "7",
+            season: 2024,
+            report_type: "playoffs",
+            games: 0,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            team_id: "1",
+            season: 2023,
+            report_type: "regular",
+            games: 30,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            team_id: "2",
+            season: 2023,
+            report_type: "regular",
+            games: 40,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            team_id: "2",
+            season: 2024,
+            report_type: "regular",
+            games: 25,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-playoffs",
+            name: "Playoff Skater",
+            position: "D",
+            team_id: "3",
+            season: 2024,
+            report_type: "regular",
+            games: 82,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-playoffs",
+            name: "Playoff Skater",
+            position: "D",
+            team_id: "3",
+            season: 2024,
+            report_type: "playoffs",
+            games: 8,
+          }),
+          createPlayerCareerRow({
+            player_id: "p-short-grinder",
+            name: "Short Grinder",
+            position: "F",
+            team_id: "8",
+            season: 2024,
+            report_type: "regular",
+            games: 59,
+          }),
+        ]);
+        mockGetAllGoalieCareerRowsFromDb.mockResolvedValue([
+          createGoalieCareerRow({
+            goalie_id: "g-grinder",
+            name: "Goalie Grinder",
+            team_id: "5",
+            season: 2023,
+            report_type: "regular",
+            games: 70,
+          }),
+        ]);
+
+        const result = await getCareerHighlightsData(
+          "regular-grinder-without-playoffs",
+        );
+
+        expect(result).toEqual([
+          {
+            id: "g-grinder",
+            name: "Goalie Grinder",
+            position: "G",
+            regularGames: 70,
+          },
+          {
+            id: "p-alpha-grinder",
+            name: "Alpha Grinder",
+            position: "D",
+            regularGames: 65,
+          },
+          {
+            id: "p-grinder",
+            name: "Grinder Skater",
+            position: "F",
+            regularGames: 65,
           },
         ]);
       });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,10 @@ export const CAREER_HIGHLIGHT_TYPES = [
   "most-teams-owned",
   "same-team-seasons-played",
   "same-team-seasons-owned",
+  "most-stanley-cups",
+  "reunion-king",
+  "stash-king",
+  "regular-grinder-without-playoffs",
 ] as const satisfies readonly CareerHighlightType[];
 
 export const DEFAULT_CAREER_HIGHLIGHT_SKIP = 0;
@@ -43,13 +47,37 @@ export const CAREER_HIGHLIGHT_CONFIG = {
     playedOnly: false,
     minCount: 10,
   },
+  "most-stanley-cups": {
+    kind: "stanley-cups",
+    minCount: 2,
+  },
+  "reunion-king": {
+    kind: "reunion-count",
+    minCount: 2,
+  },
+  "stash-king": {
+    kind: "stash-count",
+    minCount: 10,
+  },
+  "regular-grinder-without-playoffs": {
+    kind: "regular-games-without-playoffs",
+    minCount: 60,
+  },
 } as const satisfies Record<
   CareerHighlightType,
-  {
-    kind: "team-count" | "same-team-season-count";
-    playedOnly: boolean;
-    minCount: number;
-  }
+  | {
+      kind: "team-count" | "same-team-season-count";
+      playedOnly: boolean;
+      minCount: number;
+    }
+  | {
+      kind:
+        | "stanley-cups"
+        | "reunion-count"
+        | "stash-count"
+        | "regular-games-without-playoffs";
+      minCount: number;
+    }
 >;
 
 export const HTTP_STATUS = {

--- a/src/services.ts
+++ b/src/services.ts
@@ -26,6 +26,12 @@ import {
   CareerHighlightTeam,
   CareerTeamCountHighlightItem,
   CareerSameTeamHighlightItem,
+  CareerStanleyCupHighlightItem,
+  CareerStanleyCupHighlightCup,
+  CareerReunionHighlightStint,
+  CareerReunionHighlightItem,
+  CareerStashHighlightItem,
+  CareerRegularGrinderHighlightItem,
 } from "./types";
 import {
   CAREER_HIGHLIGHT_CONFIG,
@@ -617,6 +623,14 @@ const buildCareerHighlightTeams = (
   );
 };
 
+const compareCareerHighlightIdentity = (
+  left: { name: string; id: string; position: string },
+  right: { name: string; id: string; position: string },
+): number =>
+  left.name.localeCompare(right.name) ||
+  left.id.localeCompare(right.id) ||
+  left.position.localeCompare(right.position);
+
 const buildCareerTeamCountHighlightItem = (
   rows: readonly CareerHighlightRow[],
   playedOnly: boolean,
@@ -677,6 +691,207 @@ const buildCareerSameTeamHighlightItems = (
     .sort((left, right) => left.team.name.localeCompare(right.team.name));
 };
 
+const buildCareerStanleyCupHighlightCups = (
+  rows: readonly CareerHighlightRow[],
+  championSeasonKeys: ReadonlySet<string>,
+): CareerStanleyCupHighlightCup[] => {
+  const cups = new Map<string, CareerStanleyCupHighlightCup>();
+
+  for (const row of rows) {
+    if (row.reportType !== "playoffs" || row.games <= 0) continue;
+
+    const key = `${row.teamId}:${row.season}`;
+    if (!championSeasonKeys.has(key) || cups.has(key)) continue;
+
+    cups.set(key, {
+      season: row.season,
+      team: {
+        id: row.teamId,
+        name: getTeamName(row.teamId),
+      },
+    });
+  }
+
+  return [...cups.values()].sort(
+    (left, right) =>
+      left.season - right.season ||
+      left.team.name.localeCompare(right.team.name),
+  );
+};
+
+const buildCareerStanleyCupHighlightItem = (
+  rows: readonly CareerHighlightRow[],
+  championSeasonKeys: ReadonlySet<string>,
+  minCupCount: number,
+): CareerStanleyCupHighlightItem | null => {
+  const cups = buildCareerStanleyCupHighlightCups(rows, championSeasonKeys);
+  if (cups.length < minCupCount) {
+    return null;
+  }
+
+  return {
+    id: rows[0].id,
+    name: rows[0].name,
+    position: rows[0].position,
+    cupCount: cups.length,
+    cups,
+  };
+};
+
+const buildSeasonStints = (
+  seasons: ReadonlySet<number>,
+): CareerReunionHighlightStint[] => {
+  const [firstSeason, ...remainingSeasons] = [...seasons].sort(
+    (left, right) => left - right,
+  );
+  const stints: CareerReunionHighlightStint[] = [];
+  let fromSeason = firstSeason as number;
+  let previousSeason = firstSeason as number;
+
+  for (const season of remainingSeasons) {
+    if (season !== previousSeason + 1) {
+      stints.push({ fromSeason, toSeason: previousSeason });
+      fromSeason = season;
+    }
+    previousSeason = season;
+  }
+
+  stints.push({ fromSeason, toSeason: previousSeason });
+  return stints;
+};
+
+const buildCareerReunionHighlightItems = (
+  rows: readonly CareerHighlightRow[],
+  minReunionCount: number,
+): CareerReunionHighlightItem[] => {
+  const seasonsByTeam = new Map<string, Set<number>>();
+
+  for (const row of rows) {
+    const seasons = seasonsByTeam.get(row.teamId);
+    if (seasons) {
+      seasons.add(row.season);
+    } else {
+      seasonsByTeam.set(row.teamId, new Set([row.season]));
+    }
+  }
+
+  const reunionCounts = [...seasonsByTeam.entries()].map(([teamId, seasons]) => {
+    const stints = buildSeasonStints(seasons);
+    return {
+      teamId,
+      reunionCount: stints.length,
+      stints,
+    };
+  });
+  const maxReunionCount = Math.max(
+    0,
+    ...reunionCounts.map((entry) => entry.reunionCount),
+  );
+
+  if (maxReunionCount < minReunionCount) {
+    return [];
+  }
+
+  return reunionCounts
+    .filter((entry) => entry.reunionCount === maxReunionCount)
+    .map(({ teamId, reunionCount, stints }) => ({
+      id: rows[0].id,
+      name: rows[0].name,
+      position: rows[0].position,
+      reunionCount,
+      team: {
+        id: teamId,
+        name: getTeamName(teamId),
+      },
+      stints,
+    }))
+    .sort((left, right) => left.team.name.localeCompare(right.team.name));
+};
+
+const buildCareerStashHighlightItems = (
+  rows: readonly CareerHighlightRow[],
+  minStashCount: number,
+): CareerStashHighlightItem[] => {
+  const maxGamesByTeamSeason = new Map<string, number>();
+
+  for (const row of rows) {
+    const key = `${row.teamId}:${row.season}`;
+    maxGamesByTeamSeason.set(
+      key,
+      Math.max(row.games, maxGamesByTeamSeason.get(key) ?? 0),
+    );
+  }
+
+  const stashSeasonsByTeam = new Map<string, Set<number>>();
+  for (const [key, games] of maxGamesByTeamSeason.entries()) {
+    if (games !== 0) continue;
+
+    const [teamId, season] = key.split(":");
+    const seasons = stashSeasonsByTeam.get(teamId);
+    if (seasons) {
+      seasons.add(Number(season));
+    } else {
+      stashSeasonsByTeam.set(teamId, new Set([Number(season)]));
+    }
+  }
+
+  const maxSeasonCount = Math.max(
+    0,
+    ...[...stashSeasonsByTeam.values()].map((seasons) => seasons.size),
+  );
+  if (maxSeasonCount < minStashCount) {
+    return [];
+  }
+
+  return [...stashSeasonsByTeam.entries()]
+    .filter(([, seasons]) => seasons.size === maxSeasonCount)
+    .map(([teamId]) => ({
+      id: rows[0].id,
+      name: rows[0].name,
+      position: rows[0].position,
+      seasonCount: maxSeasonCount,
+      team: {
+        id: teamId,
+        name: getTeamName(teamId),
+      },
+    }))
+    .sort((left, right) => left.team.name.localeCompare(right.team.name));
+};
+
+const buildCareerRegularGrinderHighlightItem = (
+  rows: readonly CareerHighlightRow[],
+  minRegularGames: number,
+): CareerRegularGrinderHighlightItem | null => {
+  if (rows.some((row) => row.reportType === "playoffs" && row.games > 0)) {
+    return null;
+  }
+
+  const maxRegularGamesBySeason = new Map<number, number>();
+  for (const row of rows) {
+    if (row.reportType !== "regular" || row.games <= 0) continue;
+
+    maxRegularGamesBySeason.set(
+      row.season,
+      Math.max(row.games, maxRegularGamesBySeason.get(row.season) ?? 0),
+    );
+  }
+
+  const regularGames = [...maxRegularGamesBySeason.values()].reduce(
+    (sum, games) => sum + games,
+    0,
+  );
+  if (regularGames < minRegularGames) {
+    return null;
+  }
+
+  return {
+    id: rows[0].id,
+    name: rows[0].name,
+    position: rows[0].position,
+    regularGames,
+  };
+};
+
 const sortCareerTeamCountHighlightItems = (
   items: readonly CareerTeamCountHighlightItem[],
 ): CareerTeamCountHighlightItem[] =>
@@ -711,6 +926,52 @@ const sortCareerSameTeamHighlightItems = (
 
     return left.position.localeCompare(right.position);
   });
+
+const sortCareerStanleyCupHighlightItems = (
+  items: readonly CareerStanleyCupHighlightItem[],
+): CareerStanleyCupHighlightItem[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.cupCount - left.cupCount ||
+        compareCareerHighlightIdentity(left, right),
+    );
+
+const sortCareerReunionHighlightItems = (
+  items: readonly CareerReunionHighlightItem[],
+): CareerReunionHighlightItem[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.reunionCount - left.reunionCount ||
+        compareCareerHighlightIdentity(left, right) ||
+        left.team.name.localeCompare(right.team.name),
+    );
+
+const sortCareerStashHighlightItems = (
+  items: readonly CareerStashHighlightItem[],
+): CareerStashHighlightItem[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.seasonCount - left.seasonCount ||
+        compareCareerHighlightIdentity(left, right) ||
+        left.team.name.localeCompare(right.team.name),
+    );
+
+const sortCareerRegularGrinderHighlightItems = (
+  items: readonly CareerRegularGrinderHighlightItem[],
+): CareerRegularGrinderHighlightItem[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.regularGames - left.regularGames ||
+        compareCareerHighlightIdentity(left, right),
+    );
 
 export const getAvailableSeasons = async (
   teamId: string = DEFAULT_TEAM_ID,
@@ -904,7 +1165,14 @@ export const getCareerGoaliesData = async (): Promise<CareerGoalieListItem[]> =>
 
 export const getCareerHighlightsData = async (
   type: CareerHighlightType,
-): Promise<CareerTeamCountHighlightItem[] | CareerSameTeamHighlightItem[]> => {
+): Promise<
+  | CareerTeamCountHighlightItem[]
+  | CareerSameTeamHighlightItem[]
+  | CareerStanleyCupHighlightItem[]
+  | CareerReunionHighlightItem[]
+  | CareerStashHighlightItem[]
+  | CareerRegularGrinderHighlightItem[]
+> => {
   const [playerRows, goalieRows] = await Promise.all([
     getAllPlayerCareerRowsFromDb(),
     getAllGoalieCareerRowsFromDb(),
@@ -934,14 +1202,68 @@ export const getCareerHighlightsData = async (
     );
   }
 
-  return sortCareerSameTeamHighlightItems(
-    [...grouped.values()].flatMap((rows) =>
-      buildCareerSameTeamHighlightItems(
-        rows,
-        config.playedOnly,
-        config.minCount,
+  if (config.kind === "same-team-season-count") {
+    return sortCareerSameTeamHighlightItems(
+      [...grouped.values()].flatMap((rows) =>
+        buildCareerSameTeamHighlightItems(
+          rows,
+          config.playedOnly,
+          config.minCount,
+        ),
       ),
-    ),
+    );
+  }
+
+  if (config.kind === "stanley-cups") {
+    const championSeasonKeys = new Set(
+      (await getPlayoffSeasons())
+        .filter((entry) => entry.round === 5)
+        .map((entry) => `${entry.teamId}:${entry.season}`),
+    );
+
+    return sortCareerStanleyCupHighlightItems(
+      [...grouped.values()]
+        .map((rows) =>
+          buildCareerStanleyCupHighlightItem(
+            rows,
+            championSeasonKeys,
+            config.minCount,
+          ),
+        )
+        .filter(
+          (
+            item,
+          ): item is CareerStanleyCupHighlightItem => item !== null,
+        ),
+    );
+  }
+
+  if (config.kind === "reunion-count") {
+    return sortCareerReunionHighlightItems(
+      [...grouped.values()].flatMap((rows) =>
+        buildCareerReunionHighlightItems(rows, config.minCount),
+      ),
+    );
+  }
+
+  if (config.kind === "stash-count") {
+    return sortCareerStashHighlightItems(
+      [...grouped.values()].flatMap((rows) =>
+        buildCareerStashHighlightItems(rows, config.minCount),
+      ),
+    );
+  }
+
+  return sortCareerRegularGrinderHighlightItems(
+    [...grouped.values()]
+      .map((rows) =>
+        buildCareerRegularGrinderHighlightItem(rows, config.minCount),
+      )
+      .filter(
+        (
+          item,
+        ): item is CareerRegularGrinderHighlightItem => item !== null,
+      ),
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,7 +243,11 @@ export type CareerHighlightType =
   | "most-teams-played"
   | "most-teams-owned"
   | "same-team-seasons-played"
-  | "same-team-seasons-owned";
+  | "same-team-seasons-owned"
+  | "most-stanley-cups"
+  | "reunion-king"
+  | "stash-king"
+  | "regular-grinder-without-playoffs";
 
 export type CareerHighlightTeam = {
   id: string;
@@ -266,6 +270,48 @@ export type CareerSameTeamHighlightItem = {
   team: CareerHighlightTeam;
 };
 
+export type CareerStanleyCupHighlightCup = {
+  season: number;
+  team: CareerHighlightTeam;
+};
+
+export type CareerStanleyCupHighlightItem = {
+  id: string;
+  name: string;
+  position: string;
+  cupCount: number;
+  cups: CareerStanleyCupHighlightCup[];
+};
+
+export type CareerReunionHighlightStint = {
+  fromSeason: number;
+  toSeason: number;
+};
+
+export type CareerReunionHighlightItem = {
+  id: string;
+  name: string;
+  position: string;
+  reunionCount: number;
+  team: CareerHighlightTeam;
+  stints: CareerReunionHighlightStint[];
+};
+
+export type CareerStashHighlightItem = {
+  id: string;
+  name: string;
+  position: string;
+  seasonCount: number;
+  team: CareerHighlightTeam;
+};
+
+export type CareerRegularGrinderHighlightItem = {
+  id: string;
+  name: string;
+  position: string;
+  regularGames: number;
+};
+
 export type CareerTeamCountHighlightPage = {
   type: "most-teams-played" | "most-teams-owned";
   skip: number;
@@ -282,9 +328,45 @@ export type CareerSameTeamHighlightPage = {
   items: CareerSameTeamHighlightItem[];
 };
 
+export type CareerStanleyCupHighlightPage = {
+  type: "most-stanley-cups";
+  skip: number;
+  take: number;
+  total: number;
+  items: CareerStanleyCupHighlightItem[];
+};
+
+export type CareerReunionHighlightPage = {
+  type: "reunion-king";
+  skip: number;
+  take: number;
+  total: number;
+  items: CareerReunionHighlightItem[];
+};
+
+export type CareerStashHighlightPage = {
+  type: "stash-king";
+  skip: number;
+  take: number;
+  total: number;
+  items: CareerStashHighlightItem[];
+};
+
+export type CareerRegularGrinderHighlightPage = {
+  type: "regular-grinder-without-playoffs";
+  skip: number;
+  take: number;
+  total: number;
+  items: CareerRegularGrinderHighlightItem[];
+};
+
 export type CareerHighlightsPage =
   | CareerTeamCountHighlightPage
-  | CareerSameTeamHighlightPage;
+  | CareerSameTeamHighlightPage
+  | CareerStanleyCupHighlightPage
+  | CareerReunionHighlightPage
+  | CareerStashHighlightPage
+  | CareerRegularGrinderHighlightPage;
 
 export type PlayerFields =
   | "name"


### PR DESCRIPTION
## Summary
- add four new career highlights: `most-stanley-cups`, `reunion-king`, `stash-king`, and `regular-grinder-without-playoffs`
- tighten `reunion-king` threshold to 2 and add explicit `stints` ranges to its payload
- change `stash-king` to return same-team zero-game season counts instead of summing transfer stashes across teams
- update service logic, OpenAPI, README, and test coverage for the new highlight shapes

## Testing
- `npm run verify`
