### PR TITLE
Chore: Add canonical Fantrax entity registry and use it in career queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Lightweight API to serve NHL fantasy league (FFHL) team stats as JSON. Data is s
 8. Go to endpoints mentioned below
 ```
 
-**Note:** CSV files are only the import source. The API reads live data from Turso and can also serve generated JSON snapshots for read-mostly endpoints.
+**Note:** CSV files are only the import source. The API reads live data from Turso and can also serve generated JSON snapshots for read-mostly endpoints. The stats import pipeline also maintains a canonical `fantrax_entities` registry keyed by Fantrax ID so future joins can rely on a stable global player/goalie identity table.
 
 ## Endpoints
 
@@ -572,6 +572,8 @@ npm run snapshot:generate
 ## Database (Turso/SQLite)
 
 The API reads all data from a Turso (libSQL/SQLite) database. CSV files are imported into the database via the import pipeline.
+
+Stats imports also maintain a global `fantrax_entities` table with one row per Fantrax ID. Each row stores the canonical Fantrax `name`, `position`, and the `first_seen_season` / `last_seen_season` bounds derived from imported data. `npm run db:migrate` backfills this table when upgrading an older database or rebuilding an empty registry, and later `db:import:stats` runs keep it incrementally in sync with cheap UPSERTs instead of full refreshes.
 
 ### Local development
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ npm run snapshot:generate
 
 The API reads all data from a Turso (libSQL/SQLite) database. CSV files are imported into the database via the import pipeline.
 
-Stats imports also maintain a global `fantrax_entities` table with one row per Fantrax ID. Each row stores the canonical Fantrax `name`, `position`, and the `first_seen_season` / `last_seen_season` bounds derived from imported data. `npm run db:migrate` backfills this table when upgrading an older database or rebuilding an empty registry, and later `db:import:stats` runs keep it incrementally in sync with cheap UPSERTs instead of full refreshes.
+Stats imports also maintain a global `fantrax_entities` table with one row per Fantrax ID. Each row stores the canonical Fantrax `name`, `position`, and the `first_seen_season` / `last_seen_season` bounds derived from imported data. `npm run db:migrate` backfills this table when upgrading an older database or rebuilding an empty registry, and later `db:import:stats` runs keep it incrementally in sync with cheap UPSERTs instead of full refreshes. Career endpoints now prefer canonical name/position data from this registry while still aggregating season/team stats from `players` and `goalies`.
 
 ### Local development
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -134,6 +134,7 @@ npm run verify
 
 - `/teams` and `regular` / `both` season availability are derived from `src/constants.ts`, not runtime DB lookups. Only playoff season availability remains DB-backed.
 - `npm run db:migrate` - Create/update database schema and performance indexes, including career lookup indexes on `player_id` and `goalie_id`
+- `fantrax_entities` is the canonical global Fantrax identity registry (`fantrax_id`, `name`, `position`, `first_seen_season`, `last_seen_season`). `db:migrate` backfills it when upgrading an older database or rebuilding an empty registry, and `db:import:stats` keeps it current with incremental UPSERTs so import order does not change the seen-season range semantics.
 - `npm run db:pull:remote` - Replace `local.db` by pulling full schema + data from remote Turso (`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` in `.env`); creates timestamped backup in `.backups/`
 - `npm run db:backups:clean` - Remove all files under `.backups/`
 - `npm run db:import:stats` - Import all CSV files into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Regenerates API snapshots after a successful import.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -134,7 +134,7 @@ npm run verify
 
 - `/teams` and `regular` / `both` season availability are derived from `src/constants.ts`, not runtime DB lookups. Only playoff season availability remains DB-backed.
 - `npm run db:migrate` - Create/update database schema and performance indexes, including career lookup indexes on `player_id` and `goalie_id`
-- `fantrax_entities` is the canonical global Fantrax identity registry (`fantrax_id`, `name`, `position`, `first_seen_season`, `last_seen_season`). `db:migrate` backfills it when upgrading an older database or rebuilding an empty registry, and `db:import:stats` keeps it current with incremental UPSERTs so import order does not change the seen-season range semantics.
+- `fantrax_entities` is the canonical global Fantrax identity registry (`fantrax_id`, `name`, `position`, `first_seen_season`, `last_seen_season`). `db:migrate` backfills it when upgrading an older database or rebuilding an empty registry, and `db:import:stats` keeps it current with incremental UPSERTs so import order does not change the seen-season range semantics. Career queries now prefer canonical metadata from this table instead of trusting the first stats row for a player/goalie.
 - `npm run db:pull:remote` - Replace `local.db` by pulling full schema + data from remote Turso (`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` in `.env`); creates timestamped backup in `.backups/`
 - `npm run db:backups:clean` - Remove all files under `.backups/`
 - `npm run db:import:stats` - Import all CSV files into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Regenerates API snapshots after a successful import.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -137,9 +137,11 @@ src/
 └── __tests__/
     ├── auth.test.ts      # API key authentication
     ├── cache.test.ts     # Response caching & ETags
+    ├── db.schema.test.ts # Schema migration/backfill behavior for fantrax_entities
     ├── helpers.goalies.test.ts # Goalie scoring helpers
     ├── helpers.players.test.ts # Player scoring helpers
     ├── helpers.test.ts   # Shared helper utilities
+    ├── fantrax-entities.test.ts # Canonical Fantrax identity merge/upsert helpers
     ├── integration-db.ts # Temp DB + env isolation helpers for integration tests
     ├── mappings.players.test.ts # CSV-to-player transformation coverage
     ├── mappings.goalies.test.ts # CSV-to-goalie transformation coverage
@@ -156,7 +158,7 @@ src/
     └── fixtures.ts       # Shared test data
 ```
 
-Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches, route-db integration now has a dedicated suite so endpoint behavior can be validated with less internal mocking, helper scoring coverage is split by skaters/goalies while season-availability behavior rides on the route integration suite, transaction helper coverage pins down season/file naming and Fantrax history URL generation, service-unit coverage is split by season/combined, career, and leaderboard behavior, mapping coverage stays focused on CSV player/goalie transforms, and query coverage is split by roster/career/results responsibilities so the larger suites stay readable without reasserting every live route happy path.
+Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches, route-db integration now has a dedicated suite so endpoint behavior can be validated with less internal mocking, helper scoring coverage is split by skaters/goalies while season-availability behavior rides on the route integration suite, canonical Fantrax identity behavior is split between helper-level merge/upsert tests and a DB-backed schema migration suite, transaction helper coverage pins down season/file naming and Fantrax history URL generation, service-unit coverage is split by season/combined, career, and leaderboard behavior, mapping coverage stays focused on CSV player/goalie transforms, and query coverage is split by roster/career/results responsibilities so the larger suites stay readable without reasserting every live route happy path.
 
 ---
 

--- a/scripts/db-migrate.ts
+++ b/scripts/db-migrate.ts
@@ -16,10 +16,13 @@ const main = async () => {
 
   console.log("✅ Migration complete!");
   console.log(
-    "   Tables: players, goalies, import_metadata, playoff_results, regular_results",
+    "   Tables: players, goalies, fantrax_entities, import_metadata, playoff_results, regular_results",
   );
   console.log(
-    "   Indexes: idx_players_lookup, idx_goalies_lookup, idx_players_career_id, idx_goalies_career_id, idx_players_name, idx_goalies_name, idx_playoff_results_season, idx_regular_results_season",
+    "   Indexes: idx_players_lookup, idx_goalies_lookup, idx_players_career_id, idx_goalies_career_id, idx_players_name, idx_goalies_name, idx_fantrax_entities_name, idx_fantrax_entities_position, idx_playoff_results_season, idx_regular_results_season",
+  );
+  console.log(
+    "   Fantrax entity backfill runs only when upgrading an older schema or rebuilding an empty registry",
   );
 };
 

--- a/scripts/import-stats-to-db.ts
+++ b/scripts/import-stats-to-db.ts
@@ -17,6 +17,10 @@ import os from "os";
 import { spawnSync } from "child_process";
 import csv from "csvtojson";
 import { TEAMS, CURRENT_SEASON } from "../src/constants";
+import {
+  buildFantraxEntityUpsertStatements,
+  collectFantraxEntitiesFromStats,
+} from "../src/fantrax-entities";
 import { mapPlayerData, mapGoalieData } from "../src/mappings";
 import { getDbClient } from "../src/db/client";
 import type { InStatement } from "@libsql/client";
@@ -73,6 +77,7 @@ const main = async () => {
   let errors = 0;
   let skippedPlayersMissingId = 0;
   let skippedGoaliesMissingId = 0;
+  let totalFantraxEntitiesSynced = 0;
   const missingIdMessages: string[] = [];
 
   for (const team of TEAMS) {
@@ -135,6 +140,10 @@ const main = async () => {
         const goaliesMissingId = goalies.filter((g) => !g.id).length;
         const playersToImport = players.filter((p) => p.id);
         const goaliesToImport = goalies.filter((g) => g.id);
+        const fantraxEntities = collectFantraxEntitiesFromStats({
+          players: playersToImport,
+          goalies: goaliesToImport,
+        });
 
         if (playersMissingId > 0 || goaliesMissingId > 0) {
           missingIdMessages.push(
@@ -147,11 +156,12 @@ const main = async () => {
 
         if (dryRun) {
           console.log(
-            `  🔍 Would import: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`,
+            `  🔍 Would import: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies, ${fantraxEntities.length} Fantrax entities)`,
           );
         } else {
           // Build batch: delete existing + insert all rows atomically
           const statements: InStatement[] = [
+            ...buildFantraxEntityUpsertStatements(fantraxEntities),
             {
               sql: "DELETE FROM players WHERE team_id = ? AND season = ? AND report_type = ?",
               args: [team.id, season, reportType],
@@ -217,12 +227,13 @@ const main = async () => {
           await db.batch(statements, "write");
 
           console.log(
-            `  ✅ Imported: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies)`,
+            `  ✅ Imported: ${file} (${playersToImport.length} players, ${goaliesToImport.length} goalies, ${fantraxEntities.length} Fantrax entities)`,
           );
         }
 
         totalPlayers += playersToImport.length;
         totalGoalies += goaliesToImport.length;
+        totalFantraxEntitiesSynced += fantraxEntities.length;
         totalFiles++;
       } catch (error) {
         console.error(`  ❌ Error importing ${file}:`, error);
@@ -257,6 +268,7 @@ const main = async () => {
   console.log(`   Files processed: ${totalFiles}`);
   console.log(`   Players imported: ${totalPlayers}`);
   console.log(`   Goalies imported: ${totalGoalies}`);
+  console.log(`   Fantrax entities synced: ${totalFantraxEntitiesSynced}`);
   console.log(`   Errors: ${errors}`);
   console.log(
     `   Rows skipped (missing IDs): players=${skippedPlayersMissingId}, goalies=${skippedGoaliesMissingId}`,

--- a/src/__tests__/db.schema.test.ts
+++ b/src/__tests__/db.schema.test.ts
@@ -1,0 +1,269 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { createClient, type Client } from "@libsql/client";
+
+import { migrateDb } from "../db/schema";
+
+const LEGACY_SCHEMA_SQL = [
+  `CREATE TABLE IF NOT EXISTS players (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id TEXT NOT NULL,
+    season INTEGER NOT NULL,
+    report_type TEXT NOT NULL,
+    player_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    position TEXT,
+    games INTEGER NOT NULL DEFAULT 0,
+    goals INTEGER NOT NULL DEFAULT 0,
+    assists INTEGER NOT NULL DEFAULT 0,
+    points INTEGER NOT NULL DEFAULT 0,
+    plus_minus INTEGER NOT NULL DEFAULT 0,
+    penalties INTEGER NOT NULL DEFAULT 0,
+    shots INTEGER NOT NULL DEFAULT 0,
+    ppp INTEGER NOT NULL DEFAULT 0,
+    shp INTEGER NOT NULL DEFAULT 0,
+    hits INTEGER NOT NULL DEFAULT 0,
+    blocks INTEGER NOT NULL DEFAULT 0
+  )`,
+  `CREATE TABLE IF NOT EXISTS goalies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id TEXT NOT NULL,
+    season INTEGER NOT NULL,
+    report_type TEXT NOT NULL,
+    goalie_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    games INTEGER NOT NULL DEFAULT 0,
+    wins INTEGER NOT NULL DEFAULT 0,
+    saves INTEGER NOT NULL DEFAULT 0,
+    shutouts INTEGER NOT NULL DEFAULT 0,
+    goals INTEGER NOT NULL DEFAULT 0,
+    assists INTEGER NOT NULL DEFAULT 0,
+    points INTEGER NOT NULL DEFAULT 0,
+    penalties INTEGER NOT NULL DEFAULT 0,
+    ppp INTEGER NOT NULL DEFAULT 0,
+    shp INTEGER NOT NULL DEFAULT 0,
+    gaa REAL,
+    save_percent REAL
+  )`,
+  `CREATE TABLE IF NOT EXISTS import_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  )`,
+] as const;
+
+type FantraxEntityRow = {
+  fantrax_id: string;
+  name: string;
+  position: string | null;
+  first_seen_season: number;
+  last_seen_season: number;
+};
+
+const createLegacyDb = async (): Promise<{
+  db: Client;
+  cleanup: () => Promise<void>;
+}> => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ffhl-schema-test-"));
+  const dbPath = path.join(tempDir, "schema.db");
+  const db = createClient({ url: `file:${dbPath}` });
+
+  for (const sql of LEGACY_SCHEMA_SQL) {
+    await db.execute(sql);
+  }
+
+  return {
+    db,
+    cleanup: async () => {
+      (db as unknown as { close?: () => void }).close?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    },
+  };
+};
+
+describe("db schema migration", () => {
+  test("backfills fantrax entities from existing stats tables and can rebuild an empty registry", async () => {
+    const { db, cleanup } = await createLegacyDb();
+
+    try {
+      await db.execute({
+        sql: `INSERT INTO players (
+                team_id, season, report_type, player_id, name, position
+              ) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["1", 2024, "regular", "p001", "Latest Skater", "F"],
+      });
+      await db.execute({
+        sql: `INSERT INTO players (
+                team_id, season, report_type, player_id, name, position
+              ) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["2", 2012, "playoffs", "p001", "Older Typo", "D"],
+      });
+      await db.execute({
+        sql: `INSERT INTO players (
+                team_id, season, report_type, player_id, name, position
+              ) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["3", 2020, "regular", "p002", "No Position", null],
+      });
+      await db.execute({
+        sql: `INSERT INTO goalies (
+                team_id, season, report_type, goalie_id, name
+              ) VALUES (?, ?, ?, ?, ?)`,
+        args: ["1", 2018, "regular", "g001", "Goalie Prime"],
+      });
+
+      await migrateDb(db);
+
+      let result = await db.execute(
+        `SELECT fantrax_id, name, position, first_seen_season, last_seen_season
+         FROM fantrax_entities
+         ORDER BY fantrax_id ASC`,
+      );
+
+      expect(result.rows).toEqual<FantraxEntityRow[]>([
+        {
+          fantrax_id: "g001",
+          name: "Goalie Prime",
+          position: "G",
+          first_seen_season: 2018,
+          last_seen_season: 2018,
+        },
+        {
+          fantrax_id: "p001",
+          name: "Latest Skater",
+          position: "F",
+          first_seen_season: 2012,
+          last_seen_season: 2024,
+        },
+        {
+          fantrax_id: "p002",
+          name: "No Position",
+          position: null,
+          first_seen_season: 2020,
+          last_seen_season: 2020,
+        },
+      ]);
+
+      await db.execute({
+        sql: `INSERT INTO players (
+                team_id, season, report_type, player_id, name, position
+              ) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: ["4", 2025, "regular", "p001", "Newest Skater", "D"],
+      });
+      await db.execute({
+        sql: `INSERT INTO goalies (
+                team_id, season, report_type, goalie_id, name
+              ) VALUES (?, ?, ?, ?, ?)`,
+        args: ["5", 2016, "regular", "g001", "Older Goalie Name"],
+      });
+      await db.execute("DELETE FROM fantrax_entities");
+
+      await migrateDb(db);
+
+      result = await db.execute(
+        `SELECT fantrax_id, name, position, first_seen_season, last_seen_season
+         FROM fantrax_entities
+         ORDER BY fantrax_id ASC`,
+      );
+
+      expect(result.rows).toEqual<FantraxEntityRow[]>([
+        {
+          fantrax_id: "g001",
+          name: "Goalie Prime",
+          position: "G",
+          first_seen_season: 2016,
+          last_seen_season: 2018,
+        },
+        {
+          fantrax_id: "p001",
+          name: "Newest Skater",
+          position: "D",
+          first_seen_season: 2012,
+          last_seen_season: 2025,
+        },
+        {
+          fantrax_id: "p002",
+          name: "No Position",
+          position: null,
+          first_seen_season: 2020,
+          last_seen_season: 2020,
+        },
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("skips the fantrax entity backfill on repeated migrate when registry already exists", async () => {
+    const execute = jest.fn(async (statement: string | { sql: string }) => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+
+      if (sql === "SELECT value FROM import_metadata WHERE key = ?") {
+        return { rows: [{ value: "5" }] };
+      }
+
+      if (sql === "SELECT COUNT(*) AS count FROM fantrax_entities") {
+        return { rows: [{ count: 3 }] };
+      }
+
+      return { rows: [] };
+    });
+
+    await migrateDb({ execute: execute as unknown as Client["execute"] });
+
+    const executedSql = execute.mock.calls.map(([statement]) =>
+      typeof statement === "string" ? statement : statement.sql,
+    );
+
+    expect(
+      executedSql.some(
+        (sql) =>
+          sql.includes("INSERT INTO fantrax_entities") &&
+          sql.includes("FROM players p"),
+      ),
+    ).toBe(false);
+    expect(
+      executedSql.some(
+        (sql) =>
+          sql.includes("INSERT INTO fantrax_entities") &&
+          sql.includes("FROM goalies g"),
+      ),
+    ).toBe(false);
+  });
+
+  test("rebuilds fantrax entities when the current schema exists but the registry is empty", async () => {
+    const execute = jest.fn(async (statement: string | { sql: string }) => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+
+      if (sql === "SELECT value FROM import_metadata WHERE key = ?") {
+        return { rows: [{ value: "5" }] };
+      }
+
+      if (sql === "SELECT COUNT(*) AS count FROM fantrax_entities") {
+        return { rows: [{ count: 0 }] };
+      }
+
+      return { rows: [] };
+    });
+
+    await migrateDb({ execute: execute as unknown as Client["execute"] });
+
+    const executedSql = execute.mock.calls.map(([statement]) =>
+      typeof statement === "string" ? statement : statement.sql,
+    );
+
+    expect(
+      executedSql.some(
+        (sql) =>
+          sql.includes("INSERT INTO fantrax_entities") &&
+          sql.includes("FROM players p"),
+      ),
+    ).toBe(true);
+    expect(
+      executedSql.some(
+        (sql) =>
+          sql.includes("INSERT INTO fantrax_entities") &&
+          sql.includes("FROM goalies g"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/fantrax-entities.test.ts
+++ b/src/__tests__/fantrax-entities.test.ts
@@ -1,0 +1,258 @@
+import {
+  buildFantraxEntityUpsertStatements,
+  collectFantraxEntitiesFromStats,
+} from "../fantrax-entities";
+import { createGoalie, createPlayer } from "./fixtures";
+
+describe("fantrax entity helpers", () => {
+  describe("collectFantraxEntitiesFromStats", () => {
+    test("collects unique player and goalie identities and skips missing ids", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p001",
+              name: "Skater One",
+              position: "F",
+            }),
+            season: 2025,
+          },
+          {
+            ...createPlayer({
+              id: "",
+              name: "Missing Id",
+              position: "D",
+            }),
+            season: 2025,
+          },
+        ],
+        goalies: [
+          {
+            ...createGoalie({
+              id: "g001",
+              name: "Goalie One",
+            }),
+            season: 2025,
+          },
+          {
+            ...createGoalie({
+              id: "",
+              name: "Missing Goalie Id",
+            }),
+            season: 2025,
+          },
+        ],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "g001",
+          name: "Goalie One",
+          position: "G",
+          firstSeenSeason: 2025,
+          lastSeenSeason: 2025,
+        },
+        {
+          fantraxId: "p001",
+          name: "Skater One",
+          position: "F",
+          firstSeenSeason: 2025,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+
+    test("keeps the latest season as canonical while widening seen-season bounds", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p001",
+              name: "Older Typo",
+              position: "D",
+            }),
+            season: 2014,
+          },
+          {
+            ...createPlayer({
+              id: "p001",
+              name: "Latest Name",
+              position: "F",
+            }),
+            season: 2025,
+          },
+        ],
+        goalies: [],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "p001",
+          name: "Latest Name",
+          position: "F",
+          firstSeenSeason: 2014,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+
+    test("fills a missing latest-season position from older known data", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p002",
+              name: "Position Pending",
+            }),
+            season: 2025,
+          },
+          {
+            ...createPlayer({
+              id: "p002",
+              name: "Position Pending",
+              position: "D",
+            }),
+            season: 2024,
+          },
+        ],
+        goalies: [],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "p002",
+          name: "Position Pending",
+          position: "D",
+          firstSeenSeason: 2024,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+
+    test("promotes a newer season to canonical data while preserving known position", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p003",
+              name: "Older Name",
+              position: "F",
+            }),
+            season: 2023,
+          },
+          {
+            ...createPlayer({
+              id: "p003",
+              name: "Corrected Latest Name",
+            }),
+            season: 2025,
+          },
+        ],
+        goalies: [],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "p003",
+          name: "Corrected Latest Name",
+          position: "F",
+          firstSeenSeason: 2023,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+
+    test("keeps position null when no season has a known position", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p004",
+              name: "Still Unknown",
+            }),
+            season: 2025,
+          },
+          {
+            ...createPlayer({
+              id: "p004",
+              name: "Still Unknown",
+            }),
+            season: 2024,
+          },
+        ],
+        goalies: [],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "p004",
+          name: "Still Unknown",
+          position: null,
+          firstSeenSeason: 2024,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+
+    test("keeps canonical position null when a newer season still has no known position", () => {
+      const entities = collectFantraxEntitiesFromStats({
+        players: [
+          {
+            ...createPlayer({
+              id: "p005",
+              name: "Unknown Forever",
+            }),
+            season: 2024,
+          },
+          {
+            ...createPlayer({
+              id: "p005",
+              name: "Unknown Forever",
+            }),
+            season: 2025,
+          },
+        ],
+        goalies: [],
+      });
+
+      expect(entities).toEqual([
+        {
+          fantraxId: "p005",
+          name: "Unknown Forever",
+          position: null,
+          firstSeenSeason: 2024,
+          lastSeenSeason: 2025,
+        },
+      ]);
+    });
+  });
+
+  describe("buildFantraxEntityUpsertStatements", () => {
+    test("builds one upsert statement per entity", () => {
+      const statements = buildFantraxEntityUpsertStatements([
+        {
+          fantraxId: "p001",
+          name: "Skater One",
+          position: "F",
+          firstSeenSeason: 2012,
+          lastSeenSeason: 2025,
+        },
+      ]);
+
+      expect(statements).toEqual([
+        {
+          sql: expect.stringContaining(
+            "ON CONFLICT(fantrax_id) DO UPDATE SET",
+          ),
+          args: ["p001", "Skater One", "F", 2012, 2025],
+        },
+      ]);
+      const [statement] = statements;
+      if (typeof statement === "string") {
+        throw new Error("Expected object-style upsert statement.");
+      }
+      expect(String(statement.sql)).toContain("first_seen_season");
+      expect(String(statement.sql)).toContain("last_seen_season");
+    });
+  });
+});

--- a/src/__tests__/integration-db.ts
+++ b/src/__tests__/integration-db.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import type { Client } from "@libsql/client";
+import { buildFantraxEntityUpsertStatements } from "../fantrax-entities";
 import { getDbClient, resetDbClientForTests } from "../db/client";
 import { migrateDb } from "../db/schema";
 import { resetRouteCachesForTests } from "../routes";
@@ -117,6 +118,16 @@ export const createIntegrationDb = async (): Promise<IntegrationDbContext> => {
     }
   };
 
+  const syncFantraxEntities = async (
+    statements: ReadonlyArray<
+      ReturnType<typeof buildFantraxEntityUpsertStatements>[number]
+    >,
+  ): Promise<void> => {
+    for (const statement of statements) {
+      await db.execute(statement);
+    }
+  };
+
   return {
     db,
     snapshotDir,
@@ -148,6 +159,21 @@ export const createIntegrationDb = async (): Promise<IntegrationDbContext> => {
           ],
         });
       }
+
+      await syncFantraxEntities(
+        buildFantraxEntityUpsertStatements(
+          rows.map((row) => ({
+            fantraxId: row.playerId,
+            name: row.name,
+            position:
+              row.position === "F" || row.position === "D"
+                ? row.position
+                : null,
+            firstSeenSeason: row.season,
+            lastSeenSeason: row.season,
+          })),
+        ),
+      );
     },
     insertGoalies: async (rows) => {
       for (const row of rows) {
@@ -177,6 +203,18 @@ export const createIntegrationDb = async (): Promise<IntegrationDbContext> => {
           ],
         });
       }
+
+      await syncFantraxEntities(
+        buildFantraxEntityUpsertStatements(
+          rows.map((row) => ({
+            fantraxId: row.goalieId,
+            name: row.name,
+            position: "G",
+            firstSeenSeason: row.season,
+            lastSeenSeason: row.season,
+          })),
+        ),
+      );
     },
     insertPlayoffResults: async (rows) => {
       for (const row of rows) {

--- a/src/__tests__/queries.career.test.ts
+++ b/src/__tests__/queries.career.test.ts
@@ -56,8 +56,20 @@ describe("db/queries", () => {
           args: ["p001"],
         });
         expect(mockExecute).toHaveBeenCalledWith({
+          sql: expect.stringContaining("LEFT JOIN fantrax_entities fe"),
+          args: ["p001"],
+        });
+        expect(mockExecute).toHaveBeenCalledWith({
+          sql: expect.stringContaining("COALESCE(fe.name, p.name) AS name"),
+          args: ["p001"],
+        });
+        expect(mockExecute).toHaveBeenCalledWith({
+          sql: expect.stringContaining("COALESCE(fe.position, p.position) AS position"),
+          args: ["p001"],
+        });
+        expect(mockExecute).toHaveBeenCalledWith({
           sql: expect.stringContaining(
-            "CASE report_type WHEN 'regular' THEN 0 ELSE 1 END",
+            "CASE p.report_type WHEN 'regular' THEN 0 ELSE 1 END",
           ),
           args: ["p001"],
         });
@@ -106,8 +118,16 @@ describe("db/queries", () => {
           args: ["g001"],
         });
         expect(mockExecute).toHaveBeenCalledWith({
+          sql: expect.stringContaining("LEFT JOIN fantrax_entities fe"),
+          args: ["g001"],
+        });
+        expect(mockExecute).toHaveBeenCalledWith({
+          sql: expect.stringContaining("COALESCE(fe.name, g.name) AS name"),
+          args: ["g001"],
+        });
+        expect(mockExecute).toHaveBeenCalledWith({
           sql: expect.stringContaining(
-            "CASE report_type WHEN 'regular' THEN 0 ELSE 1 END",
+            "CASE g.report_type WHEN 'regular' THEN 0 ELSE 1 END",
           ),
           args: ["g001"],
         });
@@ -155,6 +175,12 @@ describe("db/queries", () => {
           expect.not.stringContaining("games > 0"),
         );
         expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("LEFT JOIN fantrax_entities fe"),
+        );
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("COALESCE(fe.name, p.name) AS name"),
+        );
+        expect(mockExecute).toHaveBeenCalledWith(
           expect.stringContaining("ORDER BY name ASC"),
         );
         expect(result).toEqual(rows);
@@ -193,6 +219,12 @@ describe("db/queries", () => {
 
         expect(mockExecute).toHaveBeenCalledWith(
           expect.not.stringContaining("games > 0"),
+        );
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("LEFT JOIN fantrax_entities fe"),
+        );
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("COALESCE(fe.name, g.name) AS name"),
         );
         expect(mockExecute).toHaveBeenCalledWith(
           expect.stringContaining("ORDER BY name ASC"),

--- a/src/__tests__/routes.integration.career.ts
+++ b/src/__tests__/routes.integration.career.ts
@@ -148,6 +148,68 @@ export const registerCareerRouteIntegrationTests = (): void => {
       }
     });
 
+    test("prefers canonical fantrax entity metadata for career player routes", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertPlayers([
+          {
+            teamId: "1",
+            season: 2024,
+            reportType: "regular",
+            playerId: "p-canonical",
+            name: "Typo Skater",
+            position: null,
+            games: 3,
+            goals: 1,
+            assists: 1,
+            points: 2,
+          },
+        ]);
+        await db.db.execute({
+          sql: "UPDATE fantrax_entities SET name = ?, position = ? WHERE fantrax_id = ?",
+          args: ["Canonical Skater", "D", "p-canonical"],
+        });
+
+        const detailReq = createRequest({
+          method: "GET",
+          url: "/career/player/p-canonical",
+          params: { id: "p-canonical" },
+        });
+        const detailRes = createResponse();
+
+        await getCareerPlayer(asRouteReq<CareerPlayerReq>(detailReq), detailRes);
+
+        expect(detailRes.statusCode).toBe(HTTP_STATUS.OK);
+        expect(getJsonBody<Record<string, unknown>>(detailRes)).toEqual(
+          expect.objectContaining({
+            id: "p-canonical",
+            name: "Canonical Skater",
+            position: "D",
+          }),
+        );
+
+        const listReq = createRequest({
+          method: "GET",
+          url: "/career/players",
+        });
+        const listRes = createResponse();
+
+        await getCareerPlayers(asRouteReq<CareerPlayersReq>(listReq), listRes);
+
+        expect(listRes.statusCode).toBe(HTTP_STATUS.OK);
+        expect(getJsonBody<Array<Record<string, unknown>>>(listRes)).toEqual([
+          expect.objectContaining({
+            id: "p-canonical",
+            name: "Canonical Skater",
+            position: "D",
+          }),
+        ]);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
     test("returns career player list data from the live DB", async () => {
       const db = await createIntegrationDb();
 
@@ -340,6 +402,64 @@ export const registerCareerRouteIntegrationTests = (): void => {
         expect(res.statusCode).toBe(HTTP_STATUS.NOT_FOUND);
         expect(res._getData()).toBe("Goalie not found");
         expect(res.getHeader("cache-control")).toBe("private, no-store");
+      } finally {
+        await db.cleanup();
+      }
+    });
+
+    test("prefers canonical fantrax entity metadata for career goalie routes", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await db.insertGoalies([
+          {
+            teamId: "1",
+            season: 2024,
+            reportType: "regular",
+            goalieId: "g-canonical",
+            name: "Typo Goalie",
+            games: 4,
+            wins: 2,
+            saves: 120,
+          },
+        ]);
+        await db.db.execute({
+          sql: "UPDATE fantrax_entities SET name = ? WHERE fantrax_id = ?",
+          args: ["Canonical Goalie", "g-canonical"],
+        });
+
+        const detailReq = createRequest({
+          method: "GET",
+          url: "/career/goalie/g-canonical",
+          params: { id: "g-canonical" },
+        });
+        const detailRes = createResponse();
+
+        await getCareerGoalie(asRouteReq<CareerGoalieReq>(detailReq), detailRes);
+
+        expect(detailRes.statusCode).toBe(HTTP_STATUS.OK);
+        expect(getJsonBody<Record<string, unknown>>(detailRes)).toEqual(
+          expect.objectContaining({
+            id: "g-canonical",
+            name: "Canonical Goalie",
+          }),
+        );
+
+        const listReq = createRequest({
+          method: "GET",
+          url: "/career/goalies",
+        });
+        const listRes = createResponse();
+
+        await getCareerGoalies(asRouteReq<CareerGoaliesReq>(listReq), listRes);
+
+        expect(listRes.statusCode).toBe(HTTP_STATUS.OK);
+        expect(getJsonBody<Array<Record<string, unknown>>>(listRes)).toEqual([
+          expect.objectContaining({
+            id: "g-canonical",
+            name: "Canonical Goalie",
+          }),
+        ]);
       } finally {
         await db.cleanup();
       }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -162,13 +162,29 @@ export const getPlayerCareerRowsFromDb = async (
 ): Promise<PlayerCareerRow[]> => {
   const db = getDbClient();
   const result = await db.execute({
-    sql: `SELECT player_id, name, position, team_id, season, report_type, games, goals, assists, points,
-                 plus_minus, penalties, shots, ppp, shp, hits, blocks
-          FROM players
-          WHERE player_id = ?
-          ORDER BY season DESC,
-                   team_id ASC,
-                   CASE report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
+    sql: `SELECT p.player_id,
+                 COALESCE(fe.name, p.name) AS name,
+                 COALESCE(fe.position, p.position) AS position,
+                 p.team_id,
+                 p.season,
+                 p.report_type,
+                 p.games,
+                 p.goals,
+                 p.assists,
+                 p.points,
+                 p.plus_minus,
+                 p.penalties,
+                 p.shots,
+                 p.ppp,
+                 p.shp,
+                 p.hits,
+                 p.blocks
+          FROM players p
+          LEFT JOIN fantrax_entities fe ON fe.fantrax_id = p.player_id
+          WHERE p.player_id = ?
+          ORDER BY p.season DESC,
+                   p.team_id ASC,
+                   CASE p.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
     args: [playerId],
   });
   return castRows<PlayerCareerRow>(result.rows);
@@ -179,13 +195,29 @@ export const getGoalieCareerRowsFromDb = async (
 ): Promise<GoalieCareerRow[]> => {
   const db = getDbClient();
   const result = await db.execute({
-    sql: `SELECT goalie_id, name, team_id, season, report_type, games, wins, saves, shutouts,
-                 goals, assists, points, penalties, ppp, shp, gaa, save_percent
-          FROM goalies
-          WHERE goalie_id = ?
-          ORDER BY season DESC,
-                   team_id ASC,
-                   CASE report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
+    sql: `SELECT g.goalie_id,
+                 COALESCE(fe.name, g.name) AS name,
+                 g.team_id,
+                 g.season,
+                 g.report_type,
+                 g.games,
+                 g.wins,
+                 g.saves,
+                 g.shutouts,
+                 g.goals,
+                 g.assists,
+                 g.points,
+                 g.penalties,
+                 g.ppp,
+                 g.shp,
+                 g.gaa,
+                 g.save_percent
+          FROM goalies g
+          LEFT JOIN fantrax_entities fe ON fe.fantrax_id = g.goalie_id
+          WHERE g.goalie_id = ?
+          ORDER BY g.season DESC,
+                   g.team_id ASC,
+                   CASE g.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
     args: [goalieId],
   });
   return castRows<GoalieCareerRow>(result.rows);
@@ -194,11 +226,27 @@ export const getGoalieCareerRowsFromDb = async (
 export const getAllPlayerCareerRowsFromDb = async (): Promise<PlayerCareerRow[]> => {
   const db = getDbClient();
   const result = await db.execute(
-    `SELECT player_id, name, position, team_id, season, report_type, games, goals, assists, points,
-            plus_minus, penalties, shots, ppp, shp, hits, blocks
-     FROM players
-     ORDER BY name ASC, player_id ASC, season DESC, team_id ASC,
-              CASE report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
+    `SELECT p.player_id,
+            COALESCE(fe.name, p.name) AS name,
+            COALESCE(fe.position, p.position) AS position,
+            p.team_id,
+            p.season,
+            p.report_type,
+            p.games,
+            p.goals,
+            p.assists,
+            p.points,
+            p.plus_minus,
+            p.penalties,
+            p.shots,
+            p.ppp,
+            p.shp,
+            p.hits,
+            p.blocks
+     FROM players p
+     LEFT JOIN fantrax_entities fe ON fe.fantrax_id = p.player_id
+     ORDER BY name ASC, p.player_id ASC, p.season DESC, p.team_id ASC,
+              CASE p.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
   );
   return castRows<PlayerCareerRow>(result.rows);
 };
@@ -206,11 +254,27 @@ export const getAllPlayerCareerRowsFromDb = async (): Promise<PlayerCareerRow[]>
 export const getAllGoalieCareerRowsFromDb = async (): Promise<GoalieCareerRow[]> => {
   const db = getDbClient();
   const result = await db.execute(
-    `SELECT goalie_id, name, team_id, season, report_type, games, wins, saves, shutouts,
-            goals, assists, points, penalties, ppp, shp, gaa, save_percent
-     FROM goalies
-     ORDER BY name ASC, goalie_id ASC, season DESC, team_id ASC,
-              CASE report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
+    `SELECT g.goalie_id,
+            COALESCE(fe.name, g.name) AS name,
+            g.team_id,
+            g.season,
+            g.report_type,
+            g.games,
+            g.wins,
+            g.saves,
+            g.shutouts,
+            g.goals,
+            g.assists,
+            g.points,
+            g.penalties,
+            g.ppp,
+            g.shp,
+            g.gaa,
+            g.save_percent
+     FROM goalies g
+     LEFT JOIN fantrax_entities fe ON fe.fantrax_id = g.goalie_id
+     ORDER BY name ASC, g.goalie_id ASC, g.season DESC, g.team_id ASC,
+              CASE g.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC`,
   );
   return castRows<GoalieCareerRow>(result.rows);
 };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@libsql/client";
 
-const DB_SCHEMA_VERSION = "4";
+const DB_SCHEMA_VERSION = "5";
+const FANTRAX_ENTITIES_SCHEMA_VERSION = 5;
 
 const SCHEMA_SQL = [
   `CREATE TABLE IF NOT EXISTS players (
@@ -43,6 +44,14 @@ const SCHEMA_SQL = [
     gaa REAL,
     save_percent REAL
   )`,
+  `CREATE TABLE IF NOT EXISTS fantrax_entities (
+    fantrax_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    position TEXT,
+    first_seen_season INTEGER NOT NULL,
+    last_seen_season INTEGER NOT NULL,
+    CHECK (position IN ('F', 'D', 'G') OR position IS NULL)
+  )`,
   `CREATE TABLE IF NOT EXISTS import_metadata (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -55,6 +64,10 @@ const SCHEMA_SQL = [
     ON goalies(goalie_id, season DESC, team_id, report_type)`,
   `CREATE INDEX IF NOT EXISTS idx_players_name ON players(name)`,
   `CREATE INDEX IF NOT EXISTS idx_goalies_name ON goalies(name)`,
+  `CREATE INDEX IF NOT EXISTS idx_fantrax_entities_name
+    ON fantrax_entities(name)`,
+  `CREATE INDEX IF NOT EXISTS idx_fantrax_entities_position
+    ON fantrax_entities(position)`,
   `CREATE TABLE IF NOT EXISTS playoff_results (
     id      INTEGER PRIMARY KEY AUTOINCREMENT,
     team_id TEXT    NOT NULL,
@@ -81,11 +94,147 @@ const SCHEMA_SQL = [
   `CREATE INDEX IF NOT EXISTS idx_regular_results_season ON regular_results(season)`,
 ] as const;
 
+const FANTRAX_ENTITIES_BACKFILL_SQL = [
+  `INSERT INTO fantrax_entities (
+      fantrax_id,
+      name,
+      position,
+      first_seen_season,
+      last_seen_season
+    )
+    SELECT
+      p.player_id,
+      COALESCE(
+        (
+          SELECT p2.name
+          FROM players p2
+          WHERE p2.player_id = p.player_id
+            AND NULLIF(TRIM(p2.name), '') IS NOT NULL
+          ORDER BY p2.season DESC,
+                   CASE p2.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC,
+                   p2.team_id ASC
+          LIMIT 1
+        ),
+        MIN(p.name)
+      ),
+      (
+        SELECT NULLIF(TRIM(p2.position), '')
+        FROM players p2
+        WHERE p2.player_id = p.player_id
+          AND NULLIF(TRIM(p2.position), '') IS NOT NULL
+        ORDER BY p2.season DESC,
+                 CASE p2.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC,
+                 p2.team_id ASC
+        LIMIT 1
+      ),
+      MIN(p.season),
+      MAX(p.season)
+    FROM players p
+    WHERE NULLIF(TRIM(p.player_id), '') IS NOT NULL
+    GROUP BY p.player_id
+    ON CONFLICT(fantrax_id) DO UPDATE SET
+      first_seen_season = MIN(fantrax_entities.first_seen_season, excluded.first_seen_season),
+      last_seen_season = MAX(fantrax_entities.last_seen_season, excluded.last_seen_season),
+      name = CASE
+        WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+          THEN excluded.name
+        ELSE fantrax_entities.name
+      END,
+      position = CASE
+        WHEN fantrax_entities.position IS NULL AND excluded.position IS NOT NULL
+          THEN excluded.position
+        WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+          THEN COALESCE(excluded.position, fantrax_entities.position)
+        ELSE fantrax_entities.position
+      END`,
+  `INSERT INTO fantrax_entities (
+      fantrax_id,
+      name,
+      position,
+      first_seen_season,
+      last_seen_season
+    )
+    SELECT
+      g.goalie_id,
+      COALESCE(
+        (
+          SELECT g2.name
+          FROM goalies g2
+          WHERE g2.goalie_id = g.goalie_id
+            AND NULLIF(TRIM(g2.name), '') IS NOT NULL
+          ORDER BY g2.season DESC,
+                   CASE g2.report_type WHEN 'regular' THEN 0 ELSE 1 END ASC,
+                   g2.team_id ASC
+          LIMIT 1
+        ),
+        MIN(g.name)
+      ),
+      'G',
+      MIN(g.season),
+      MAX(g.season)
+    FROM goalies g
+    WHERE NULLIF(TRIM(g.goalie_id), '') IS NOT NULL
+    GROUP BY g.goalie_id
+    ON CONFLICT(fantrax_id) DO UPDATE SET
+      first_seen_season = MIN(fantrax_entities.first_seen_season, excluded.first_seen_season),
+      last_seen_season = MAX(fantrax_entities.last_seen_season, excluded.last_seen_season),
+      name = CASE
+        WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+          THEN excluded.name
+        ELSE fantrax_entities.name
+      END,
+      position = CASE
+        WHEN fantrax_entities.position IS NULL
+          THEN excluded.position
+        WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+          THEN excluded.position
+        ELSE fantrax_entities.position
+      END`,
+] as const;
+
 type DbExecutor = Pick<Client, "execute">;
+
+const getImportMetadataValue = async (
+  db: DbExecutor,
+  key: string,
+): Promise<string | null> => {
+  const result = await db.execute({
+    sql: "SELECT value FROM import_metadata WHERE key = ?",
+    args: [key],
+  });
+  const row = result.rows[0] as { value?: string | number | bigint } | undefined;
+
+  return row?.value === undefined ? null : String(row.value);
+};
+
+const shouldBackfillFantraxEntities = async (
+  db: DbExecutor,
+): Promise<boolean> => {
+  const schemaVersion = await getImportMetadataValue(db, "schema_version");
+  const parsedSchemaVersion =
+    schemaVersion === null ? 0 : Number.parseInt(schemaVersion, 10);
+
+  if (!(parsedSchemaVersion >= FANTRAX_ENTITIES_SCHEMA_VERSION)) {
+    return true;
+  }
+
+  const result = await db.execute("SELECT COUNT(*) AS count FROM fantrax_entities");
+  const row = result.rows[0] as unknown as {
+    count: number | string | bigint;
+  };
+
+  return Number(row.count) === 0;
+};
 
 export const migrateDb = async (db: DbExecutor): Promise<void> => {
   for (const sql of SCHEMA_SQL) {
     await db.execute(sql);
+  }
+
+  if (await shouldBackfillFantraxEntities(db)) {
+    for (const sql of FANTRAX_ENTITIES_BACKFILL_SQL) {
+      await db.execute(sql);
+    }
   }
 
   await db.execute({

--- a/src/fantrax-entities.ts
+++ b/src/fantrax-entities.ts
@@ -1,0 +1,116 @@
+import type { InStatement } from "@libsql/client";
+
+import type { GoalieWithSeason, PlayerWithSeason } from "./types";
+
+export type FantraxEntityPosition = "F" | "D" | "G";
+
+export type FantraxEntity = {
+  fantraxId: string;
+  name: string;
+  position: FantraxEntityPosition | null;
+  firstSeenSeason: number;
+  lastSeenSeason: number;
+};
+
+const FANTRAX_ENTITY_UPSERT_SQL = `INSERT INTO fantrax_entities (
+  fantrax_id,
+  name,
+  position,
+  first_seen_season,
+  last_seen_season
+) VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(fantrax_id) DO UPDATE SET
+  first_seen_season = MIN(fantrax_entities.first_seen_season, excluded.first_seen_season),
+  last_seen_season = MAX(fantrax_entities.last_seen_season, excluded.last_seen_season),
+  name = CASE
+    WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+      THEN excluded.name
+    ELSE fantrax_entities.name
+  END,
+  position = CASE
+    WHEN fantrax_entities.position IS NULL AND excluded.position IS NOT NULL
+      THEN excluded.position
+    WHEN excluded.last_seen_season >= fantrax_entities.last_seen_season
+      THEN COALESCE(excluded.position, fantrax_entities.position)
+    ELSE fantrax_entities.position
+  END`;
+
+const mergeFantraxEntity = (
+  existing: FantraxEntity | undefined,
+  incoming: FantraxEntity,
+): FantraxEntity => {
+  if (!existing) {
+    return incoming;
+  }
+
+  const useIncomingCanonical =
+    incoming.lastSeenSeason >= existing.lastSeenSeason;
+
+  return {
+    fantraxId: existing.fantraxId,
+    name: useIncomingCanonical ? incoming.name : existing.name,
+    position: useIncomingCanonical
+      ? (incoming.position ?? existing.position ?? null)
+      : (existing.position ?? incoming.position ?? null),
+    firstSeenSeason: Math.min(existing.firstSeenSeason, incoming.firstSeenSeason),
+    lastSeenSeason: Math.max(existing.lastSeenSeason, incoming.lastSeenSeason),
+  };
+};
+
+export const collectFantraxEntitiesFromStats = (args: {
+  players: readonly PlayerWithSeason[];
+  goalies: readonly GoalieWithSeason[];
+}): FantraxEntity[] => {
+  const byId = new Map<string, FantraxEntity>();
+
+  for (const player of args.players) {
+    if (!player.id) {
+      continue;
+    }
+
+    const incoming: FantraxEntity = {
+      fantraxId: player.id,
+      name: player.name,
+      position:
+        player.position === "F" || player.position === "D"
+          ? player.position
+          : null,
+      firstSeenSeason: player.season,
+      lastSeenSeason: player.season,
+    };
+    byId.set(player.id, mergeFantraxEntity(byId.get(player.id), incoming));
+  }
+
+  for (const goalie of args.goalies) {
+    if (!goalie.id) {
+      continue;
+    }
+
+    const incoming: FantraxEntity = {
+      fantraxId: goalie.id,
+      name: goalie.name,
+      position: "G",
+      firstSeenSeason: goalie.season,
+      lastSeenSeason: goalie.season,
+    };
+    byId.set(goalie.id, mergeFantraxEntity(byId.get(goalie.id), incoming));
+  }
+
+  return [...byId.values()].sort((a, b) =>
+    a.fantraxId.localeCompare(b.fantraxId),
+  );
+};
+
+export const buildFantraxEntityUpsertStatements = (
+  entities: readonly FantraxEntity[],
+): InStatement[] =>
+  entities.map((entity) => ({
+    sql: FANTRAX_ENTITY_UPSERT_SQL,
+    args: [
+      entity.fantraxId,
+      entity.name,
+      entity.position,
+      entity.firstSeenSeason,
+      entity.lastSeenSeason,
+    ],
+  }));


### PR DESCRIPTION
Summary:
- add a global `fantrax_entities` table keyed by Fantrax ID with canonical name, position, and first/last seen seasons
- backfill `fantrax_entities` during `db:migrate` when upgrading an older database or rebuilding an empty registry
- keep `fantrax_entities` incrementally synced during stats import with UPSERTs instead of full refreshes
- update `db-migrate` output to include the new table, indexes, and guarded backfill behavior
- make career player and goalie queries prefer canonical metadata from `fantrax_entities`
- keep career aggregates sourced from `players` and `goalies`, changing only the canonical name/position source
- update integration/query coverage to verify canonical metadata is used in live career routes
- document the new registry and its current use in career endpoints

Testing:
- npm run verify