### PR TITLE
Fix: Skip playoff placeholder rows and target snapshot regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ ID behavior:
   - `id` for goalies
 - The import pipeline expects Fantrax's leading `ID` column to be preserved.
 - Rows with a missing Fantrax ID are skipped during DB import and reported after the import completes; the rest of the file still imports.
-- Rows with `0` games are imported into the database, but player/goalie API responses currently filter them out.
+- Rows with `0` games are imported into the database, except playoff placeholder rows with `Status "-"` and `0` GP, which are skipped during DB import; player/goalie API responses still filter the remaining `0`-game rows out.
 
 ### Import files from `csv/temp`
 
@@ -596,7 +596,7 @@ Behavior:
 
 - `db:import:stats` refreshes `import_metadata.last_modified` and then runs `npm run snapshot:generate -- --scope=stats`
 - `db:import:stats -- --report-type=regular` regenerates `regular` and `both` combined player/goalie snapshots
-- `db:import:stats -- --report-type=playoffs` regenerates `playoffs` and `both` combined player/goalie snapshots
+- `db:import:stats -- --report-type=playoffs` regenerates `playoffs` and `both` combined player/goalie snapshots only for teams whose playoff CSVs were imported
 - `db:import:playoff-results` refreshes only `/leaderboard/playoffs`
 - `db:import:regular-results` refreshes only `/leaderboard/regular`
 - `db:import:transactions` refreshes `import_metadata.last_modified` and then refreshes only `/leaderboard/transactions`
@@ -614,6 +614,7 @@ Manual generation:
 ```bash
 npm run snapshot:generate
 npm run snapshot:generate -- --scope=stats --report-type=regular
+npm run snapshot:generate -- --scope=stats --report-type=playoffs --team-id=1 --team-id=12
 npm run snapshot:generate -- --scope=career --scope=career-highlights
 npm run snapshot:generate -- --scope=transactions
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -128,7 +128,7 @@ npm run verify
   - `id` for goalies
 - The import pipeline expects Fantrax's leading `ID` column to be preserved.
 - Rows with a missing Fantrax ID are skipped during DB import and reported after the import completes; the rest of the file still imports.
-- Rows with `0` games are imported into the database, but player/goalie API queries currently filter them out.
+- Rows with `0` games are imported into the database, except playoff placeholder rows with `Status "-"` and `0` GP, which are skipped during DB import; player/goalie API queries still filter the remaining `0`-game rows out.
 
 ### Database (Turso/SQLite)
 
@@ -148,7 +148,7 @@ npm run verify
 - `npm run db:import:transactions` - Incrementally import current-season transaction rows from `csv/transactions/` into database (local by default; set `USE_REMOTE_DB=true` in `.env` for remote). Updates `import_metadata.last_modified` and refreshes only the transactions snapshot. Supports `--full`, `--all`, `--season=YYYY`, `--current-only`, `--dry-run`, and `--dir=/custom/path`.
 - `npm run db:import:playoff-results` - Import playoff round results from `fantrax-playoffs.json` into database (set `USE_REMOTE_DB=true` to target remote Turso). Regenerates only the playoff leaderboard snapshot after a successful import.
 - `npm run db:import:regular-results` - Imports regular season standings from `fantrax-regular.json` into the `regular_results` table. Set `USE_REMOTE_DB=true` to target remote Turso. Regenerates only the regular leaderboard snapshot after a successful import.
-- `npm run snapshot:generate` - Generate JSON snapshots into `generated/snapshots/`. Supports `--scope=transactions|leaderboard-regular|leaderboard-playoffs|stats|career|career-highlights|all`; if `stats` is included, `--report-type=regular|playoffs|both|all` limits which combined report snapshots are rebuilt. If `USE_R2_SNAPSHOTS=true`, uploads each generated JSON payload to the configured snapshot bucket/prefix, adds `generated-at` metadata, uploads `manifest.json` last, retries transient R2/TLS failures with exponential backoff, and logs successful uploads with progress counters.
+- `npm run snapshot:generate` - Generate JSON snapshots into `generated/snapshots/`. Supports `--scope=transactions|leaderboard-regular|leaderboard-playoffs|stats|career|career-highlights|all`; if `stats` is included, `--report-type=regular|playoffs|both|all` limits which combined report snapshots are rebuilt and repeated `--team-id=<id>` flags can narrow stats regeneration to specific fantasy teams. If `USE_R2_SNAPSHOTS=true`, uploads each generated JSON payload to the configured snapshot bucket/prefix, adds `generated-at` metadata, uploads `manifest.json` last, retries transient R2/TLS failures with exponential backoff, and logs successful uploads with progress counters.
 - Snapshot-backed routes expose `x-stats-data-source: snapshot|db` so you can inspect whether a successful response came from a snapshot or a live DB path.
 
 ### R2 Storage (CSV backup + optional API snapshots)

--- a/scripts/generate-snapshots.ts
+++ b/scripts/generate-snapshots.ts
@@ -201,7 +201,16 @@ const buildSnapshotEntries = async (
   }
 
   if (config.scopes.includes("stats")) {
+    const statsTeamIds =
+      config.statsTeamIds === null
+        ? null
+        : new Set(config.statsTeamIds);
+
     for (const team of TEAMS) {
+      if (statsTeamIds !== null && !statsTeamIds.has(team.id)) {
+        continue;
+      }
+
       for (const reportType of config.statsReportTypes) {
         entries.push({
           key: getCombinedSnapshotKey("players", reportType, team.id),
@@ -279,6 +288,9 @@ const main = async () => {
   console.info(`   Scopes: ${config.scopes.join(", ")}`);
   if (config.scopes.includes("stats")) {
     console.info(`   Stats reports: ${config.statsReportTypes.join(", ")}`);
+    if (config.statsTeamIds !== null) {
+      console.info(`   Stats teams: ${config.statsTeamIds.join(", ")}`);
+    }
   }
   if (shouldUploadToR2()) {
     console.info(

--- a/scripts/import-stats-to-db.ts
+++ b/scripts/import-stats-to-db.ts
@@ -79,6 +79,7 @@ const main = async () => {
   let skippedGoaliesMissingId = 0;
   let totalFantraxEntitiesSynced = 0;
   const missingIdMessages: string[] = [];
+  const snapshotTeamIds = new Set<string>();
 
   for (const team of TEAMS) {
     const teamDir = path.join(csvDir, team.id);
@@ -132,9 +133,11 @@ const main = async () => {
 
         const players = mapPlayerData(dataWithSeason, {
           includeZeroGames: true,
+          excludeStatusDashZeroGames: reportType === "playoffs",
         });
         const goalies = mapGoalieData(dataWithSeason, {
           includeZeroGames: true,
+          excludeStatusDashZeroGames: reportType === "playoffs",
         });
         const playersMissingId = players.filter((p) => !p.id).length;
         const goaliesMissingId = goalies.filter((g) => !g.id).length;
@@ -235,6 +238,7 @@ const main = async () => {
         totalGoalies += goaliesToImport.length;
         totalFantraxEntitiesSynced += fantraxEntities.length;
         totalFiles++;
+        snapshotTeamIds.add(team.id);
       } catch (error) {
         console.error(`  ❌ Error importing ${file}:`, error);
         errors++;
@@ -262,6 +266,11 @@ const main = async () => {
     ];
     if (reportTypeFilter !== null) {
       snapshotArgs.push(`--report-type=${reportTypeFilter}`);
+    }
+    for (const teamId of TEAMS
+      .map((team) => team.id)
+      .filter((teamId) => snapshotTeamIds.has(teamId))) {
+      snapshotArgs.push(`--team-id=${teamId}`);
     }
     const snapshotRun = spawnSync("npm", snapshotArgs, {
       stdio: "inherit",

--- a/scripts/snapshot-generation.ts
+++ b/scripts/snapshot-generation.ts
@@ -1,3 +1,5 @@
+import { TEAMS } from "../src/config";
+
 export const SNAPSHOT_GENERATION_SCOPES = [
   "all",
   "career",
@@ -30,6 +32,7 @@ export type SnapshotStatsReportType =
 export type SnapshotGenerationConfig = {
   scopes: ExplicitSnapshotGenerationScope[];
   statsReportTypes: SnapshotStatsReportType[];
+  statsTeamIds: string[] | null;
   isFullGeneration: boolean;
 };
 
@@ -48,6 +51,40 @@ const parseScopeTokens = (args: readonly string[]): string[] =>
     .flatMap((arg) => arg.slice("--scope=".length).split(","))
     .map((value) => value.trim())
     .filter(Boolean);
+
+const parseTeamIdTokens = (args: readonly string[]): string[] =>
+  args
+    .filter((arg) => arg.startsWith("--team-id="))
+    .flatMap((arg) => arg.slice("--team-id=".length).split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+const normalizeStatsTeamIds = (teamIds: readonly string[]): string[] => {
+  const selected = new Set(teamIds);
+  return TEAMS.map((team) => team.id).filter((teamId) => selected.has(teamId));
+};
+
+export const resolveSnapshotStatsTeamIds = (
+  args: readonly string[],
+): string[] | null => {
+  const rawTeamIds = parseTeamIdTokens(args);
+
+  if (rawTeamIds.length === 0) {
+    return null;
+  }
+
+  const uniqueTeamIds = new Set(rawTeamIds);
+  const validTeamIds = new Set(TEAMS.map((team) => team.id));
+  const invalidTeamId = [...uniqueTeamIds].find((teamId) => !validTeamIds.has(teamId));
+
+  if (invalidTeamId) {
+    throw new Error(
+      `Invalid --team-id value: ${invalidTeamId}. Valid values: ${TEAMS.map((team) => team.id).join(", ")}.`,
+    );
+  }
+
+  return normalizeStatsTeamIds([...uniqueTeamIds]);
+};
 
 export const resolveSnapshotStatsReportTypes = (
   rawValue?: string | null,
@@ -82,6 +119,7 @@ export const resolveSnapshotGenerationConfig = (
   const reportTypeArgs = args.filter((arg) =>
     arg.startsWith("--report-type="),
   );
+  const statsTeamIds = resolveSnapshotStatsTeamIds(args);
 
   if (reportTypeArgs.length > 1) {
     throw new Error("Use at most one --report-type value.");
@@ -95,8 +133,10 @@ export const resolveSnapshotGenerationConfig = (
     return {
       scopes: [...EXPLICIT_SNAPSHOT_GENERATION_SCOPES],
       statsReportTypes,
+      statsTeamIds,
       isFullGeneration:
-        statsReportTypes.length === SNAPSHOT_STATS_REPORT_TYPES.length,
+        statsReportTypes.length === SNAPSHOT_STATS_REPORT_TYPES.length &&
+        statsTeamIds === null,
     };
   }
 
@@ -126,8 +166,10 @@ export const resolveSnapshotGenerationConfig = (
   return {
     scopes,
     statsReportTypes,
+    statsTeamIds,
     isFullGeneration:
       scopes.length === EXPLICIT_SNAPSHOT_GENERATION_SCOPES.length &&
-      statsReportTypes.length === SNAPSHOT_STATS_REPORT_TYPES.length,
+      statsReportTypes.length === SNAPSHOT_STATS_REPORT_TYPES.length &&
+      statsTeamIds === null,
   };
 };

--- a/src/__tests__/mappings.goalies.test.ts
+++ b/src/__tests__/mappings.goalies.test.ts
@@ -200,6 +200,37 @@ describe("mappings", () => {
         expect(result[0].wins).toBe(0);
       });
 
+      test('excludes Status "-" goalies with 0 games when configured', () => {
+        const zeroGoalie = {
+          ...mockRawDataGoalie2014,
+          field6: "-",
+          field8: "0",
+          field9: "0",
+        };
+        const result = mapGoalieData([mockRawDataFirstRow, zeroGoalie], {
+          includeZeroGames: true,
+          excludeStatusDashZeroGames: true,
+        });
+
+        expect(result).toHaveLength(0);
+      });
+
+      test('keeps zero-game goalies with a non-dash status when the placeholder filter is enabled', () => {
+        const zeroGoalie = {
+          ...mockRawDataGoalie2014,
+          field6: "Min",
+          field8: "0",
+          field9: "0",
+        };
+        const result = mapGoalieData([mockRawDataFirstRow, zeroGoalie], {
+          includeZeroGames: true,
+          excludeStatusDashZeroGames: true,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].games).toBe(0);
+      });
+
       test("excludes later goalie header rows when includeZeroGames is true", () => {
         const secondHeaderRow = {
           ...mockRawDataFirstRow,

--- a/src/__tests__/mappings.players.test.ts
+++ b/src/__tests__/mappings.players.test.ts
@@ -54,6 +54,46 @@ describe("mappings", () => {
         expect(result[0].games).toBe(0);
       });
 
+      test('excludes Status "-" players with 0 games when configured', () => {
+        const result = mapPlayerData(
+          [
+            mockRawDataFirstRow,
+            {
+              ...mockRawDataZeroGames,
+              field6: "-",
+            },
+          ],
+          {
+            includeZeroGames: true,
+            excludeStatusDashZeroGames: true,
+          },
+        );
+
+        expect(result).toHaveLength(0);
+      });
+
+      test('keeps Status "-" players that have games when the placeholder filter is enabled', () => {
+        const result = mapPlayerData(
+          [
+            mockRawDataFirstRow,
+            {
+              ...mockRawDataZeroGames,
+              field3: "Active Dash Status Player",
+              field6: "-",
+              field8: "1",
+            },
+          ],
+          {
+            includeZeroGames: true,
+            excludeStatusDashZeroGames: true,
+          },
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("Active Dash Status Player");
+        expect(result[0].games).toBe(1);
+      });
+
       test("excludes later section header rows when includeZeroGames is true", () => {
         const secondHeaderRow = {
           ...mockRawDataFirstRow,

--- a/src/__tests__/snapshot-generation.test.ts
+++ b/src/__tests__/snapshot-generation.test.ts
@@ -3,6 +3,7 @@ import {
   SNAPSHOT_STATS_REPORT_TYPES,
   resolveSnapshotGenerationConfig,
   resolveSnapshotStatsReportTypes,
+  resolveSnapshotStatsTeamIds,
 } from "../../scripts/snapshot-generation";
 
 describe("snapshot generation helpers", () => {
@@ -34,6 +35,7 @@ describe("snapshot generation helpers", () => {
         "transactions",
       ],
       statsReportTypes: ["regular", "playoffs", "both"],
+      statsTeamIds: null,
       isFullGeneration: true,
     });
   });
@@ -48,6 +50,7 @@ describe("snapshot generation helpers", () => {
     ).toEqual({
       scopes: ["stats", "transactions"],
       statsReportTypes: ["regular", "both"],
+      statsTeamIds: null,
       isFullGeneration: false,
     });
   });
@@ -61,6 +64,7 @@ describe("snapshot generation helpers", () => {
     ).toEqual({
       scopes: ["career-highlights", "leaderboard-regular"],
       statsReportTypes: ["both"],
+      statsTeamIds: null,
       isFullGeneration: false,
     });
   });
@@ -76,7 +80,24 @@ describe("snapshot generation helpers", () => {
         "transactions",
       ],
       statsReportTypes: ["regular", "playoffs", "both"],
+      statsTeamIds: null,
       isFullGeneration: true,
+    });
+  });
+
+  test("supports targeted stats generation for selected teams", () => {
+    expect(
+      resolveSnapshotGenerationConfig([
+        "--scope=stats",
+        "--report-type=playoffs",
+        "--team-id=12,1",
+        "--team-id=12",
+      ]),
+    ).toEqual({
+      scopes: ["stats"],
+      statsReportTypes: ["playoffs", "both"],
+      statsTeamIds: ["1", "12"],
+      isFullGeneration: false,
     });
   });
 
@@ -102,6 +123,14 @@ describe("snapshot generation helpers", () => {
     expect(resolveSnapshotStatsReportTypes("both")).toEqual(["both"]);
   });
 
+  test("maps stats team filters for manual callers", () => {
+    expect(resolveSnapshotStatsTeamIds([])).toBeNull();
+    expect(resolveSnapshotStatsTeamIds(["--team-id=12,1", "--team-id=12"])).toEqual([
+      "1",
+      "12",
+    ]);
+  });
+
   test("rejects invalid scope combinations and values", () => {
     expect(() =>
       resolveSnapshotGenerationConfig(["--scope=all", "--scope=stats"]),
@@ -125,5 +154,11 @@ describe("snapshot generation helpers", () => {
         "--report-type=playoffs",
       ]),
     ).toThrow("Use at most one --report-type value.");
+  });
+
+  test("rejects invalid team ids", () => {
+    expect(() => resolveSnapshotStatsTeamIds(["--team-id=999"])).toThrow(
+      "Invalid --team-id value: 999. Valid values:",
+    );
   });
 });

--- a/src/config/csv.ts
+++ b/src/config/csv.ts
@@ -3,6 +3,7 @@ export const CSV = {
   NAME: "field2" as const,
   SKATER_TYPE: "Skaters" as const,
   PLAYER_POSITION: "field4" as const,
+  STATUS: "field5" as const,
   // Player fields
   PLAYER_GAMES: "field7" as const,
   PLAYER_GOALS: "field8" as const,

--- a/src/features/stats/mapping.ts
+++ b/src/features/stats/mapping.ts
@@ -69,12 +69,26 @@ const parseNameAndFantraxId = (
 
 type MapCsvOptions = {
   includeZeroGames?: boolean;
+  excludeStatusDashZeroGames?: boolean;
 };
 
 const isHeaderRow = (item: RawData): boolean => {
   return (
     item[CSV.SKATER_TYPE] === "ID" ||
     getShiftedField(item, CSV.SKATER_TYPE) === "Pos"
+  );
+};
+
+const shouldExcludeStatusDashZeroGameRow = (
+  item: RawData,
+  games: string,
+  options: MapCsvOptions,
+): boolean => {
+  return (
+    options.excludeStatusDashZeroGames === true &&
+    getShiftedField(item, CSV.STATUS) === "-" &&
+    games.trim() !== "" &&
+    parseNumber(games) === 0
   );
 };
 
@@ -91,6 +105,10 @@ export const mapPlayerData = (
       const games = getShiftedField(item, CSV.PLAYER_GAMES);
 
       if (name === "" || skaterType === "G") {
+        return false;
+      }
+
+      if (shouldExcludeStatusDashZeroGameRow(item, games, options)) {
         return false;
       }
 
@@ -265,6 +283,10 @@ export const mapGoalieData = (
       const wins = getShiftedField(item, CSV.GOALIE_GAMES_OR_WINS_OLD);
 
       if (name === "" || skaterType !== "G") {
+        return false;
+      }
+
+      if (shouldExcludeStatusDashZeroGameRow(item, games, options)) {
         return false;
       }
 


### PR DESCRIPTION
## Summary

- skip playoff placeholder skater/goalie rows during DB import when `Status` is `-` and `GP` is `0`
- keep regular-season zero-game import behavior unchanged
- add targeted stats snapshot generation via repeated `--team-id=<id>` filters
- make `db:import:stats -- --report-type=playoffs` regenerate playoff-related stats snapshots only for teams whose playoff CSVs were actually imported
- add/update tests and docs for the new playoff filtering and targeted snapshot behavior

## Testing

- `npm run verify`
