### PR TITLE
Refactor: Replace microrouter with rou3

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ Each weight is a decimal between 0 and 1. Lowering a weight reduces the impact o
 
 ## Technology
 
-Written with [TypeScript](https://www.typescriptlang.org/), using [micro](https://github.com/zeit/micro) with [NodeJS](https://nodejs.org) for routing. Data stored in [Turso](https://turso.tech) (libSQL/SQLite). CSV import uses [csvtojson](https://github.com/Keyang/node-csvtojson) for parsing source files.
+Written with [TypeScript](https://www.typescriptlang.org/) on [NodeJS](https://nodejs.org). HTTP request/response handling uses [micro](https://github.com/zeit/micro), route matching uses [rou3](https://github.com/h3js/rou3), and CORS handling uses `micro-cors`. Data is stored in [Turso](https://turso.tech) (libSQL/SQLite). CSV import uses [csvtojson](https://github.com/Keyang/node-csvtojson) for parsing source files.
 
 ## Future roadmap
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 - **Node.js**: 24.x or later (uses native fetch, stable WebSocket support)
 - **npm**: 10.x or later
-- **TypeScript**: 5.9+ (via devDependencies)
+- **TypeScript**: 5.9+ (via devDependencies). The repo now uses `module: nodenext` so ESM-only dependencies such as `rou3` can be adopted without converting the whole package to ESM at once.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,6 +24,7 @@ All new code **must maintain 100% test coverage:**
 - **ts-jest** - TypeScript transformation
 - **node-mocks-http** - HTTP request/response mocking
 - **Temporary SQLite/libSQL file DBs** - Route/service/query integration coverage without production snapshots or mocked DB queries
+- Jest runs through `NODE_OPTIONS=--experimental-vm-modules` so the suite can execute the current hybrid CommonJS + ESM-only dependency setup.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "js-yaml": "^4.1.1",
         "micro": "^10.0.1",
         "micro-cors": "^0.1.1",
-        "microrouter": "^3.1.3",
-        "playwright": "^1.58.2"
+        "playwright": "^1.58.2",
+        "rou3": "^0.8.1"
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.1016.0",
@@ -23,7 +23,6 @@
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
-        "@types/microrouter": "^3.1.6",
         "@types/node": "^24.12.0",
         "ajv": "^8.18.0",
         "concurrently": "^9.2.1",
@@ -4207,28 +4206,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/micro": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@types/micro/-/micro-7.3.7.tgz",
-      "integrity": "sha512-MFsX7eCj0Tg3TtphOQvANNvNtFpya+s/rYOCdV6o+DFjOQPFi2EVRbBALjbbgZTXUaJP1Q281MJiJOD40d0UxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/microrouter": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@types/microrouter/-/microrouter-3.1.6.tgz",
-      "integrity": "sha512-V+VX5guSnHIlECKnnnl72ZLeXJCJE5hZfI9/Y9CZ0Redmg+OxLHGRtEV3fjo4T3lGd3oQXpghndiQfanRocaIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/micro": "^7.3.7",
-        "@types/node": "*",
-        "url-pattern": "^1.0.3"
-      }
-    },
     "node_modules/@types/node": {
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
@@ -7915,18 +7892,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/microrouter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/microrouter/-/microrouter-3.1.3.tgz",
-      "integrity": "sha512-JQBGmEuu62fUvUsrPaBAOaEYXmR7r3kaPz0j1xyU2Vj/FjDKN26Ij59CJMA1iDGxn8a5qxvfXe+36uQ2G0/F0A==",
-      "license": "MIT",
-      "dependencies": {
-        "url-pattern": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=6.10.0"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -8997,6 +8962,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9888,15 +9859,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-pattern": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
-      "integrity": "sha512-uQcEj/2puA4aq1R3A2+VNVBgaWYR24FdWjl7VNW83rnWftlhyzOZ/tBjezRiC2UkIzuxC8Top3IekN3vUf1WxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Fantrax stats parser",
   "main": "./lib/index.js",
+  "type": "commonjs",
   "repository": "git@github.com:maestor/node-fantrax-stats-parser.git",
   "author": "Kalle Haavisto <maestori@gmail.com>",
   "license": "MIT",
@@ -64,10 +65,10 @@
     "parseAndUploadCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; USE_R2_STORAGE=${USE_R2_STORAGE:-false} USE_REMOTE_DB=${USE_REMOTE_DB:-false} ./scripts/import-temp-csv.sh",
     "parseAndUploadRawCsv": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; tsx scripts/upload-raw-to-r2.ts",
     "start": "npm run build && node lib/server.js",
-    "test": "jest --watchman=false",
-    "test:integration": "jest --watchman=false --runInBand --testPathPatterns=integration",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage --watchman=false",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --watchman=false",
+    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --watchman=false --runInBand --testPathPatterns=integration",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --watchman=false",
     "verify": "npm run lint:check && npm run typecheck && npm run unused && npm run build && npm run test:coverage"
   },
   "dependencies": {
@@ -75,8 +76,8 @@
     "js-yaml": "^4.1.1",
     "micro": "^10.0.1",
     "micro-cors": "^0.1.1",
-    "microrouter": "^3.1.3",
-    "playwright": "^1.58.2"
+    "playwright": "^1.58.2",
+    "rou3": "^0.8.1"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1016.0",
@@ -85,7 +86,6 @@
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
-    "@types/microrouter": "^3.1.6",
     "@types/node": "^24.12.0",
     "ajv": "^8.18.0",
     "concurrently": "^9.2.1",

--- a/src/__tests__/router.test.ts
+++ b/src/__tests__/router.test.ts
@@ -1,0 +1,145 @@
+import { createRequest, createResponse } from "node-mocks-http";
+import { createApp } from "../router";
+import { get } from "../shared/router";
+
+jest.mock("micro-cors", () => jest.fn(() => (handler: unknown) => handler));
+
+describe("router", () => {
+  test("matches route params without stripping the original request url", async () => {
+    const app = await createApp([
+      get("/players/:id", (req, res) => {
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            id: req.params.id,
+            url: req.url,
+          }),
+        );
+      }),
+    ]);
+
+    const req = createRequest({
+      method: "GET",
+      url: "/players/42?view=full",
+      headers: { host: "localhost" },
+    });
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getData()).toBe(
+      JSON.stringify({
+        id: "42",
+        url: "/players/42?view=full",
+      }),
+    );
+  });
+
+  test("normalizes microrouter-style catch-all patterns for rou3", async () => {
+    const app = await createApp([
+      get("/*", (_req, res) => {
+        res.statusCode = 404;
+        res.end("caught");
+      }),
+    ]);
+
+    const req = createRequest({
+      method: "GET",
+      url: "/missing/deeper/path",
+      headers: { host: "localhost" },
+    });
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res._getData()).toBe("caught");
+  });
+
+  test("falls back to localhost when the request has no host header", async () => {
+    const app = await createApp([
+      get("/teams", (req, res) => {
+        res.statusCode = 200;
+        res.end(JSON.stringify(req.params));
+      }),
+    ]);
+
+    const req = createRequest({
+      method: "GET",
+      url: "/teams?view=summary",
+    });
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getData()).toBe(JSON.stringify({}));
+  });
+
+  test("falls back to manual path parsing when URL construction throws", async () => {
+    const app = await createApp([
+      get("/fallback", (_req, res) => {
+        res.statusCode = 200;
+        res.end("fallback");
+      }),
+    ]);
+
+    const req = createRequest({
+      method: "GET",
+      headers: { host: ":::" },
+    }) as ReturnType<typeof createRequest> & {
+      url?: string;
+    };
+    req.url = "/fallback?view=summary";
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getData()).toBe("fallback");
+  });
+
+  test("falls back to root when manual path parsing receives only a query string", async () => {
+    const app = await createApp([
+      get("/", (_req, res) => {
+        res.statusCode = 200;
+        res.end("root");
+      }),
+    ]);
+
+    const req = createRequest({
+      method: "GET",
+      headers: { host: ":::" },
+    }) as ReturnType<typeof createRequest> & {
+      url?: string;
+    };
+    req.url = "?view=summary";
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getData()).toBe("root");
+  });
+
+  test("returns the default 404 when no route matches", async () => {
+    const app = await createApp([]);
+
+    const req = createRequest({
+      url: "/no-match",
+      headers: { host: "localhost" },
+    }) as ReturnType<typeof createRequest> & {
+      method?: string;
+      url?: string;
+    };
+    req.method = undefined;
+    req.url = undefined;
+    const res = createResponse();
+
+    await app(req as never, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res._getData()).toBe("Route not exists");
+  });
+});

--- a/src/__tests__/types-barrel.test.ts
+++ b/src/__tests__/types-barrel.test.ts
@@ -1,6 +1,6 @@
 describe("type barrels", () => {
   test("load the shared type barrel without runtime exports", async () => {
-    const sharedTypes = await import("../shared/types");
+    const sharedTypes = jest.requireActual("../shared/types");
 
     expect(sharedTypes).toBeDefined();
   });

--- a/src/features/career/routes.ts
+++ b/src/features/career/routes.ts
@@ -1,4 +1,4 @@
-import { AugmentedRequestHandler } from "microrouter";
+import type { RouteHandler } from "../../shared/router";
 import {
   getCareerGoaliesData,
   getCareerHighlightsData,
@@ -42,21 +42,21 @@ const parsePagingParam = (
   return Number.isSafeInteger(parsed) ? parsed : null;
 };
 
-export const getCareerPlayer: AugmentedRequestHandler = async (req, res) => {
+export const getCareerPlayer: RouteHandler<{ id: string }> = async (req, res) => {
   await withErrorHandlingCached(req, res, async () => ({
     data: await getPlayerCareerData(req.params.id),
     dataSource: "db",
   }));
 };
 
-export const getCareerGoalie: AugmentedRequestHandler = async (req, res) => {
+export const getCareerGoalie: RouteHandler<{ id: string }> = async (req, res) => {
   await withErrorHandlingCached(req, res, async () => ({
     data: await getGoalieCareerData(req.params.id),
     dataSource: "db",
   }));
 };
 
-export const getCareerPlayers: AugmentedRequestHandler = async (req, res) => {
+export const getCareerPlayers: RouteHandler = async (req, res) => {
   await withErrorHandlingCached(req, res, () =>
     loadSnapshotOrFallback(getCareerPlayersSnapshotKey(), () =>
       getCareerPlayersData(),
@@ -64,7 +64,7 @@ export const getCareerPlayers: AugmentedRequestHandler = async (req, res) => {
   );
 };
 
-export const getCareerGoalies: AugmentedRequestHandler = async (req, res) => {
+export const getCareerGoalies: RouteHandler = async (req, res) => {
   await withErrorHandlingCached(req, res, () =>
     loadSnapshotOrFallback(getCareerGoaliesSnapshotKey(), () =>
       getCareerGoaliesData(),
@@ -72,7 +72,10 @@ export const getCareerGoalies: AugmentedRequestHandler = async (req, res) => {
   );
 };
 
-export const getCareerHighlights: AugmentedRequestHandler = async (req, res) => {
+export const getCareerHighlights: RouteHandler<{ type: string }> = async (
+  req,
+  res,
+) => {
   const rawType = req.params.type;
   if (!isCareerHighlightType(rawType)) {
     sendNoStore(

--- a/src/features/leaderboard/routes.ts
+++ b/src/features/leaderboard/routes.ts
@@ -1,4 +1,4 @@
-import { AugmentedRequestHandler } from "microrouter";
+import type { RouteHandler } from "../../shared/router";
 import {
   getPlayoffLeaderboardData,
   getRegularLeaderboardData,
@@ -14,7 +14,7 @@ import {
   withErrorHandlingCached,
 } from "../../shared/route-utils";
 
-export const getPlayoffsLeaderboard: AugmentedRequestHandler = async (
+export const getPlayoffsLeaderboard: RouteHandler = async (
   req,
   res,
 ) => {
@@ -25,7 +25,7 @@ export const getPlayoffsLeaderboard: AugmentedRequestHandler = async (
   );
 };
 
-export const getRegularLeaderboard: AugmentedRequestHandler = async (
+export const getRegularLeaderboard: RouteHandler = async (
   req,
   res,
 ) => {
@@ -36,7 +36,7 @@ export const getRegularLeaderboard: AugmentedRequestHandler = async (
   );
 };
 
-export const getTransactionsLeaderboard: AugmentedRequestHandler = async (
+export const getTransactionsLeaderboard: RouteHandler = async (
   req,
   res,
 ) => {

--- a/src/features/meta/routes.ts
+++ b/src/features/meta/routes.ts
@@ -1,4 +1,4 @@
-import { AugmentedRequestHandler } from "microrouter";
+import type { RouteHandler } from "../../shared/router";
 import {
   getAvailableSeasons,
   getLastModifiedData,
@@ -17,7 +17,7 @@ import {
 } from "../../shared/route-utils";
 import type { Report } from "../../shared/types";
 
-export const getSeasons: AugmentedRequestHandler = async (req, res) => {
+export const getSeasons: RouteHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
 
@@ -38,14 +38,14 @@ export const getSeasons: AugmentedRequestHandler = async (req, res) => {
   }));
 };
 
-export const getTeams: AugmentedRequestHandler = async (req, res) => {
+export const getTeams: RouteHandler = async (req, res) => {
   await withErrorHandlingCached(req, res, async () => ({
     data: getTeamsData(),
     dataSource: "db",
   }));
 };
 
-export const getLastModified: AugmentedRequestHandler = async (req, res) => {
+export const getLastModified: RouteHandler = async (req, res) => {
   await withErrorHandlingCached(req, res, async () => ({
     data: { lastModified: await getLastModifiedData() },
     dataSource: "db",

--- a/src/features/stats/routes.ts
+++ b/src/features/stats/routes.ts
@@ -1,4 +1,4 @@
-import { AugmentedRequestHandler } from "microrouter";
+import type { RouteHandler } from "../../shared/router";
 import {
   getGoaliesStatsCombined,
   getGoaliesStatsSeason,
@@ -24,7 +24,7 @@ import {
 } from "../../shared/route-utils";
 import type { Report } from "../../shared/types";
 
-export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
+export const getPlayersSeason: RouteHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
@@ -52,7 +52,7 @@ export const getPlayersSeason: AugmentedRequestHandler = async (req, res) => {
   }));
 };
 
-export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
+export const getPlayersCombined: RouteHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {
@@ -76,7 +76,7 @@ export const getPlayersCombined: AugmentedRequestHandler = async (req, res) => {
   );
 };
 
-export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
+export const getGoaliesSeason: RouteHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const season = parseSeasonParam(req.params.season);
   if (!reportTypeAvailable(req.params.reportType as Report)) {
@@ -104,7 +104,7 @@ export const getGoaliesSeason: AugmentedRequestHandler = async (req, res) => {
   }));
 };
 
-export const getGoaliesCombined: AugmentedRequestHandler = async (req, res) => {
+export const getGoaliesCombined: RouteHandler = async (req, res) => {
   const teamId = resolveTeamId(getQueryParam(req, "teamId"));
   const startFrom = parseSeasonParam(getQueryParam(req, "startFrom"));
   if (!reportTypeAvailable(req.params.reportType as Report)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import type { RequestHandler } from "micro";
 import { send } from "micro";
-import { router, get, AugmentedRequestHandler } from "microrouter";
-const cors = require("micro-cors")();
 
 import { withApiKeyAuth } from "./auth";
+import { createApp } from "./router";
+import { get, type RouteDefinition, type RouteHandler } from "./shared/router";
 
 import {
   getPlayersCombined,
@@ -32,13 +32,13 @@ import { getOpenApiSpec, getSwaggerUi } from "./openapi";
 import { HTTP_STATUS } from "./shared/http";
 import { sendNoStore } from "./shared/route-utils";
 
-const service: RequestHandler = async (_req, res) => {
+const service: RouteHandler = async (_req, res) => {
   send(res, 200, "Hello there! The FFHL Stats Service is running.");
 };
 
-const notFound: RequestHandler = (_req, res) => send(res, 404, "Route not exists");
+const notFound: RouteHandler = (_req, res) => send(res, 404, "Route not exists");
 
-export const getHealthcheck: AugmentedRequestHandler = async (_req, res) => {
+export const getHealthcheck: RouteHandler = async (_req, res) => {
   sendNoStore(res, HTTP_STATUS.OK, {
     status: "ok",
     uptimeSeconds: process.uptime(),
@@ -46,37 +46,43 @@ export const getHealthcheck: AugmentedRequestHandler = async (_req, res) => {
   });
 };
 
-// Generic wrapper: keep the handler's original (microrouter) request type.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const protectedRoute = <H extends (req: any, res: any) => any>(handler: H): H => withApiKeyAuth(handler);
+const protectedRoute = <H extends (...args: never[]) => unknown>(handler: H): H =>
+  withApiKeyAuth(handler as never) as H;
 
-const app = cors(
-  router(
-    get("/", service),
-    get("/healthcheck", getHealthcheck),
-    get("/health", getHealthcheck),
-    get("/last-modified", protectedRoute(getLastModified)),
-    get("/teams", protectedRoute(getTeams)),
-    get("/seasons", protectedRoute(getSeasons)),
-    get("/seasons/:reportType", protectedRoute(getSeasons)),
-    get("/players/season/:reportType/:season", protectedRoute(getPlayersSeason)),
-    get("/players/season/:reportType", protectedRoute(getPlayersSeason)),
-    get("/players/combined/:reportType", protectedRoute(getPlayersCombined)),
-    get("/goalies/season/:reportType/:season", protectedRoute(getGoaliesSeason)),
-    get("/goalies/season/:reportType", protectedRoute(getGoaliesSeason)),
-    get("/goalies/combined/:reportType", protectedRoute(getGoaliesCombined)),
-    get("/career/players", protectedRoute(getCareerPlayers)),
-    get("/career/goalies", protectedRoute(getCareerGoalies)),
-    get("/career/highlights/:type", protectedRoute(getCareerHighlights)),
-    get("/career/player/:id", protectedRoute(getCareerPlayer)),
-    get("/career/goalie/:id", protectedRoute(getCareerGoalie)),
-    get("/leaderboard/playoffs", protectedRoute(getPlayoffsLeaderboard)),
-    get("/leaderboard/regular", protectedRoute(getRegularLeaderboard)),
-    get("/leaderboard/transactions", protectedRoute(getTransactionsLeaderboard)),
-    get("/openapi.json", getOpenApiSpec),
-    get("/api-docs", getSwaggerUi),
-    get("/*", notFound)
-  )
-);
+const routes = [
+  get("/", service),
+  get("/healthcheck", getHealthcheck),
+  get("/health", getHealthcheck),
+  get("/last-modified", protectedRoute(getLastModified)),
+  get("/teams", protectedRoute(getTeams)),
+  get("/seasons", protectedRoute(getSeasons)),
+  get("/seasons/:reportType", protectedRoute(getSeasons)),
+  get("/players/season/:reportType/:season", protectedRoute(getPlayersSeason)),
+  get("/players/season/:reportType", protectedRoute(getPlayersSeason)),
+  get("/players/combined/:reportType", protectedRoute(getPlayersCombined)),
+  get("/goalies/season/:reportType/:season", protectedRoute(getGoaliesSeason)),
+  get("/goalies/season/:reportType", protectedRoute(getGoaliesSeason)),
+  get("/goalies/combined/:reportType", protectedRoute(getGoaliesCombined)),
+  get("/career/players", protectedRoute(getCareerPlayers)),
+  get("/career/goalies", protectedRoute(getCareerGoalies)),
+  get("/career/highlights/:type", protectedRoute(getCareerHighlights)),
+  get("/career/player/:id", protectedRoute(getCareerPlayer)),
+  get("/career/goalie/:id", protectedRoute(getCareerGoalie)),
+  get("/leaderboard/playoffs", protectedRoute(getPlayoffsLeaderboard)),
+  get("/leaderboard/regular", protectedRoute(getRegularLeaderboard)),
+  get("/leaderboard/transactions", protectedRoute(getTransactionsLeaderboard)),
+  get("/openapi.json", getOpenApiSpec),
+  get("/api-docs", getSwaggerUi),
+  get("/*", notFound),
+] satisfies ReadonlyArray<RouteDefinition>;
+
+let appPromise: Promise<RequestHandler> | undefined;
+
+const getApp = (): Promise<RequestHandler> => {
+  appPromise ??= createApp(routes);
+  return appPromise;
+};
+
+const app: RequestHandler = async (req, res) => (await getApp())(req, res);
 
 module.exports = Object.assign(app, { getHealthcheck });

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,75 @@
+import type { IncomingMessage } from "http";
+import type { RequestHandler } from "micro";
+import type { MatchedRoute } from "rou3";
+import type {
+  RouteDefinition,
+  RouteHandler,
+  RouteParams,
+  RouteRequest,
+} from "./shared/router";
+
+type CorsFactory = () => (handler: RequestHandler) => RequestHandler;
+type RouterModule = typeof import("rou3");
+type RouteData = {
+  handler: RouteHandler;
+};
+
+const microCors = require("micro-cors") as CorsFactory;
+const importRou3 = new Function(
+  "specifier",
+  "return import(specifier);",
+) as (specifier: string) => Promise<RouterModule>;
+
+const cors = microCors();
+
+const normalizeRoutePath = (path: string): string =>
+  path === "/*" ? "/**" : path;
+
+const getPathname = (req: IncomingMessage): string => {
+  const rawUrl = typeof req.url === "string" && req.url ? req.url : "/";
+  const host =
+    typeof req.headers.host === "string" ? req.headers.host : "localhost";
+
+  try {
+    return new URL(rawUrl, `http://${host}`).pathname;
+  } catch {
+    const pathname = rawUrl.split("?", 1)[0];
+    return pathname || "/";
+  }
+};
+
+const augmentRouteRequest = (
+  req: IncomingMessage,
+  params?: RouteParams,
+): RouteRequest => Object.assign(req, { params: params ?? {} }) as RouteRequest;
+
+export const createApp = async (
+  routes: readonly RouteDefinition[],
+): Promise<RequestHandler> => {
+  const { addRoute, createRouter, findRoute } =
+    await importRou3("rou3");
+  const router = createRouter<RouteData>();
+
+  for (const route of routes) {
+    addRoute(router, route.method, normalizeRoutePath(route.path), {
+      handler: route.handler,
+    });
+  }
+
+  return cors(async (req, res) => {
+    const match = findRoute(
+      router,
+      typeof req.method === "string" ? req.method.toUpperCase() : undefined,
+      getPathname(req),
+      { params: true },
+    ) as MatchedRoute<RouteData> | undefined;
+
+    if (!match) {
+      res.statusCode = 404;
+      res.end("Route not exists");
+      return;
+    }
+
+    return match.data.handler(augmentRouteRequest(req, match.params), res);
+  });
+};

--- a/src/shared/route-utils.ts
+++ b/src/shared/route-utils.ts
@@ -1,6 +1,5 @@
 import { send } from "micro";
-import { ServerResponse } from "microrouter";
-import type { IncomingMessage } from "http";
+import type { IncomingMessage, ServerResponse } from "http";
 import {
   buildCacheKey,
   isIfNoneMatchHit,

--- a/src/shared/router.ts
+++ b/src/shared/router.ts
@@ -1,0 +1,30 @@
+import type { IncomingMessage, ServerResponse } from "http";
+
+export type RouteParams = Record<string, string | undefined>;
+
+export type RouteRequest<TParams extends RouteParams = RouteParams> =
+  IncomingMessage & {
+    params: TParams;
+  };
+
+export type RouteHandler<TParams extends RouteParams = RouteParams> = {
+  bivarianceHack: (
+    req: RouteRequest<TParams>,
+    res: ServerResponse,
+  ) => unknown | Promise<unknown>;
+}["bivarianceHack"];
+
+export type RouteDefinition = {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+};
+
+export const get = <TParams extends RouteParams>(
+  path: string,
+  handler: RouteHandler<TParams>,
+): RouteDefinition => ({
+  method: "GET",
+  path,
+  handler: handler as RouteHandler,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "commonjs",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": [
       "es2022",
       "dom"


### PR DESCRIPTION
## Summary
- replace `microrouter` with a `rou3`-backed router adapter while keeping the existing `micro` HTTP layer
- add shared route typing plus focused router tests for params, catch-all matching, and URL fallback behavior
- switch TypeScript to `module` / `moduleResolution` `nodenext`, add `rou3`, and run Jest with `NODE_OPTIONS=--experimental-vm-modules`
- update README and dev/testing docs to reflect the current router stack and test runtime details

## Testing
- `npm run verify`
