### PR TITLE
Fix: Harden snapshot R2 uploads and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ R2_BUCKET_NAME=ffhl-stats-csv
 USE_R2_SNAPSHOTS=false
 # R2_SNAPSHOT_BUCKET_NAME=ffhl-stats-snapshots  # Optional; defaults to R2_BUCKET_NAME
 # R2_SNAPSHOT_PREFIX=snapshots                  # Optional object prefix inside the bucket
+# R2_SNAPSHOT_MAX_ATTEMPTS=4                    # Optional retry cap for transient snapshot R2 failures
+# R2_SNAPSHOT_RETRY_BASE_DELAY_MS=250          # Optional exponential backoff base delay for snapshot R2 retries
 # SNAPSHOT_DIR=generated/snapshots             # Optional local snapshot directory
 # SNAPSHOT_CACHE_TTL_MS=60000                  # Optional in-memory snapshot cache ttl
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ R2_BUCKET_NAME=ffhl-stats-csv
 USE_R2_SNAPSHOTS=false
 # R2_SNAPSHOT_BUCKET_NAME=ffhl-stats-snapshots  # Optional; defaults to R2_BUCKET_NAME
 # R2_SNAPSHOT_PREFIX=snapshots                  # Optional object prefix
+# R2_SNAPSHOT_MAX_ATTEMPTS=4                    # Optional retry cap for transient snapshot R2 failures
+# R2_SNAPSHOT_RETRY_BASE_DELAY_MS=250           # Optional exponential backoff base delay for snapshot R2 retries
 # SNAPSHOT_DIR=generated/snapshots              # Optional local snapshot directory
 # SNAPSHOT_CACHE_TTL_MS=60000                   # Optional in-memory snapshot cache ttl
 ```
@@ -597,7 +599,10 @@ Behavior:
 - `db:import:regular-results` refreshes only `/leaderboard/regular`
 - `db:import:transactions` refreshes `import_metadata.last_modified` and then refreshes only `/leaderboard/transactions`
 - snapshots are written locally to `generated/snapshots/`
-- if `USE_R2_SNAPSHOTS=true`, the same generation step also uploads JSON snapshots to R2
+- if `USE_R2_SNAPSHOTS=true`, the same generation step uploads each snapshot JSON to `R2_SNAPSHOT_BUCKET_NAME` (or `R2_BUCKET_NAME`) under `R2_SNAPSHOT_PREFIX/...`, then uploads `manifest.json` last
+- snapshot uploads store `Content-Type: application/json` plus `generated-at` object metadata
+- transient snapshot R2 failures (including TLS/network hiccups) are retried automatically with exponential backoff; tune with `R2_SNAPSHOT_MAX_ATTEMPTS` and `R2_SNAPSHOT_RETRY_BASE_DELAY_MS`
+- when R2 snapshot upload is enabled, the generator logs each successful object upload with progress counters so long runs show forward movement
 - at runtime the API tries local snapshots first, then R2, and finally falls back to live DB queries
 - successful responses expose `x-stats-data-source: snapshot` or `x-stats-data-source: db`
 - career and career-highlight snapshots are intentionally manual-only after stats imports; existing snapshots continue serving until you regenerate them

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -148,7 +148,7 @@ npm run verify
 - `npm run db:import:transactions` - Incrementally import current-season transaction rows from `csv/transactions/` into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Updates `import_metadata.last_modified` and refreshes only the transactions snapshot. Supports `--full`, `--all`, `--season=YYYY`, `--current-only`, `--dry-run`, and `--dir=/custom/path`.
 - `npm run db:import:playoff-results` - Import playoff round results from `fantrax-playoffs.json` into database (set `USE_REMOTE_DB=true` to target remote Turso). Regenerates only the playoff leaderboard snapshot after a successful import.
 - `npm run db:import:regular-results` - Imports regular season standings from `fantrax-regular.json` into the `regular_results` table. Set `USE_REMOTE_DB=true` to target remote Turso. Regenerates only the regular leaderboard snapshot after a successful import.
-- `npm run snapshot:generate` - Generate JSON snapshots into `generated/snapshots/`. Supports `--scope=transactions|leaderboard-regular|leaderboard-playoffs|stats|career|career-highlights|all`; if `stats` is included, `--report-type=regular|playoffs|both|all` limits which combined report snapshots are rebuilt. If `USE_R2_SNAPSHOTS=true`, uploads generated snapshots to R2 too.
+- `npm run snapshot:generate` - Generate JSON snapshots into `generated/snapshots/`. Supports `--scope=transactions|leaderboard-regular|leaderboard-playoffs|stats|career|career-highlights|all`; if `stats` is included, `--report-type=regular|playoffs|both|all` limits which combined report snapshots are rebuilt. If `USE_R2_SNAPSHOTS=true`, uploads each generated JSON payload to the configured snapshot bucket/prefix, adds `generated-at` metadata, uploads `manifest.json` last, retries transient R2/TLS failures with exponential backoff, and logs successful uploads with progress counters.
 - Snapshot-backed routes expose `x-stats-data-source: snapshot|db` so you can inspect whether a successful response came from a snapshot or a live DB path.
 
 ### R2 Storage (CSV backup + optional API snapshots)
@@ -232,6 +232,8 @@ USE_REMOTE_DB=false
 # USE_R2_SNAPSHOTS=false            # Upload/read generated API snapshots via R2
 # R2_SNAPSHOT_BUCKET_NAME=          # Optional; defaults to R2_BUCKET_NAME
 # R2_SNAPSHOT_PREFIX=snapshots      # Optional object prefix for snapshot JSONs
+# R2_SNAPSHOT_MAX_ATTEMPTS=4        # Optional retry cap for transient snapshot R2 failures
+# R2_SNAPSHOT_RETRY_BASE_DELAY_MS=250 # Optional exponential backoff base delay for snapshot R2 retries
 # SNAPSHOT_DIR=generated/snapshots  # Optional local snapshot directory
 # SNAPSHOT_CACHE_TTL_MS=60000       # Optional in-memory snapshot cache ttl
 # RAW_UPLOAD=false

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -147,6 +147,7 @@ src/
     ├── mappings.goalies.test.ts # CSV-to-goalie transformation coverage
     ├── openapi-schema.ts # Shared OpenAPI schema validators for route tests
     ├── queries.*.test.ts # Database query suites (roster stats, career rows, results/metadata)
+    ├── r2-retry.test.ts # Snapshot R2 retry/backoff classification and limits
     ├── routes.integration.helpers.ts # Shared helpers for route integration suites
     ├── routes.integration.test.ts # Entry point for the categorized route integration suites
     ├── routes.integration.*.ts # Domain-focused route integration modules (seasons, players, goalies, career, leaderboard)
@@ -160,7 +161,7 @@ src/
     └── fixtures.ts       # Shared test data
 ```
 
-Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suite because it includes local filesystem, cache, and R2 fallback branches, route-db integration now has a dedicated suite so endpoint behavior can be validated with less internal mocking, helper scoring coverage is split by skaters/goalies while season-availability behavior rides on the route integration suite, canonical Fantrax identity behavior is split between helper-level merge/upsert tests and a DB-backed schema migration suite, transaction helper coverage pins down season/file naming and Fantrax history URL generation, transaction import coverage now separately pins down entity matching, grouping, commissioner-fix exclusion, and season reimport behavior, service-unit coverage is split by season/combined, career, and leaderboard behavior, mapping coverage stays focused on CSV player/goalie transforms, and query coverage is split by roster/career/results responsibilities so the larger suites stay readable without reasserting every live route happy path.
+Keep this directory updated whenever a new module or integration boundary is added. Snapshot behavior now has its own dedicated suites because snapshot loading covers local filesystem, cache, and R2 fallback branches while `r2-retry.test.ts` pins down transient upload classification/backoff behavior, route-db integration now has a dedicated suite so endpoint behavior can be validated with less internal mocking, helper scoring coverage is split by skaters/goalies while season-availability behavior rides on the route integration suite, canonical Fantrax identity behavior is split between helper-level merge/upsert tests and a DB-backed schema migration suite, transaction helper coverage pins down season/file naming and Fantrax history URL generation, transaction import coverage now separately pins down entity matching, grouping, commissioner-fix exclusion, and season reimport behavior, service-unit coverage is split by season/combined, career, and leaderboard behavior, mapping coverage stays focused on CSV player/goalie transforms, and query coverage is split by roster/career/results responsibilities so the larger suites stay readable without reasserting every live route happy path.
 
 ---
 

--- a/scripts/generate-snapshots.ts
+++ b/scripts/generate-snapshots.ts
@@ -38,11 +38,18 @@ import {
   getSnapshotFilePath,
   getSnapshotManifestKey,
   getSnapshotObjectKey,
+  getSnapshotPrefix,
   getTransactionsLeaderboardSnapshotKey,
   isR2SnapshotConfigAvailable,
   loadSnapshot,
 } from "../src/snapshots";
 import { getLastModifiedFromDb } from "../src/db/queries";
+import {
+  getR2SnapshotMaxAttempts,
+  getR2SnapshotRetryBaseDelayMs,
+  retryR2Operation,
+  type R2RetryContext,
+} from "../src/r2/retry";
 
 type SnapshotEntry = {
   bytes: number;
@@ -60,7 +67,39 @@ type SnapshotManifest = {
   }>;
 };
 
+type UploadProgress = {
+  completed: number;
+  total: number;
+};
+
 const shouldUploadToR2 = (): boolean => process.env.USE_R2_SNAPSHOTS === "true";
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const logR2Retry = ({
+  delayMs,
+  error,
+  maxAttempts,
+  nextAttempt,
+  operation,
+}: R2RetryContext): void => {
+  console.warn(
+    `⚠️  ${operation} failed: ${getErrorMessage(error)}. ` +
+      `Retrying in ${delayMs}ms (${nextAttempt}/${maxAttempts})...`,
+  );
+};
+
+const logR2UploadSuccess = (
+  snapshotKey: string,
+  uploadProgress: UploadProgress,
+): void => {
+  uploadProgress.completed += 1;
+  console.info(
+    `✅ Uploaded to R2 (${uploadProgress.completed}/${uploadProgress.total}): ` +
+      `${getSnapshotObjectKey(snapshotKey)}`,
+  );
+};
 
 const writeSnapshotFile = (snapshotKey: string, body: string): number => {
   const filePath = getSnapshotFilePath(snapshotKey);
@@ -79,17 +118,30 @@ const uploadSnapshotFile = async (
     throw new Error("Missing snapshot bucket configuration");
   }
 
-  await createSnapshotR2Client().send(
-    new PutObjectCommand({
-      Bucket: bucketName,
-      Key: getSnapshotObjectKey(snapshotKey),
-      Body: body,
-      ContentType: "application/json",
-      Metadata: {
-        "generated-at": generatedAt,
-      },
-    }),
-  );
+  const objectKey = getSnapshotObjectKey(snapshotKey);
+
+  try {
+    await retryR2Operation(
+      `R2 upload ${objectKey}`,
+      () =>
+        createSnapshotR2Client().send(
+          new PutObjectCommand({
+            Bucket: bucketName,
+            Key: objectKey,
+            Body: body,
+            ContentType: "application/json",
+            Metadata: {
+              "generated-at": generatedAt,
+            },
+          }),
+        ),
+      logR2Retry,
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to upload R2 snapshot ${bucketName}/${objectKey}: ${getErrorMessage(error)}`,
+    );
+  }
 };
 
 const buildSnapshotEntries = async (
@@ -166,11 +218,15 @@ const buildSnapshotEntries = async (
 
 const loadExistingManifest = async (): Promise<SnapshotManifest | null> => {
   try {
-    return await loadSnapshot<SnapshotManifest>(getSnapshotManifestKey());
+    return await retryR2Operation(
+      `snapshot manifest lookup ${getSnapshotManifestKey()}`,
+      () => loadSnapshot<SnapshotManifest>(getSnapshotManifestKey()),
+      logR2Retry,
+    );
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     console.warn(
-      `⚠️  Failed to load existing snapshot manifest, continuing without merge: ${message}`,
+      "⚠️  Failed to load existing snapshot manifest, continuing without merge: " +
+        getErrorMessage(error),
     );
     return null;
   }
@@ -220,11 +276,25 @@ const main = async () => {
   if (config.scopes.includes("stats")) {
     console.info(`   Stats reports: ${config.statsReportTypes.join(", ")}`);
   }
+  if (shouldUploadToR2()) {
+    console.info(
+      `   R2 target: ${getSnapshotBucketName()}/${getSnapshotPrefix()}/`,
+    );
+    console.info(
+      "   R2 retry policy: " +
+        `${getR2SnapshotMaxAttempts()} attempts, ` +
+        `${getR2SnapshotRetryBaseDelayMs()}ms base backoff`,
+    );
+  }
 
   const entries = await buildSnapshotEntries(config);
   const existingManifest = config.isFullGeneration
     ? null
     : await loadExistingManifest();
+  const uploadProgress: UploadProgress = {
+    completed: 0,
+    total: entries.length + 1,
+  };
 
   for (const entry of entries) {
     const body = JSON.stringify(entry.data);
@@ -237,6 +307,7 @@ const main = async () => {
         );
       }
       await uploadSnapshotFile(entry.key, body, generatedAt);
+      logR2UploadSuccess(entry.key, uploadProgress);
     }
   }
 
@@ -256,6 +327,7 @@ const main = async () => {
       manifestBody,
       generatedAt,
     );
+    logR2UploadSuccess(getSnapshotManifestKey(), uploadProgress);
   }
 
   console.info(`✅ Snapshot generation complete (${entries.length} payloads)`);

--- a/src/__tests__/r2-retry.test.ts
+++ b/src/__tests__/r2-retry.test.ts
@@ -1,0 +1,182 @@
+import {
+  getR2SnapshotMaxAttempts,
+  getR2SnapshotRetryBaseDelayMs,
+  isRetryableR2Error,
+  retryR2Operation,
+} from "../r2/retry";
+
+const originalEnv = process.env;
+
+describe("r2 retry helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    process.env = { ...originalEnv };
+    delete process.env.R2_SNAPSHOT_MAX_ATTEMPTS;
+    delete process.env.R2_SNAPSHOT_RETRY_BASE_DELAY_MS;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test("uses default retry settings and honors trimmed environment overrides", () => {
+    expect(getR2SnapshotMaxAttempts()).toBe(4);
+    expect(getR2SnapshotRetryBaseDelayMs()).toBe(250);
+
+    process.env.R2_SNAPSHOT_MAX_ATTEMPTS = " 6 ";
+    process.env.R2_SNAPSHOT_RETRY_BASE_DELAY_MS = " 800 ";
+
+    expect(getR2SnapshotMaxAttempts()).toBe(6);
+    expect(getR2SnapshotRetryBaseDelayMs()).toBe(800);
+  });
+
+  test("falls back to defaults when retry settings are invalid", () => {
+    process.env.R2_SNAPSHOT_MAX_ATTEMPTS = "0";
+    process.env.R2_SNAPSHOT_RETRY_BASE_DELAY_MS = "nope";
+
+    expect(getR2SnapshotMaxAttempts()).toBe(4);
+    expect(getR2SnapshotRetryBaseDelayMs()).toBe(250);
+  });
+
+  test("classifies transient R2 errors as retryable", () => {
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("throttled"), { $retryable: {} }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("server error"), {
+          $metadata: { httpStatusCode: 503 },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("timed out"), {
+          name: "TimeoutError",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("tls alert"), {
+          code: "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("timed out"), {
+          code: "CUSTOM_TIMEOUT",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("ssl handshake failed"), {
+          code: "ERR_SSL_HANDSHAKE_FAILURE",
+        }),
+      ),
+    ).toBe(true);
+    expect(isRetryableR2Error(new Error("socket hang up"))).toBe(true);
+  });
+
+  test("does not retry non-transient or non-Error failures", () => {
+    expect(isRetryableR2Error(new Error("validation failed"))).toBe(false);
+    expect(
+      isRetryableR2Error(
+        Object.assign(new Error("validation failed"), {
+          code: "EACCES",
+        }),
+      ),
+    ).toBe(false);
+    expect(isRetryableR2Error({ status: 503 })).toBe(false);
+  });
+
+  test("returns immediately when the operation succeeds on the first attempt", async () => {
+    const run = jest.fn().mockResolvedValue("ok");
+
+    await expect(retryR2Operation("upload snapshot", run)).resolves.toBe("ok");
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries transient failures with exponential backoff and succeeds", async () => {
+    jest.useFakeTimers();
+    const transientError = Object.assign(new Error("bad record mac"), {
+      code: "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC",
+    });
+    const run = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(transientError)
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValue("uploaded");
+    const onRetry = jest.fn();
+
+    const promise = retryR2Operation("upload snapshot", run, onRetry);
+
+    await Promise.resolve();
+    expect(onRetry).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        attempt: 1,
+        delayMs: 250,
+        error: transientError,
+        maxAttempts: 4,
+        nextAttempt: 2,
+        operation: "upload snapshot",
+      }),
+    );
+
+    await jest.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+
+    expect(onRetry).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        attempt: 2,
+        delayMs: 500,
+        error: transientError,
+        maxAttempts: 4,
+        nextAttempt: 3,
+        operation: "upload snapshot",
+      }),
+    );
+
+    await jest.runOnlyPendingTimersAsync();
+    await expect(promise).resolves.toBe("uploaded");
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  test("stops retrying when the failure is not retryable", async () => {
+    const error = new Error("permission denied");
+    const run = jest.fn().mockRejectedValue(error);
+
+    await expect(retryR2Operation("upload snapshot", run)).rejects.toBe(error);
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops after the configured maximum number of attempts", async () => {
+    jest.useFakeTimers();
+    process.env.R2_SNAPSHOT_MAX_ATTEMPTS = "2";
+    const transientError = Object.assign(new Error("bad record mac"), {
+      code: "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC",
+    });
+    const run = jest.fn().mockRejectedValue(transientError);
+    const onRetry = jest.fn();
+
+    const promise = retryR2Operation("upload snapshot", run, onRetry);
+    const rejection = expect(promise).rejects.toBe(transientError);
+
+    await Promise.resolve();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    await jest.runOnlyPendingTimersAsync();
+    await rejection;
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/r2/retry.ts
+++ b/src/r2/retry.ts
@@ -1,0 +1,141 @@
+const DEFAULT_R2_SNAPSHOT_MAX_ATTEMPTS = 4;
+const DEFAULT_R2_SNAPSHOT_RETRY_BASE_DELAY_MS = 250;
+
+const RETRYABLE_HTTP_STATUS_CODES = new Set([
+  408, 425, 429, 500, 502, 503, 504,
+]);
+const RETRYABLE_ERROR_NAMES = new Set([
+  "InternalError",
+  "NetworkingError",
+  "RequestTimeout",
+  "SlowDown",
+  "TimeoutError",
+]);
+const RETRYABLE_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNRESET",
+  "EPIPE",
+  "ERR_SOCKET_CONNECTION_TIMEOUT",
+  "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+const RETRYABLE_MESSAGE_SNIPPETS = [
+  "bad record mac",
+  "connection reset",
+  "network error",
+  "socket hang up",
+  "timed out",
+] as const;
+
+type RetryableR2Error = Error & {
+  $metadata?: {
+    httpStatusCode?: number;
+  };
+  $retryable?: unknown;
+  code?: string;
+};
+
+export type R2RetryContext = {
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+  maxAttempts: number;
+  nextAttempt: number;
+  operation: string;
+};
+
+const getEnv = (key: string): string | undefined => {
+  const value = process.env[key]?.trim();
+  return value ? value : undefined;
+};
+
+const parsePositiveInt = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const getRetryDelayMs = (attempt: number): number =>
+  getR2SnapshotRetryBaseDelayMs() * 2 ** (attempt - 1);
+
+const sleep = async (delayMs: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+export const getR2SnapshotMaxAttempts = (): number =>
+  parsePositiveInt(getEnv("R2_SNAPSHOT_MAX_ATTEMPTS")) ??
+  DEFAULT_R2_SNAPSHOT_MAX_ATTEMPTS;
+
+export const getR2SnapshotRetryBaseDelayMs = (): number =>
+  parsePositiveInt(getEnv("R2_SNAPSHOT_RETRY_BASE_DELAY_MS")) ??
+  DEFAULT_R2_SNAPSHOT_RETRY_BASE_DELAY_MS;
+
+/** @internal Test-only export for snapshot R2 retry classification coverage. */
+export const isRetryableR2Error = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+
+  const retryableError = error as RetryableR2Error;
+  const statusCode = retryableError.$metadata?.httpStatusCode;
+  const code = retryableError.code?.toUpperCase();
+
+  if (retryableError.$retryable) {
+    return true;
+  }
+
+  if (statusCode && RETRYABLE_HTTP_STATUS_CODES.has(statusCode)) {
+    return true;
+  }
+
+  if (RETRYABLE_ERROR_NAMES.has(retryableError.name)) {
+    return true;
+  }
+
+  if (
+    code &&
+    (RETRYABLE_ERROR_CODES.has(code) ||
+      code.includes("TIMEOUT") ||
+      code.startsWith("ERR_SSL"))
+  ) {
+    return true;
+  }
+
+  const message = retryableError.message.toLowerCase();
+  return RETRYABLE_MESSAGE_SNIPPETS.some((snippet) =>
+    message.includes(snippet),
+  );
+};
+
+export const retryR2Operation = async <T>(
+  operation: string,
+  run: () => Promise<T>,
+  onRetry?: (context: R2RetryContext) => void,
+): Promise<T> => {
+  const maxAttempts = getR2SnapshotMaxAttempts();
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isRetryableR2Error(error)) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(attempt);
+      onRetry?.({
+        attempt,
+        delayMs,
+        error,
+        maxAttempts,
+        nextAttempt: attempt + 1,
+        operation,
+      });
+      await sleep(delayMs);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- harden snapshot R2 uploads with bounded retry/backoff for transient network and TLS failures, including bad record mac errors
- improve snapshot generation console output with per-object R2 upload progress so long runs show forward movement
- document the snapshot upload flow, retry knobs, and test coverage updates

## Testing
- npm run verify
