### PR TITLE
Feature: Add played percentages to entry draft summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -H "x-api-key: <your-key>" \
   "https://ffhl-stats-api.vercel.app/draft/entry"
 ```
 
-`/draft/entry` includes per-pick `playedInLeague` and `playedForDraftingTeam` flags plus matching team-summary counts.
+`/draft/entry` includes per-pick `playedInLeague` and `playedForDraftingTeam` flags plus matching team-summary counts and percentages.
 
 ### Meta
 

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -297,7 +297,7 @@ Notes:
 - entry-draft entity mappings are matched by `season + pickNumber`
 - opening-draft entity mappings are matched by `pickNumber`
 - draft entity mappings also carry `draftedTeamId`; if the imported row no longer matches that team, the importer skips the mapping instead of forcing a stale link
-- entry-draft `fantrax_entity_id` links also power the API's per-pick `playedInLeague` and `playedForDraftingTeam` flags plus matching team summary counts
+- entry-draft `fantrax_entity_id` links also power the API's per-pick `playedInLeague` and `playedForDraftingTeam` flags plus matching team summary counts and percentages
 - entry-draft imports replace only the imported season rows
 - opening-draft import clears and reloads the whole `opening_draft_picks` table
 - stored rows keep only team IDs plus pick metadata, not duplicated team names or source-file references

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -228,7 +228,9 @@ components:
           tradedPicks,
           playersPerDraftAverage,
           playedInLeague,
+          playedInLeaguePercent,
           playedForDraftingTeam,
+          playedForDraftingTeamPercent,
         ]
       properties:
         total:
@@ -248,10 +250,18 @@ components:
           type: integer
           description: Drafted players with at least one games-played row in `players` or `goalies` for any fantasy team.
           example: 28
+        playedInLeaguePercent:
+          type: number
+          description: Fraction of drafted players who appeared in league games for any fantasy team, rounded to three decimals.
+          example: 0.7
         playedForDraftingTeam:
           type: integer
           description: Drafted players with at least one games-played row for the same fantasy team that drafted them.
           example: 14
+        playedForDraftingTeamPercent:
+          type: number
+          description: Fraction of drafted players who appeared in league games for the fantasy team that drafted them, rounded to three decimals.
+          example: 0.35
 
     EntryDraftRoundsSummary:
       type: object
@@ -1626,8 +1636,8 @@ paths:
         Each team's `seasons` array is sorted newest-first, and picks within one season
         are sorted by draft order.
         Team roots also include a `summary` object with highest-pick, average-position,
-        pick-count aggregates, played counts, and a fixed round breakdown calculated from
-        the grouped data.
+        pick-count aggregates, played counts, played percentages, and a fixed round
+        breakdown calculated from the grouped data.
         Each pick also includes `playedInLeague` and `playedForDraftingTeam` flags based
         on whether the linked Fantrax entity has games-played rows in `players` or
         `goalies`.

--- a/src/__tests__/routes.integration.drafts.ts
+++ b/src/__tests__/routes.integration.drafts.ts
@@ -331,7 +331,9 @@ export const registerDraftRouteIntegrationTests = (): void => {
                 tradedPicks: 1,
                 playersPerDraftAverage: 0.5,
                 playedInLeague: 1,
+                playedInLeaguePercent: 1,
                 playedForDraftingTeam: 0,
+                playedForDraftingTeamPercent: 0,
               },
               rounds: {
                 first: 1,
@@ -411,7 +413,9 @@ export const registerDraftRouteIntegrationTests = (): void => {
                 tradedPicks: 1,
                 playersPerDraftAverage: 2,
                 playedInLeague: 3,
+                playedInLeaguePercent: 0.75,
                 playedForDraftingTeam: 2,
+                playedForDraftingTeamPercent: 0.5,
               },
               rounds: {
                 first: 3,

--- a/src/__tests__/services.drafts.test.ts
+++ b/src/__tests__/services.drafts.test.ts
@@ -230,7 +230,9 @@ describe("draft services", () => {
               tradedPicks: 1,
               playersPerDraftAverage: 0.5,
               playedInLeague: 1,
+              playedInLeaguePercent: 1,
               playedForDraftingTeam: 0,
+              playedForDraftingTeamPercent: 0,
             },
             rounds: {
               first: 1,
@@ -310,7 +312,9 @@ describe("draft services", () => {
               tradedPicks: 1,
               playersPerDraftAverage: 2,
               playedInLeague: 3,
+              playedInLeaguePercent: 0.75,
               playedForDraftingTeam: 2,
+              playedForDraftingTeamPercent: 0.5,
             },
             rounds: {
               first: 3,
@@ -365,7 +369,9 @@ describe("draft services", () => {
               tradedPicks: 0,
               playersPerDraftAverage: 0,
               playedInLeague: 0,
+              playedInLeaguePercent: 0,
               playedForDraftingTeam: 0,
+              playedForDraftingTeamPercent: 0,
             },
             rounds: {
               first: 0,

--- a/src/features/drafts/service.ts
+++ b/src/features/drafts/service.ts
@@ -62,7 +62,9 @@ export type EntryDraftTeamSummary = {
     tradedPicks: number;
     playersPerDraftAverage: number;
     playedInLeague: number;
+    playedInLeaguePercent: number;
     playedForDraftingTeam: number;
+    playedForDraftingTeamPercent: number;
   };
   rounds: EntryDraftRoundsSummary;
 };
@@ -145,6 +147,9 @@ const toDraftPickResponse = (pick: DraftPick): DraftPick => ({
 const roundDraftAverage = (value: number): number =>
   Math.round((value + Number.EPSILON) * 100) / 100;
 
+const roundDraftPercent = (count: number, total: number): number =>
+  total > 0 ? Math.round(((count / total) + Number.EPSILON) * 1000) / 1000 : 0;
+
 const isDraftedEntryPick = (
   pick: DraftPick & { season: number },
 ): pick is DraftedEntryPick => pick.draftedPlayer !== null;
@@ -173,6 +178,10 @@ const buildEntryDraftTeamSummary = (
   const total = draftedPicks.length;
   const ownPicks = draftedPicks.filter(
     (pick) => pick.originalOwner.id === teamId,
+  ).length;
+  const playedInLeague = draftedPicks.filter((pick) => pick.playedInLeague).length;
+  const playedForDraftingTeam = draftedPicks.filter(
+    (pick) => pick.playedForDraftingTeam,
   ).length;
   const highestPickNumber =
     draftedPicks.length > 0
@@ -205,10 +214,13 @@ const buildEntryDraftTeamSummary = (
       ownPicks,
       tradedPicks: total - ownPicks,
       playersPerDraftAverage: roundDraftAverage(total / seasons.length),
-      playedInLeague: draftedPicks.filter((pick) => pick.playedInLeague).length,
-      playedForDraftingTeam: draftedPicks.filter(
-        (pick) => pick.playedForDraftingTeam,
-      ).length,
+      playedInLeague,
+      playedInLeaguePercent: roundDraftPercent(playedInLeague, total),
+      playedForDraftingTeam,
+      playedForDraftingTeamPercent: roundDraftPercent(
+        playedForDraftingTeam,
+        total,
+      ),
     },
     rounds: buildRoundsSummary(draftedPicks),
   };


### PR DESCRIPTION
## Summary
- add `playedInLeaguePercent` and `playedForDraftingTeamPercent` to `/draft/entry` team `summary.amounts`
- calculate both as 0..1 fractions with zero-safe handling and three-decimal rounding
- update draft service tests, route integration coverage, and OpenAPI/docs to reflect the new response shape

## Testing
- npm run verify
