### PR TITLE
Feature: Add teams to regular grinder highlights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Default workflow is a user-created branch (not `main`).
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
+- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
 - Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The API includes team-scoped season/combined leaderboards plus career endpoints 
 `/career/players`, `/career/goalies`, `/career/player/{id}`, `/career/goalie/{id}`, and `/career/highlights/{type}`.
 The highlights route supports `skip` / `take` paging and the route tokens `most-teams-played`, `most-teams-owned`, `same-team-seasons-played`, `same-team-seasons-owned`, `most-stanley-cups`, `reunion-king`, `stash-king`, and `regular-grinder-without-playoffs`.
 `reunion-king` items include stint ranges as `fromSeason` / `toSeason` pairs for each return stint.
+`regular-grinder-without-playoffs` items include the played fantasy `teams` list in addition to `regularGames`.
 Current highlight minimums are: `most-teams-played` 4, `most-teams-owned` 5, `same-team-seasons-played` 8, `same-team-seasons-owned` 10, `most-stanley-cups` 2, `reunion-king` 2, `stash-king` 10, and `regular-grinder-without-playoffs` 60.
 
 ### Viewing docs locally

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -567,7 +567,7 @@ components:
 
     CareerRegularGrinderHighlightItem:
       type: object
-      required: [id, name, position, regularGames]
+      required: [id, name, position, regularGames, teams]
       properties:
         id:
           type: string
@@ -577,6 +577,10 @@ components:
           type: string
         regularGames:
           type: integer
+        teams:
+          type: array
+          items:
+            $ref: "#/components/schemas/CareerHighlightTeam"
 
     CareerTeamCountHighlightPage:
       type: object
@@ -1552,8 +1556,8 @@ paths:
         `stash-king` returns the top same-team zero-game season counts, similar to
         `same-team-seasons-owned` but counting only team seasons where both regular and playoff
         games stayed at zero.
-        `regular-grinder-without-playoffs` returns total regular-season games for players/goalies who
-        never recorded a playoff appearance.
+        `regular-grinder-without-playoffs` returns total regular-season games plus the played fantasy teams
+        for players/goalies who never recorded a playoff appearance.
         Minimum cutoffs are 4 teams for `most-teams-played`, 5 teams for `most-teams-owned`,
         8 same-team seasons for `same-team-seasons-played`, 10 same-team seasons for
         `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunion stints for

--- a/src/__tests__/routes.integration.career.ts
+++ b/src/__tests__/routes.integration.career.ts
@@ -1260,12 +1260,17 @@ export const registerCareerRouteIntegrationTests = (): void => {
               name: "Goalie Grinder",
               position: "G",
               regularGames: 70,
+              teams: [{ id: "5", name: "Montreal Canadiens" }],
             },
             {
               id: "p-grinder",
               name: "Grinder Skater",
               position: "F",
               regularGames: 65,
+              teams: [
+                { id: "2", name: "Carolina Hurricanes" },
+                { id: "1", name: "Colorado Avalanche" },
+              ],
             },
           ],
         });

--- a/src/__tests__/services.career.list.test.ts
+++ b/src/__tests__/services.career.list.test.ts
@@ -1320,18 +1320,27 @@ describe("services", () => {
             name: "Goalie Grinder",
             position: "G",
             regularGames: 70,
+            teams: [{ id: "5", name: "Montreal Canadiens" }],
           },
           {
             id: "p-alpha-grinder",
             name: "Alpha Grinder",
             position: "D",
             regularGames: 65,
+            teams: [
+              { id: "6", name: "Detroit Red Wings" },
+              { id: "7", name: "Edmonton Oilers" },
+            ],
           },
           {
             id: "p-grinder",
             name: "Grinder Skater",
             position: "F",
             regularGames: 65,
+            teams: [
+              { id: "2", name: "Carolina Hurricanes" },
+              { id: "1", name: "Colorado Avalanche" },
+            ],
           },
         ]);
       });

--- a/src/services.ts
+++ b/src/services.ts
@@ -867,6 +867,9 @@ const buildCareerRegularGrinderHighlightItem = (
   }
 
   const maxRegularGamesBySeason = new Map<number, number>();
+  const regularPlayedRows = rows.filter(
+    (row) => row.reportType === "regular" && row.games > 0,
+  );
   for (const row of rows) {
     if (row.reportType !== "regular" || row.games <= 0) continue;
 
@@ -889,6 +892,7 @@ const buildCareerRegularGrinderHighlightItem = (
     name: rows[0].name,
     position: rows[0].position,
     regularGames,
+    teams: buildCareerHighlightTeams(regularPlayedRows),
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,7 @@ export type CareerRegularGrinderHighlightItem = {
   name: string;
   position: string;
   regularGames: number;
+  teams: CareerHighlightTeam[];
 };
 
 export type CareerTeamCountHighlightPage = {


### PR DESCRIPTION
## Summary
- add `teams` to `regular-grinder-without-playoffs` career highlight items
- build the team list from played regular-season rows using the same ordering/shape as other career highlight team lists
- update OpenAPI and README documentation for the new response field
- add service and route integration coverage for the expanded highlight payload

## Verification
- npm run verify
