### PR TITLE
Fix: Entities only option for draft entities import

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ npm run snapshot:generate
 
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - development workflow, code standards, project structure, OpenAPI maintenance
 - [docs/TESTING.md](docs/TESTING.md) - test strategy, coverage expectations, integration testing rules
-- [docs/IMPORTING.md](docs/IMPORTING.md) - Fantrax sync/import workflows, FFHL draft sync, draft entity linking, CSV normalization
+- [docs/IMPORTING.md](docs/IMPORTING.md) - Fantrax sync/import workflows, FFHL draft sync, draft entity linking/backfill, CSV normalization
 - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) - Vercel, Turso, R2, API auth, caching, operational commands
 - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md) - snapshot-backed endpoints, generation rules, R2 snapshot storage
 - [docs/SCORING.md](docs/SCORING.md) - player and goalie scoring model details

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -302,10 +302,12 @@ Notes:
 - stored rows keep only team IDs plus pick metadata, not duplicated team names or source-file references
 - unresolved draft rows stay in the tables with `fantrax_entity_id = NULL` and their original scraped `player_name`
 - by default the importer targets `local.db`
+- use `--entities-only` to update only existing draft-table rows from the local mapping JSONs without rereading `entry-draft-{season}.json` or `opening-draft.json`
 
 Useful options:
 
 - `--dir=./custom/drafts`
+- `--entities-only`
 - `--season=2025`
 - `--opening-only`
 - `--dry-run`

--- a/scripts/db-import-drafts.ts
+++ b/scripts/db-import-drafts.ts
@@ -17,13 +17,17 @@ import { migrateDb } from "../src/db/schema.js";
 import {
   DEFAULT_ENTRY_DRAFT_OUT_DIR,
 } from "../src/features/drafts/parser.js";
-import { importDraftPicksToDb } from "../src/features/drafts/import.js";
+import {
+  applyDraftEntityMappingsToDb,
+  importDraftPicksToDb,
+} from "../src/features/drafts/import.js";
 
 const main = async (): Promise<void> => {
   const args = process.argv.slice(2);
   const outDirArg = args.find((arg) => arg.startsWith("--dir="));
   const seasonArg = args.find((arg) => arg.startsWith("--season="));
   const openingOnly = args.includes("--opening-only");
+  const entitiesOnly = args.includes("--entities-only");
   const dryRun = args.includes("--dry-run");
   const season =
     seasonArg !== undefined ? Number.parseInt(seasonArg.split("=")[1], 10) : undefined;
@@ -42,6 +46,32 @@ const main = async (): Promise<void> => {
 
   const db = getDbClient();
   await migrateDb(db);
+
+  if (entitiesOnly) {
+    const summary = await applyDraftEntityMappingsToDb({
+      db,
+      draftsDir,
+      dryRun,
+      season,
+      openingOnly,
+    });
+
+    console.info("✅ Draft entity backfill complete");
+    console.info(`   Draft dir: ${summary.draftsDir}`);
+    console.info(
+      `   Mode: ${
+        openingOnly
+          ? "opening only"
+          : season !== undefined
+            ? `entry season ${season}`
+            : "full backfill"
+      }`,
+    );
+    console.info(`   Entry rows updated: ${summary.entryUpdatedCount}`);
+    console.info(`   Opening rows updated: ${summary.openingUpdatedCount}`);
+    console.info(`   Dry run: ${summary.dryRun}`);
+    return;
+  }
 
   const summary = await importDraftPicksToDb({
     db,

--- a/src/__tests__/drafts.import.test.ts
+++ b/src/__tests__/drafts.import.test.ts
@@ -911,6 +911,158 @@ describe("draft DB import", () => {
     }
   });
 
+  test("uses the default draft directory for opening-only entity backfill", async () => {
+    const dbContext = await createIntegrationDb();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ffhl-draft-entities-defaults-"));
+    const previousCwd = process.cwd();
+    const defaultDraftDir = path.join(tempRoot, "src", "playwright", ".fantrax", "drafts");
+
+    try {
+      await fs.mkdir(defaultDraftDir, { recursive: true });
+      await insertOpeningDraftRow(dbContext.db, {
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "12",
+        ownerTeamId: "12",
+        playerName: "Old Opening Alias",
+        fantraxEntityId: "old-opening-id",
+      });
+      await writeDraftFile(defaultDraftDir, "entities-opening-draft.json", [
+        createOpeningEntityMapping(),
+      ]);
+
+      process.chdir(tempRoot);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        openingOnly: true,
+      });
+
+      expect(summary).toEqual({
+        draftsDir: await fs.realpath(defaultDraftDir),
+        entryUpdatedCount: 0,
+        openingUpdatedCount: 1,
+        dryRun: false,
+      });
+
+      const openingRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM opening_draft_picks`,
+      );
+      expect(openingRows.rows).toEqual([
+        {
+          player_name: "Canonical Opening Player",
+          fantrax_entity_id: "ftx-opening-1",
+        },
+      ]);
+
+      const metadata = await dbContext.db.execute({
+        sql: "SELECT value FROM import_metadata WHERE key = ?",
+        args: ["last_modified"],
+      });
+      expect(metadata.rows).toHaveLength(1);
+      expect((metadata.rows[0] as unknown as { value: string }).value).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await fs.rm(tempRoot, { recursive: true, force: true });
+      await dbContext.cleanup();
+    }
+  });
+
+  test("skips unchanged opening rows during entity-only backfill", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await insertOpeningDraftRow(dbContext.db, {
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "12",
+        ownerTeamId: "12",
+        playerName: "Canonical Opening Player",
+        fantraxEntityId: "ftx-opening-1",
+      });
+      await writeDraftFile(draftDir.dir, "entities-opening-draft.json", [
+        createOpeningEntityMapping(),
+      ]);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        draftsDir: draftDir.dir,
+        openingOnly: true,
+      });
+
+      expect(summary).toEqual({
+        draftsDir: path.resolve(draftDir.dir),
+        entryUpdatedCount: 0,
+        openingUpdatedCount: 0,
+        dryRun: false,
+      });
+
+      const openingRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM opening_draft_picks`,
+      );
+      expect(openingRows.rows).toEqual([
+        {
+          player_name: "Canonical Opening Player",
+          fantrax_entity_id: "ftx-opening-1",
+        },
+      ]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
+  test("updates null entry player names during entity-only backfill", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await insertEntryDraftRow(dbContext.db, {
+        season: 2025,
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "21",
+        ownerTeamId: "17",
+        playerName: null,
+      });
+      await writeDraftFile(draftDir.dir, "entities-entry-draft.json", [
+        createEntryEntityMapping(),
+      ]);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        draftsDir: draftDir.dir,
+        season: 2025,
+      });
+
+      expect(summary).toEqual({
+        draftsDir: path.resolve(draftDir.dir),
+        entryUpdatedCount: 1,
+        openingUpdatedCount: 0,
+        dryRun: false,
+      });
+
+      const entryRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM entry_draft_picks`,
+      );
+      expect(entryRows.rows).toEqual([
+        {
+          player_name: "Canonical Entry Player",
+          fantrax_entity_id: "ftx-entry-1",
+        },
+      ]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
   test("throws when entity-only mode combines season and openingOnly", async () => {
     const dbContext = await createIntegrationDb();
     const draftDir = await createTempDraftDir();

--- a/src/__tests__/drafts.import.test.ts
+++ b/src/__tests__/drafts.import.test.ts
@@ -3,7 +3,10 @@ import os from "os";
 import path from "path";
 
 import { createIntegrationDb } from "./integration-db.js";
-import { importDraftPicksToDb } from "../features/drafts/import.js";
+import {
+  applyDraftEntityMappingsToDb,
+  importDraftPicksToDb,
+} from "../features/drafts/import.js";
 import type { EntryDraftPick, OpeningDraftPick } from "../features/drafts/parser.js";
 
 const createTempDraftDir = async (): Promise<{
@@ -104,6 +107,61 @@ const createOpeningEntityMapping = (
   fantraxEntityName: "Canonical Opening Player",
   ...overrides,
 });
+
+const insertEntryDraftRow = async (
+  db: Awaited<ReturnType<typeof createIntegrationDb>>["db"],
+  row: {
+    season: number;
+    pickNumber: number;
+    round: number;
+    draftedTeamId: string;
+    ownerTeamId: string;
+    playerName: string | null;
+    fantraxEntityId?: string | null;
+  },
+): Promise<void> => {
+  await db.execute({
+    sql: `INSERT INTO entry_draft_picks (
+            season, pick_number, round, drafted_team_id, owner_team_id, player_name,
+            fantrax_entity_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      row.season,
+      row.pickNumber,
+      row.round,
+      row.draftedTeamId,
+      row.ownerTeamId,
+      row.playerName,
+      row.fantraxEntityId ?? null,
+    ],
+  });
+};
+
+const insertOpeningDraftRow = async (
+  db: Awaited<ReturnType<typeof createIntegrationDb>>["db"],
+  row: {
+    pickNumber: number;
+    round: number;
+    draftedTeamId: string;
+    ownerTeamId: string;
+    playerName: string;
+    fantraxEntityId?: string | null;
+  },
+): Promise<void> => {
+  await db.execute({
+    sql: `INSERT INTO opening_draft_picks (
+            pick_number, round, drafted_team_id, owner_team_id, player_name, fantrax_entity_id
+          ) VALUES (?, ?, ?, ?, ?, ?)`,
+    args: [
+      row.pickNumber,
+      row.round,
+      row.draftedTeamId,
+      row.ownerTeamId,
+      row.playerName,
+      row.fantraxEntityId ?? null,
+    ],
+  });
+};
 
 describe("draft DB import", () => {
   test("imports entry and opening draft picks into the database", async () => {
@@ -598,6 +656,274 @@ describe("draft DB import", () => {
         "SELECT COUNT(*) AS count FROM opening_draft_picks",
       );
       expect(openingCount.rows).toEqual([{ count: 0 }]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
+  test("applies entity mappings to existing draft rows without reimporting draft sources", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await insertEntryDraftRow(dbContext.db, {
+        season: 2025,
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "21",
+        ownerTeamId: "17",
+        playerName: "Entry Alias",
+      });
+      await insertOpeningDraftRow(dbContext.db, {
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "12",
+        ownerTeamId: "12",
+        playerName: "Opening Alias",
+      });
+      await writeDraftFile(draftDir.dir, "entities-entry-draft.json", [
+        createEntryEntityMapping(),
+      ]);
+      await writeDraftFile(draftDir.dir, "entities-opening-draft.json", [
+        createOpeningEntityMapping(),
+      ]);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        draftsDir: draftDir.dir,
+        importedAt: "2026-03-28T12:00:00.000Z",
+      });
+
+      expect(summary).toEqual({
+        draftsDir: path.resolve(draftDir.dir),
+        entryUpdatedCount: 1,
+        openingUpdatedCount: 1,
+        dryRun: false,
+      });
+
+      const entryRows = await dbContext.db.execute(
+        `SELECT season, pick_number, player_name, fantrax_entity_id
+         FROM entry_draft_picks`,
+      );
+      expect(entryRows.rows).toEqual([
+        {
+          season: 2025,
+          pick_number: 1,
+          player_name: "Canonical Entry Player",
+          fantrax_entity_id: "ftx-entry-1",
+        },
+      ]);
+
+      const openingRows = await dbContext.db.execute(
+        `SELECT pick_number, player_name, fantrax_entity_id
+         FROM opening_draft_picks`,
+      );
+      expect(openingRows.rows).toEqual([
+        {
+          pick_number: 1,
+          player_name: "Canonical Opening Player",
+          fantrax_entity_id: "ftx-opening-1",
+        },
+      ]);
+
+      const metadata = await dbContext.db.execute({
+        sql: "SELECT value FROM import_metadata WHERE key = ?",
+        args: ["last_modified"],
+      });
+      expect(metadata.rows).toEqual([{ value: "2026-03-28T12:00:00.000Z" }]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
+  test("supports season filters and dry-run mode for entity-only backfill", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await insertEntryDraftRow(dbContext.db, {
+        season: 2024,
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "21",
+        ownerTeamId: "17",
+        playerName: "Old 2024 Entry Alias",
+      });
+      await insertEntryDraftRow(dbContext.db, {
+        season: 2025,
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "21",
+        ownerTeamId: "17",
+        playerName: "Old 2025 Entry Alias",
+      });
+      await insertOpeningDraftRow(dbContext.db, {
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "12",
+        ownerTeamId: "12",
+        playerName: "Old Opening Alias",
+      });
+      await writeDraftFile(draftDir.dir, "entities-entry-draft.json", [
+        createEntryEntityMapping({
+          season: 2024,
+          fantraxEntityId: "ftx-entry-2024",
+          fantraxEntityName: "Canonical 2024 Entry Player",
+        }),
+        createEntryEntityMapping({
+          season: 2025,
+          fantraxEntityId: "ftx-entry-2025",
+          fantraxEntityName: "Canonical 2025 Entry Player",
+        }),
+      ]);
+      await writeDraftFile(draftDir.dir, "entities-opening-draft.json", [
+        createOpeningEntityMapping(),
+      ]);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        draftsDir: draftDir.dir,
+        season: 2025,
+        dryRun: true,
+      });
+
+      expect(summary).toEqual({
+        draftsDir: path.resolve(draftDir.dir),
+        entryUpdatedCount: 1,
+        openingUpdatedCount: 0,
+        dryRun: true,
+      });
+
+      const entryRows = await dbContext.db.execute(
+        `SELECT season, player_name, fantrax_entity_id
+         FROM entry_draft_picks
+         ORDER BY season ASC`,
+      );
+      expect(entryRows.rows).toEqual([
+        {
+          season: 2024,
+          player_name: "Old 2024 Entry Alias",
+          fantrax_entity_id: null,
+        },
+        {
+          season: 2025,
+          player_name: "Old 2025 Entry Alias",
+          fantrax_entity_id: null,
+        },
+      ]);
+
+      const openingRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM opening_draft_picks`,
+      );
+      expect(openingRows.rows).toEqual([
+        {
+          player_name: "Old Opening Alias",
+          fantrax_entity_id: null,
+        },
+      ]);
+
+      const metadata = await dbContext.db.execute({
+        sql: "SELECT value FROM import_metadata WHERE key = ?",
+        args: ["last_modified"],
+      });
+      expect(metadata.rows).toEqual([]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
+  test("skips unchanged and mismatched rows during entity-only backfill", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await insertEntryDraftRow(dbContext.db, {
+        season: 2025,
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "21",
+        ownerTeamId: "17",
+        playerName: "Canonical Entry Player",
+        fantraxEntityId: "ftx-entry-1",
+      });
+      await insertOpeningDraftRow(dbContext.db, {
+        pickNumber: 1,
+        round: 1,
+        draftedTeamId: "12",
+        ownerTeamId: "12",
+        playerName: "Opening Alias",
+      });
+      await writeDraftFile(draftDir.dir, "entities-entry-draft.json", [
+        createEntryEntityMapping(),
+      ]);
+      await writeDraftFile(draftDir.dir, "entities-opening-draft.json", [
+        createOpeningEntityMapping({
+          draftedTeamId: "8",
+        }),
+      ]);
+
+      const summary = await applyDraftEntityMappingsToDb({
+        db: dbContext.db,
+        draftsDir: draftDir.dir,
+      });
+
+      expect(summary).toEqual({
+        draftsDir: path.resolve(draftDir.dir),
+        entryUpdatedCount: 0,
+        openingUpdatedCount: 0,
+        dryRun: false,
+      });
+
+      const entryRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM entry_draft_picks`,
+      );
+      expect(entryRows.rows).toEqual([
+        {
+          player_name: "Canonical Entry Player",
+          fantrax_entity_id: "ftx-entry-1",
+        },
+      ]);
+
+      const openingRows = await dbContext.db.execute(
+        `SELECT player_name, fantrax_entity_id
+         FROM opening_draft_picks`,
+      );
+      expect(openingRows.rows).toEqual([
+        {
+          player_name: "Opening Alias",
+          fantrax_entity_id: null,
+        },
+      ]);
+
+      const metadata = await dbContext.db.execute({
+        sql: "SELECT value FROM import_metadata WHERE key = ?",
+        args: ["last_modified"],
+      });
+      expect(metadata.rows).toEqual([]);
+    } finally {
+      await draftDir.cleanup();
+      await dbContext.cleanup();
+    }
+  });
+
+  test("throws when entity-only mode combines season and openingOnly", async () => {
+    const dbContext = await createIntegrationDb();
+    const draftDir = await createTempDraftDir();
+
+    try {
+      await expect(
+        applyDraftEntityMappingsToDb({
+          db: dbContext.db,
+          draftsDir: draftDir.dir,
+          season: 2025,
+          openingOnly: true,
+        }),
+      ).rejects.toThrow("Use either season or openingOnly, not both.");
     } finally {
       await draftDir.cleanup();
       await dbContext.cleanup();

--- a/src/features/drafts/import.ts
+++ b/src/features/drafts/import.ts
@@ -40,7 +40,14 @@ export type DraftImportSummary = {
   dryRun: boolean;
 };
 
-type DraftDbWriter = Pick<Client, "batch">;
+export type DraftEntityBackfillSummary = {
+  draftsDir: string;
+  entryUpdatedCount: number;
+  openingUpdatedCount: number;
+  dryRun: boolean;
+};
+
+type DraftDbClient = Pick<Client, "batch" | "execute">;
 type EntryDraftEntityMapping = {
   id: number;
   season: number;
@@ -62,6 +69,8 @@ type EntryDraftStoredRow = EntryDraftImportRow & {
 type OpeningDraftStoredRow = OpeningDraftImportRow & {
   fantraxEntityId: string | null;
 };
+type EntryDraftDbRow = EntryDraftStoredRow;
+type OpeningDraftDbRow = OpeningDraftStoredRow;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -288,6 +297,21 @@ const readOpeningDraftEntityMappings = async (
   );
 };
 
+const loadDraftEntityMappings = async (draftsDir: string): Promise<{
+  entryMappingsByKey: ReadonlyMap<string, EntryDraftEntityMapping>;
+  openingMappingsByKey: ReadonlyMap<string, OpeningDraftEntityMapping>;
+}> => {
+  const [entryMappings, openingMappings] = await Promise.all([
+    readEntryDraftEntityMappings(path.resolve(draftsDir, ENTRY_DRAFT_ENTITY_FILE_NAME)),
+    readOpeningDraftEntityMappings(path.resolve(draftsDir, OPENING_DRAFT_ENTITY_FILE_NAME)),
+  ]);
+
+  return {
+    entryMappingsByKey: buildEntryDraftEntityMappingByKey(entryMappings),
+    openingMappingsByKey: buildOpeningDraftEntityMappingByKey(openingMappings),
+  };
+};
+
 const resolveDraftFiles = async (args: {
   draftsDir: string;
   season?: number;
@@ -469,8 +493,61 @@ const buildOpeningDraftStatements = (
   })),
 ];
 
+const loadEntryDraftRowsFromDb = async (
+  db: Pick<Client, "execute">,
+  season?: number,
+): Promise<EntryDraftDbRow[]> => {
+  const result =
+    season === undefined
+      ? await db.execute(
+          `SELECT season, pick_number, round, drafted_team_id, owner_team_id, player_name,
+                  fantrax_entity_id
+           FROM entry_draft_picks
+           ORDER BY season ASC, pick_number ASC`,
+        )
+      : await db.execute({
+          sql: `SELECT season, pick_number, round, drafted_team_id, owner_team_id, player_name,
+                       fantrax_entity_id
+                FROM entry_draft_picks
+                WHERE season = ?
+                ORDER BY season ASC, pick_number ASC`,
+          args: [season],
+        });
+
+  return result.rows.map((row) => ({
+    season: Number(row.season),
+    pickNumber: Number(row.pick_number),
+    round: Number(row.round),
+    draftedTeamId: String(row.drafted_team_id),
+    ownerTeamId: String(row.owner_team_id),
+    playerName: row.player_name === null ? null : String(row.player_name),
+    fantraxEntityId:
+      row.fantrax_entity_id === null ? null : String(row.fantrax_entity_id),
+  }));
+};
+
+const loadOpeningDraftRowsFromDb = async (
+  db: Pick<Client, "execute">,
+): Promise<OpeningDraftDbRow[]> => {
+  const result = await db.execute(
+    `SELECT pick_number, round, drafted_team_id, owner_team_id, player_name, fantrax_entity_id
+     FROM opening_draft_picks
+     ORDER BY pick_number ASC`,
+  );
+
+  return result.rows.map((row) => ({
+    pickNumber: Number(row.pick_number),
+    round: Number(row.round),
+    draftedTeamId: String(row.drafted_team_id),
+    ownerTeamId: String(row.owner_team_id),
+    playerName: String(row.player_name),
+    fantraxEntityId:
+      row.fantrax_entity_id === null ? null : String(row.fantrax_entity_id),
+  }));
+};
+
 export const importDraftPicksToDb = async (args: {
-  db: DraftDbWriter;
+  db: DraftDbClient;
   draftsDir?: string;
   dryRun?: boolean;
   importedAt?: string;
@@ -487,11 +564,14 @@ export const importDraftPicksToDb = async (args: {
     season: args.season,
     openingOnly: args.openingOnly,
   });
-  const [entryDrafts, openingDraft, entryMappings, openingMappings] = await Promise.all([
+  const [
+    entryDrafts,
+    openingDraft,
+    { entryMappingsByKey, openingMappingsByKey },
+  ] = await Promise.all([
     Promise.all(entryFiles.map(readEntryDraftFile)),
     openingFile ? readOpeningDraftFile(openingFile) : Promise.resolve([]),
-    readEntryDraftEntityMappings(path.resolve(draftsDir, ENTRY_DRAFT_ENTITY_FILE_NAME)),
-    readOpeningDraftEntityMappings(path.resolve(draftsDir, OPENING_DRAFT_ENTITY_FILE_NAME)),
+    loadDraftEntityMappings(draftsDir),
   ]);
   const summary: DraftImportSummary = {
     draftsDir,
@@ -506,8 +586,6 @@ export const importDraftPicksToDb = async (args: {
     return summary;
   }
 
-  const entryMappingsByKey = buildEntryDraftEntityMappingByKey(entryMappings);
-  const openingMappingsByKey = buildOpeningDraftEntityMappingByKey(openingMappings);
   const storedEntryDrafts = entryDrafts.map((draft) => ({
     season: draft.season,
     picks: draft.picks.map<EntryDraftStoredRow>((pick) => {
@@ -538,6 +616,98 @@ export const importDraftPicksToDb = async (args: {
       args: ["last_modified", args.importedAt ?? new Date().toISOString()],
     },
   ];
+
+  await args.db.batch(statements, "write");
+
+  return summary;
+};
+
+export const applyDraftEntityMappingsToDb = async (args: {
+  db: DraftDbClient;
+  draftsDir?: string;
+  dryRun?: boolean;
+  importedAt?: string;
+  season?: number;
+  openingOnly?: boolean;
+}): Promise<DraftEntityBackfillSummary> => {
+  if (args.openingOnly && args.season !== undefined) {
+    throw new Error("Use either season or openingOnly, not both.");
+  }
+
+  const draftsDir = path.resolve(args.draftsDir ?? getDefaultDraftsDir());
+  const [{ entryMappingsByKey, openingMappingsByKey }, entryRows, openingRows] =
+    await Promise.all([
+      loadDraftEntityMappings(draftsDir),
+      args.openingOnly ? Promise.resolve([]) : loadEntryDraftRowsFromDb(args.db, args.season),
+      args.season !== undefined ? Promise.resolve([]) : loadOpeningDraftRowsFromDb(args.db),
+    ]);
+  const statements: InStatement[] = [];
+  const summary: DraftEntityBackfillSummary = {
+    draftsDir,
+    entryUpdatedCount: 0,
+    openingUpdatedCount: 0,
+    dryRun: args.dryRun ?? false,
+  };
+
+  for (const row of entryRows) {
+    const mapping = getEntryDraftEntityMapping(entryMappingsByKey, row);
+    if (
+      mapping === undefined ||
+      (row.fantraxEntityId === mapping.fantraxEntityId &&
+        row.playerName === mapping.fantraxEntityName)
+    ) {
+      continue;
+    }
+
+    summary.entryUpdatedCount += 1;
+
+    statements.push({
+      sql: `UPDATE entry_draft_picks
+            SET fantrax_entity_id = ?, player_name = ?
+            WHERE season = ? AND pick_number = ? AND drafted_team_id = ?`,
+      args: [
+        mapping.fantraxEntityId,
+        mapping.fantraxEntityName,
+        row.season,
+        row.pickNumber,
+        row.draftedTeamId,
+      ],
+    });
+  }
+
+  for (const row of openingRows) {
+    const mapping = getOpeningDraftEntityMapping(openingMappingsByKey, row);
+    if (
+      mapping === undefined ||
+      (row.fantraxEntityId === mapping.fantraxEntityId &&
+        row.playerName === mapping.fantraxEntityName)
+    ) {
+      continue;
+    }
+
+    summary.openingUpdatedCount += 1;
+
+    statements.push({
+      sql: `UPDATE opening_draft_picks
+            SET fantrax_entity_id = ?, player_name = ?
+            WHERE pick_number = ? AND drafted_team_id = ?`,
+      args: [
+        mapping.fantraxEntityId,
+        mapping.fantraxEntityName,
+        row.pickNumber,
+        row.draftedTeamId,
+      ],
+    });
+  }
+
+  if (summary.dryRun || statements.length === 0) {
+    return summary;
+  }
+
+  statements.push({
+    sql: "INSERT OR REPLACE INTO import_metadata (key, value) VALUES (?, ?)",
+    args: ["last_modified", args.importedAt ?? new Date().toISOString()],
+  });
 
   await args.db.batch(statements, "write");
 


### PR DESCRIPTION
## Summary
- add `--entities-only` support to `scripts/db-import-drafts.ts` so draft entity links and canonical names can be backfilled without reimporting draft source JSON
- add in-place draft entity backfill logic in `src/features/drafts/import.ts`
- keep rows without a matching entity mapping untouched, while updating matched rows by natural draft keys
  - entry draft: `season + pickNumber`
  - opening draft: `pickNumber`

## Testing
- `npm run verify`

## Notes
- entity-only backfill also supports `--season`, `--opening-only`, and `--dry-run`
- added coverage for default draft-dir resolution, dry-run behavior, unchanged rows, mismatched team safety checks, and null-name entry rows
- documented `--entities-only` usage in `docs/IMPORTING.md`
