### PR TITLE
Fix: Make rou3 import visible to Vercel

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -15,10 +15,6 @@ type RouteData = {
 };
 
 const microCors = require("micro-cors") as CorsFactory;
-const importRou3 = new Function(
-  "specifier",
-  "return import(specifier);",
-) as (specifier: string) => Promise<RouterModule>;
 
 const cors = microCors();
 
@@ -47,7 +43,7 @@ export const createApp = async (
   routes: readonly RouteDefinition[],
 ): Promise<RequestHandler> => {
   const { addRoute, createRouter, findRoute } =
-    await importRou3("rou3");
+    (await import("rou3")) as RouterModule;
   const router = createRouter<RouteData>();
 
   for (const route of routes) {


### PR DESCRIPTION
## Summary
- fix Vercel deployment packaging for `rou3`
- replace the `new Function(...import...)` loader with a normal `await import("rou3")`
- make the dependency visible to Vercel's tracer so `rou3` is included in the deployed bundle

## Testing
- `npm run verify`
