### PR TITLE
Feature: Add finals leaderboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ curl -H "x-api-key: <your-key>" \
 
 curl -H "x-api-key: <your-key>" \
   "https://ffhl-stats-api.vercel.app/leaderboard/transactions"
+
+curl -H "x-api-key: <your-key>" \
+  "https://ffhl-stats-api.vercel.app/leaderboard/finals"
 ```
 
 ### Draft

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -83,3 +83,28 @@ Weights live in `src/config/settings.ts`:
 - `GOALIE_SCORE_WEIGHTS`
 
 Each weight is a decimal between `0` and `1`. Lowering a weight reduces that stat's influence without changing the overall `0-100` scale.
+
+## Finals Rates
+
+`/leaderboard/finals` returns a `rates` object for each imported finals season:
+
+- `winRate`: the champion's raw finals match-points share, `winnerMatchPoints / totalCategories * 100`
+- `deservedToWinRate`: a games-adjusted finals strength model that compares the actual winner against the loser category by category
+
+The finals model:
+
+- uses skater games for skater counting stats and goalie games for goalie counting stats
+- keeps `hits` and `blocks` at full weight
+- only downweights three noisier swing categories
+
+Current finals weights:
+
+- `plusMinus`: `0.75`
+- `shp`: `0.6`
+- `shutouts`: `0.6`
+- every other finals category: `1.0`
+
+Goalie qualification behavior matches the imported finals data:
+
+- `wins`, `saves`, and `shutouts` always stay numeric
+- `gaa` and `savePercent` become `null` when a finalist misses the two-goalie-game minimum

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1505,6 +1505,192 @@ components:
           type: integer
           description: Count of distinct goalie Fantrax entity IDs the team rostered that season.
 
+    FinalsLeaderboardEntry:
+      type: object
+      required:
+        - season
+        - wonOnHomeTiebreak
+        - winnerTeamId
+        - winnerTeamName
+        - awayTeam
+        - homeTeam
+        - categories
+        - rates
+      properties:
+        season:
+          type: integer
+        wonOnHomeTiebreak:
+          type: boolean
+        winnerTeamId:
+          type: string
+        winnerTeamName:
+          type: string
+        awayTeam:
+          $ref: "#/components/schemas/FinalsLeaderboardTeam"
+        homeTeam:
+          $ref: "#/components/schemas/FinalsLeaderboardTeam"
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/FinalsLeaderboardCategory"
+        rates:
+          $ref: "#/components/schemas/FinalsLeaderboardRates"
+
+    FinalsLeaderboardTeam:
+      type: object
+      required:
+        - teamId
+        - teamName
+        - score
+        - playedGames
+        - totals
+      properties:
+        teamId:
+          type: string
+        teamName:
+          type: string
+        score:
+          $ref: "#/components/schemas/FinalsLeaderboardScore"
+        playedGames:
+          $ref: "#/components/schemas/FinalsLeaderboardPlayedGames"
+        totals:
+          $ref: "#/components/schemas/FinalsLeaderboardTeamTotals"
+
+    FinalsLeaderboardScore:
+      type: object
+      required:
+        - matchPoints
+        - categoriesWon
+        - categoriesLost
+        - categoriesTied
+      properties:
+        matchPoints:
+          type: number
+        categoriesWon:
+          type: integer
+        categoriesLost:
+          type: integer
+        categoriesTied:
+          type: integer
+
+    FinalsLeaderboardPlayedGames:
+      type: object
+      required:
+        - total
+        - skaters
+        - goalies
+      properties:
+        total:
+          type: integer
+        skaters:
+          type: integer
+        goalies:
+          type: integer
+
+    FinalsLeaderboardTeamTotals:
+      type: object
+      required:
+        - goals
+        - assists
+        - points
+        - plusMinus
+        - penalties
+        - shots
+        - ppp
+        - shp
+        - hits
+        - blocks
+        - wins
+        - saves
+        - shutouts
+        - gaa
+        - savePercent
+      properties:
+        goals:
+          type: integer
+        assists:
+          type: integer
+        points:
+          type: integer
+        plusMinus:
+          type: integer
+        penalties:
+          type: integer
+        shots:
+          type: integer
+        ppp:
+          type: integer
+        shp:
+          type: integer
+        hits:
+          type: integer
+        blocks:
+          type: integer
+        wins:
+          type: integer
+        saves:
+          type: integer
+        shutouts:
+          type: integer
+        gaa:
+          type: number
+          nullable: true
+        savePercent:
+          type: number
+          nullable: true
+
+    FinalsStatKey:
+      type: string
+      enum:
+        - goals
+        - assists
+        - points
+        - plusMinus
+        - penalties
+        - shots
+        - ppp
+        - shp
+        - hits
+        - blocks
+        - wins
+        - saves
+        - shutouts
+        - gaa
+        - savePercent
+
+    FinalsLeaderboardCategory:
+      type: object
+      required:
+        - statKey
+        - awayValue
+        - homeValue
+        - winnerTeamId
+      properties:
+        statKey:
+          $ref: "#/components/schemas/FinalsStatKey"
+        awayValue:
+          type: number
+          nullable: true
+        homeValue:
+          type: number
+          nullable: true
+        winnerTeamId:
+          type: string
+          nullable: true
+
+    FinalsLeaderboardRates:
+      type: object
+      required:
+        - winRate
+        - deservedToWinRate
+      properties:
+        winRate:
+          type: number
+          description: The actual finals scoreboard share for the champion, equivalent to raw match-points share.
+        deservedToWinRate:
+          type: number
+          description: A weighted, games-adjusted finals strength model that downweights plusMinus, SHP, and shutouts.
+
 security:
   - apiKey: []
 
@@ -2030,5 +2216,24 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TransactionLeaderboardEntry"
+        "401":
+          description: Missing or invalid API key.
+
+  /leaderboard/finals:
+    get:
+      summary: Finals matchup leaderboard
+      description: |
+        Returns one finals matchup summary per imported season, including away/home team details,
+        category results, and a `rates` object with both the actual win share and a modeled
+        deserved-to-win percentage.
+      responses:
+        "200":
+          description: Finals matchup summaries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FinalsLeaderboardEntry"
         "401":
           description: Missing or invalid API key.

--- a/src/__tests__/finals.scoring.test.ts
+++ b/src/__tests__/finals.scoring.test.ts
@@ -1,0 +1,711 @@
+import {
+  buildFinalsScoringContext,
+  calculateWeightedEdgeRate,
+  calculateWinRate,
+  FINALS_DESERVED_TO_WIN_WEIGHTS,
+} from "../features/finals/scoring.js";
+import type {
+  FinalsMatchupDbEntry,
+  FinalsModelWeights,
+  FinalsTeamData,
+} from "../features/finals/types.js";
+
+const createTeam = (
+  teamId: string,
+  overrides: Partial<FinalsTeamData> = {},
+): FinalsTeamData => {
+  const base: FinalsTeamData = {
+    teamId,
+    isWinner: false,
+    score: {
+      matchPoints: 7.5,
+      categoriesWon: 7,
+      categoriesLost: 7,
+      categoriesTied: 1,
+    },
+    playedGames: {
+      total: 12,
+      skaters: 10,
+      goalies: 2,
+    },
+    totals: {
+      goals: 10,
+      assists: 10,
+      points: 20,
+      plusMinus: 2,
+      penalties: 12,
+      shots: 80,
+      ppp: 6,
+      shp: 1,
+      hits: 30,
+      blocks: 20,
+      wins: 1,
+      saves: 50,
+      shutouts: 0,
+      gaa: 2.5,
+      savePercent: 0.91,
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    score: {
+      ...base.score,
+      ...overrides.score,
+    },
+    playedGames: {
+      ...base.playedGames,
+      ...overrides.playedGames,
+    },
+    totals: {
+      ...base.totals,
+      ...overrides.totals,
+    },
+  };
+};
+
+const createMatchup = (
+  overrides: {
+    season?: number;
+    wonOnHomeTiebreak?: boolean;
+    winnerTeamId?: string;
+    awayTeam?: Partial<FinalsTeamData>;
+    homeTeam?: Partial<FinalsTeamData>;
+  } = {},
+): FinalsMatchupDbEntry => {
+  const {
+    awayTeam: awayOverrides,
+    homeTeam: homeOverrides,
+    season = 2024,
+    wonOnHomeTiebreak = false,
+    winnerTeamId = "1",
+  } = overrides;
+
+  return {
+    season,
+    wonOnHomeTiebreak,
+    winnerTeamId,
+    awayTeam: createTeam("1", {
+      isWinner: true,
+      score: {
+        matchPoints: 8.5,
+        categoriesWon: 8,
+        categoriesLost: 6,
+        categoriesTied: 1,
+      },
+      ...awayOverrides,
+    }),
+    homeTeam: createTeam("2", homeOverrides),
+  };
+};
+
+describe("finals scoring", () => {
+  test("builds a minimum plus-minus scale when no matchups are available", () => {
+    expect(buildFinalsScoringContext([])).toEqual({
+      plusMinusRateScale: 0.05,
+    });
+  });
+
+  test("calculates winRate from match points and falls back to 50 with no categories", () => {
+    expect(calculateWinRate(createMatchup())).toBe(56.7);
+
+    expect(
+      calculateWinRate(
+        createMatchup({
+          awayTeam: {
+            score: {
+              matchPoints: 0,
+              categoriesWon: 0,
+              categoriesLost: 0,
+              categoriesTied: 0,
+            },
+          },
+        }),
+      ),
+    ).toBe(50);
+  });
+
+  test("returns 50 when the finalists are identical", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        score: {
+          matchPoints: 7.5,
+          categoriesWon: 7,
+          categoriesLost: 7,
+          categoriesTied: 1,
+        },
+      },
+      homeTeam: {
+        score: {
+          matchPoints: 7.5,
+          categoriesWon: 7,
+          categoriesLost: 7,
+          categoriesTied: 1,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBe(50);
+  });
+
+  test("returns neutral when both finalists have zero skater exposure", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        playedGames: { total: 2, skaters: 0, goalies: 2 },
+        totals: {
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 0,
+          hits: 0,
+          blocks: 0,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 2, skaters: 0, goalies: 2 },
+        totals: {
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 0,
+          hits: 0,
+          blocks: 0,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBe(50);
+  });
+
+  test("favors better per-game pace even when the raw total is lower", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        playedGames: { total: 6, skaters: 4, goalies: 2 },
+        totals: {
+          goals: 4,
+          assists: 4,
+          points: 8,
+          plusMinus: 2,
+          penalties: 4,
+          shots: 24,
+          ppp: 2,
+          shp: 0,
+          hits: 12,
+          blocks: 8,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 5,
+          assists: 5,
+          points: 10,
+          plusMinus: 2,
+          penalties: 10,
+          shots: 50,
+          ppp: 3,
+          shp: 0,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBeGreaterThan(50);
+  });
+
+  test("downweights plus-minus, SHP, and shutouts in the deserved rate", () => {
+    const allOneWeights = Object.fromEntries(
+      Object.keys(FINALS_DESERVED_TO_WIN_WEIGHTS).map((key) => [key, 1]),
+    ) as FinalsModelWeights;
+    const matchup = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: -10,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 0,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 10,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 3,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 2,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+    });
+    const context = buildFinalsScoringContext([matchup]);
+
+    expect(
+      calculateWeightedEdgeRate(matchup, FINALS_DESERVED_TO_WIN_WEIGHTS, context),
+    ).toBeGreaterThan(calculateWeightedEdgeRate(matchup, allOneWeights, context));
+  });
+
+  test("respects goalie-rate qualification, null rate values, and zero-weight fallbacks", () => {
+    const qualifiedWinner = createMatchup({
+      winnerTeamId: "2",
+      awayTeam: {
+        isWinner: false,
+        score: {
+          matchPoints: 6.5,
+          categoriesWon: 6,
+          categoriesLost: 8,
+          categoriesTied: 1,
+        },
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 30,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        isWinner: true,
+        score: {
+          matchPoints: 8.5,
+          categoriesWon: 8,
+          categoriesLost: 6,
+          categoriesTied: 1,
+        },
+      },
+    });
+    const disqualifiedWinner = createMatchup({
+      awayTeam: {
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 30,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+    });
+    const bothUnqualified = createMatchup({
+      awayTeam: {
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 30,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 30,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+    });
+    const nullRatesDespiteQualification = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+    });
+    const zeroWeightRate = calculateWeightedEdgeRate(
+      createMatchup(),
+      {
+        goals: 0,
+        assists: 0,
+        points: 0,
+        plusMinus: 0,
+        penalties: 0,
+        shots: 0,
+        ppp: 0,
+        shp: 0,
+        hits: 0,
+        blocks: 0,
+        wins: 0,
+        saves: 0,
+        shutouts: 0,
+        gaa: 0,
+        savePercent: 0,
+      },
+      buildFinalsScoringContext([]),
+    );
+
+    expect(
+      calculateWeightedEdgeRate(
+        qualifiedWinner,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([qualifiedWinner]),
+      ),
+    ).toBeGreaterThan(50);
+    expect(
+      calculateWeightedEdgeRate(
+        disqualifiedWinner,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([disqualifiedWinner]),
+      ),
+    ).toBeLessThan(50);
+    expect(
+      calculateWeightedEdgeRate(
+        bothUnqualified,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([bothUnqualified]),
+      ),
+    ).toBe(50);
+    expect(
+      calculateWeightedEdgeRate(
+        nullRatesDespiteQualification,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([nullRatesDespiteQualification]),
+      ),
+    ).toBe(50);
+    expect(zeroWeightRate).toBe(50);
+  });
+
+  test("handles zero-shot save percentage comparisons without blowing up", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.1,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBeGreaterThan(50);
+  });
+
+  test("treats tied zero-shot save percentage cases as neutral and can penalize the winner", () => {
+    const tiedZeroShotMatchup = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0,
+        },
+      },
+    });
+    const loserBetterZeroShotMatchup = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 0,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.1,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        tiedZeroShotMatchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([tiedZeroShotMatchup]),
+      ),
+    ).toBe(50);
+    expect(
+      calculateWeightedEdgeRate(
+        loserBetterZeroShotMatchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([loserBetterZeroShotMatchup]),
+      ),
+    ).toBeLessThan(50);
+  });
+
+  test("treats identical perfect qualified goalie rates as neutral", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 2,
+          saves: 20,
+          shutouts: 2,
+          gaa: 0,
+          savePercent: 1,
+        },
+      },
+      homeTeam: {
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 2,
+          saves: 20,
+          shutouts: 2,
+          gaa: 0,
+          savePercent: 1,
+        },
+      },
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBe(50);
+  });
+});

--- a/src/__tests__/queries.results.test.ts
+++ b/src/__tests__/queries.results.test.ts
@@ -7,6 +7,8 @@ jest.mock("../db/client", () => {
 
 import { getDbClient } from "../db/client.js";
 import {
+  getFinalsCategories,
+  getFinalsMatchups,
   getPlayoffLeaderboard,
   getPlayoffSeasons,
   getRegularLeaderboard,
@@ -345,6 +347,146 @@ describe("db/queries", () => {
         const result = await getTransactionSeasons();
 
         expect(result).toEqual([]);
+      });
+    });
+
+    describe("getFinalsMatchups", () => {
+      test("returns mapped finals matchup rows with nested away and home teams", async () => {
+        mockExecute.mockResolvedValue({
+          rows: [
+            {
+              season: 2024,
+              home_tiebreak_won: 0,
+              winner_team_id: "4",
+              away_team_id: "1",
+              away_is_winner: 0,
+              away_categories_won: 6,
+              away_categories_lost: 8,
+              away_categories_tied: 1,
+              away_match_points: 6.5,
+              away_played_games_total: 51,
+              away_played_games_skaters: 50,
+              away_played_games_goalies: 1,
+              away_goals: 13,
+              away_assists: 13,
+              away_points: 26,
+              away_plus_minus: 5,
+              away_penalties: 14,
+              away_shots: 135,
+              away_ppp: 9,
+              away_shp: 0,
+              away_hits: 62,
+              away_blocks: 34,
+              away_wins: 0,
+              away_saves: 17,
+              away_shutouts: 0,
+              away_gaa: null,
+              away_save_percent: null,
+              home_team_id: "4",
+              home_is_winner: 1,
+              home_categories_won: 8,
+              home_categories_lost: 6,
+              home_categories_tied: 1,
+              home_match_points: 8.5,
+              home_played_games_total: 52,
+              home_played_games_skaters: 49,
+              home_played_games_goalies: 3,
+              home_goals: 8,
+              home_assists: 18,
+              home_points: 26,
+              home_plus_minus: -8,
+              home_penalties: 28,
+              home_shots: 148,
+              home_ppp: 9,
+              home_shp: 0,
+              home_hits: 73,
+              home_blocks: 40,
+              home_wins: 1,
+              home_saves: 107,
+              home_shutouts: 1,
+              home_gaa: 3.23,
+              home_save_percent: 0.907,
+            },
+          ],
+        });
+
+        const result = await getFinalsMatchups();
+
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("FROM finals_matchups"),
+        );
+        expect(result).toEqual([
+          {
+            season: 2024,
+            wonOnHomeTiebreak: false,
+            winnerTeamId: "4",
+            awayTeam: expect.objectContaining({
+              teamId: "1",
+              isWinner: false,
+              totals: expect.objectContaining({
+                saves: 17,
+                gaa: null,
+                savePercent: null,
+              }),
+            }),
+            homeTeam: expect.objectContaining({
+              teamId: "4",
+              isWinner: true,
+              totals: expect.objectContaining({
+                gaa: 3.23,
+                savePercent: 0.907,
+              }),
+            }),
+          },
+        ]);
+      });
+    });
+
+    describe("getFinalsCategories", () => {
+      test("returns mapped finals category rows in stat order", async () => {
+        mockExecute.mockResolvedValue({
+          rows: [
+            {
+              season: 2024,
+              stat_key: "goals",
+              away_value: 13,
+              home_value: 8,
+              winner_team_id: "1",
+            },
+            {
+              season: 2024,
+              stat_key: "savePercent",
+              away_value: null,
+              home_value: 0.907,
+              winner_team_id: "4",
+            },
+          ],
+        });
+
+        const result = await getFinalsCategories();
+
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("FROM finals_matchup_categories"),
+        );
+        expect(mockExecute).toHaveBeenCalledWith(
+          expect.stringContaining("WHEN 'savePercent' THEN"),
+        );
+        expect(result).toEqual([
+          {
+            season: 2024,
+            statKey: "goals",
+            awayValue: 13,
+            homeValue: 8,
+            winnerTeamId: "1",
+          },
+          {
+            season: 2024,
+            statKey: "savePercent",
+            awayValue: null,
+            homeValue: 0.907,
+            winnerTeamId: "4",
+          },
+        ]);
       });
     });
   });

--- a/src/__tests__/routes.integration.finals.ts
+++ b/src/__tests__/routes.integration.finals.ts
@@ -1,0 +1,227 @@
+import { createRequest, createResponse } from "node-mocks-http";
+import { getFinalsLeaderboard } from "../features/finals/routes.js";
+import { HTTP_STATUS } from "../shared/http.js";
+import { createIntegrationDb } from "./integration-db.js";
+import { expectArraySchema } from "./openapi-schema.js";
+import { asRouteReq, getJsonBody } from "./routes.integration.helpers.js";
+
+type FinalsRouteReq = Parameters<typeof getFinalsLeaderboard>[0];
+
+const insertFinalsFixture = async (
+  db: Awaited<ReturnType<typeof createIntegrationDb>>["db"],
+): Promise<void> => {
+  await db.execute({
+    sql: `INSERT INTO finals_matchups (
+            season, away_team_id, home_team_id, winner_team_id, home_tiebreak_won
+          ) VALUES (?, ?, ?, ?, ?)`,
+    args: [2014, "1", "5", "5", 0],
+  });
+
+  await db.execute({
+    sql: `INSERT INTO finals_matchup_teams (
+            season, team_id, side, is_winner, categories_won, categories_lost,
+            categories_tied, match_points, played_games_total, played_games_skaters,
+            played_games_goalies, goals, assists, points, plus_minus, penalties,
+            shots, ppp, shp, hits, blocks, wins, saves, shutouts, gaa, save_percent
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      2014,
+      "1",
+      "away",
+      0,
+      2,
+      10,
+      3,
+      3.5,
+      51,
+      50,
+      1,
+      13,
+      13,
+      26,
+      5,
+      14,
+      135,
+      9,
+      0,
+      62,
+      34,
+      0,
+      17,
+      0,
+      null,
+      null,
+    ],
+  });
+  await db.execute({
+    sql: `INSERT INTO finals_matchup_teams (
+            season, team_id, side, is_winner, categories_won, categories_lost,
+            categories_tied, match_points, played_games_total, played_games_skaters,
+            played_games_goalies, goals, assists, points, plus_minus, penalties,
+            shots, ppp, shp, hits, blocks, wins, saves, shutouts, gaa, save_percent
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      2014,
+      "5",
+      "home",
+      1,
+      10,
+      2,
+      3,
+      11.5,
+      52,
+      49,
+      3,
+      8,
+      18,
+      26,
+      -8,
+      28,
+      148,
+      9,
+      0,
+      73,
+      40,
+      1,
+      107,
+      1,
+      3.23,
+      0.907,
+    ],
+  });
+
+  const categories = [
+    ["goals", 13, 8, "1"],
+    ["points", 26, 26, null],
+    ["wins", 0, 1, "5"],
+    ["saves", 17, 107, "5"],
+    ["gaa", null, 3.23, "5"],
+    ["savePercent", null, 0.907, "5"],
+  ] as const;
+
+  for (const [statKey, awayValue, homeValue, winnerTeamId] of categories) {
+    await db.execute({
+      sql: `INSERT INTO finals_matchup_categories (
+              season, stat_key, away_value, home_value, winner_team_id
+            ) VALUES (?, ?, ?, ?, ?)`,
+      args: [2014, statKey, awayValue, homeValue, winnerTeamId],
+    });
+  }
+};
+
+export const registerFinalsRouteIntegrationTests = (): void => {
+  describe("finals routes", () => {
+    test("builds finals leaderboard rows from the live finals tables", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        await insertFinalsFixture(db.db);
+
+        const req = createRequest({
+          method: "GET",
+          url: "/leaderboard/finals",
+        });
+        const res = createResponse();
+
+        await getFinalsLeaderboard(asRouteReq<FinalsRouteReq>(req), res);
+
+        const body = getJsonBody<Array<Record<string, unknown>>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(res.getHeader("x-stats-data-source")).toBe("db");
+        expect(body).toHaveLength(1);
+        expect(body[0]).toMatchObject({
+          season: 2014,
+          winnerTeamId: "5",
+          winnerTeamName: "Montreal Canadiens",
+          wonOnHomeTiebreak: false,
+          awayTeam: {
+            teamId: "1",
+            teamName: "Colorado Avalanche",
+            playedGames: {
+              total: 51,
+              skaters: 50,
+              goalies: 1,
+            },
+            totals: {
+              saves: 17,
+              gaa: null,
+              savePercent: null,
+            },
+          },
+          homeTeam: {
+            teamId: "5",
+            teamName: "Montreal Canadiens",
+          },
+          rates: {
+            winRate: 76.7,
+            deservedToWinRate: expect.any(Number),
+          },
+        });
+        expect(body[0].awayTeam).not.toHaveProperty("isWinner");
+        expect(body[0].homeTeam).not.toHaveProperty("isWinner");
+        expect(body[0].categories).toEqual([
+          {
+            statKey: "goals",
+            awayValue: 13,
+            homeValue: 8,
+            winnerTeamId: "1",
+          },
+          {
+            statKey: "points",
+            awayValue: 26,
+            homeValue: 26,
+            winnerTeamId: null,
+          },
+          {
+            statKey: "wins",
+            awayValue: 0,
+            homeValue: 1,
+            winnerTeamId: "5",
+          },
+          {
+            statKey: "saves",
+            awayValue: 17,
+            homeValue: 107,
+            winnerTeamId: "5",
+          },
+          {
+            statKey: "gaa",
+            awayValue: null,
+            homeValue: 3.23,
+            winnerTeamId: "5",
+          },
+          {
+            statKey: "savePercent",
+            awayValue: null,
+            homeValue: 0.907,
+            winnerTeamId: "5",
+          },
+        ]);
+        expectArraySchema("FinalsLeaderboardEntry", body);
+      } finally {
+        await db.cleanup();
+      }
+    });
+
+    test("returns an empty finals list when no finals rows exist", async () => {
+      const db = await createIntegrationDb();
+
+      try {
+        const req = createRequest({
+          method: "GET",
+          url: "/leaderboard/finals",
+        });
+        const res = createResponse();
+
+        await getFinalsLeaderboard(asRouteReq<FinalsRouteReq>(req), res);
+
+        const body = getJsonBody<Array<Record<string, unknown>>>(res);
+        expect(res.statusCode).toBe(HTTP_STATUS.OK);
+        expect(res.getHeader("x-stats-data-source")).toBe("db");
+        expect(body).toEqual([]);
+      } finally {
+        await db.cleanup();
+      }
+    });
+  });
+};

--- a/src/__tests__/routes.integration.test.ts
+++ b/src/__tests__/routes.integration.test.ts
@@ -1,5 +1,6 @@
 import { registerCareerRouteIntegrationTests } from "./routes.integration.career.js";
 import { registerDraftRouteIntegrationTests } from "./routes.integration.drafts.js";
+import { registerFinalsRouteIntegrationTests } from "./routes.integration.finals.js";
 import { registerGoalieRouteIntegrationTests } from "./routes.integration.goalies.js";
 import { registerLeaderboardRouteIntegrationTests } from "./routes.integration.leaderboard.js";
 import { registerPlayerRouteIntegrationTests } from "./routes.integration.players.js";
@@ -12,4 +13,5 @@ describe("routes integration", () => {
   registerGoalieRouteIntegrationTests();
   registerCareerRouteIntegrationTests();
   registerLeaderboardRouteIntegrationTests();
+  registerFinalsRouteIntegrationTests();
 });

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -15,6 +15,7 @@ import {
   getRegularLeaderboard,
   getTransactionsLeaderboard,
 } from "../features/leaderboard/routes.js";
+import { getFinalsLeaderboard } from "../features/finals/routes.js";
 import app, { getHealthcheck } from "../app.js";
 import { send } from "../http/response.js";
 import {
@@ -33,6 +34,7 @@ import {
   getRegularLeaderboardData,
   getTransactionLeaderboardData,
 } from "../features/leaderboard/service.js";
+import { getFinalsLeaderboardData } from "../features/finals/service.js";
 import {
   reportTypeAvailable,
   seasonAvailable,
@@ -49,6 +51,7 @@ jest.mock("../http/response");
 jest.mock("../features/meta/service");
 jest.mock("../features/stats/service");
 jest.mock("../features/leaderboard/service");
+jest.mock("../features/finals/service");
 jest.mock("../shared/seasons");
 jest.mock("../shared/teams");
 jest.mock("../infra/snapshots/store", () => ({
@@ -350,6 +353,16 @@ describe("routes", () => {
             );
           },
         },
+        {
+          handler: getFinalsLeaderboard,
+          req: createRequest({
+            method: "GET",
+            url: "/leaderboard/finals",
+          }),
+          arrange: (error) => {
+            (getFinalsLeaderboardData as jest.Mock).mockRejectedValue(error);
+          },
+        },
       ];
 
       for (const routeCase of cases) {
@@ -408,6 +421,111 @@ describe("routes", () => {
       expect(getTransactionLeaderboardData).toHaveBeenCalledTimes(1);
       expect(res.getHeader("x-stats-data-source")).toBe("db");
       expectArraySchema("TransactionLeaderboardEntry", payload);
+      expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, payload);
+    });
+  });
+
+  describe("getFinalsLeaderboard", () => {
+    test("returns finals leaderboard data from the finals service", async () => {
+      const payload = [
+        {
+          season: 2024,
+          wonOnHomeTiebreak: false,
+          winnerTeamId: "1",
+          winnerTeamName: "Colorado Avalanche",
+          awayTeam: {
+            teamId: "1",
+            teamName: "Colorado Avalanche",
+            score: {
+              matchPoints: 8.5,
+              categoriesWon: 8,
+              categoriesLost: 6,
+              categoriesTied: 1,
+            },
+            playedGames: {
+              total: 51,
+              skaters: 50,
+              goalies: 1,
+            },
+            totals: {
+              goals: 13,
+              assists: 13,
+              points: 26,
+              plusMinus: 5,
+              penalties: 14,
+              shots: 135,
+              ppp: 9,
+              shp: 0,
+              hits: 62,
+              blocks: 34,
+              wins: 0,
+              saves: 17,
+              shutouts: 0,
+              gaa: null,
+              savePercent: null,
+            },
+          },
+          homeTeam: {
+            teamId: "5",
+            teamName: "Montreal Canadiens",
+            score: {
+              matchPoints: 6.5,
+              categoriesWon: 6,
+              categoriesLost: 8,
+              categoriesTied: 1,
+            },
+            playedGames: {
+              total: 52,
+              skaters: 49,
+              goalies: 3,
+            },
+            totals: {
+              goals: 8,
+              assists: 18,
+              points: 26,
+              plusMinus: -8,
+              penalties: 28,
+              shots: 148,
+              ppp: 9,
+              shp: 0,
+              hits: 73,
+              blocks: 40,
+              wins: 1,
+              saves: 107,
+              shutouts: 1,
+              gaa: 3.23,
+              savePercent: 0.907,
+            },
+          },
+          categories: [
+            {
+              statKey: "gaa",
+              awayValue: null,
+              homeValue: 3.23,
+              winnerTeamId: "5",
+            },
+          ],
+          rates: {
+            winRate: 56.7,
+            deservedToWinRate: 60.4,
+          },
+        },
+      ];
+      (getFinalsLeaderboardData as jest.Mock).mockResolvedValue(payload);
+
+      const req = createRequest({
+        method: "GET",
+        url: "/leaderboard/finals",
+      });
+      const res = createResponse();
+
+      await getFinalsLeaderboard(asRouteReq(req), res);
+
+      expect(getFinalsLeaderboardData).toHaveBeenCalledTimes(1);
+      expect(res.getHeader("x-stats-data-source")).toBe("db");
+      expectArraySchema("FinalsLeaderboardEntry", payload);
+      expect(payload[0].awayTeam).not.toHaveProperty("isWinner");
+      expect(payload[0].homeTeam).not.toHaveProperty("isWinner");
       expect(send).toHaveBeenCalledWith(res, HTTP_STATUS.OK, payload);
     });
   });

--- a/src/__tests__/services.finals.test.ts
+++ b/src/__tests__/services.finals.test.ts
@@ -1,0 +1,244 @@
+import { getFinalsLeaderboardData } from "../features/finals/service.js";
+import {
+  getFinalsCategories,
+  getFinalsMatchups,
+} from "../db/queries.js";
+
+jest.mock("../db/queries");
+
+describe("finals service", () => {
+  const mockGetFinalsMatchups =
+    getFinalsMatchups as jest.MockedFunction<typeof getFinalsMatchups>;
+  const mockGetFinalsCategories =
+    getFinalsCategories as jest.MockedFunction<typeof getFinalsCategories>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns an empty list when no finals are imported", async () => {
+    mockGetFinalsMatchups.mockResolvedValue([]);
+    mockGetFinalsCategories.mockResolvedValue([]);
+
+    await expect(getFinalsLeaderboardData()).resolves.toEqual([]);
+  });
+
+  test("maps finals matchups, category winners, team names, and rates", async () => {
+    mockGetFinalsMatchups.mockResolvedValue([
+      {
+        season: 2024,
+        wonOnHomeTiebreak: false,
+        winnerTeamId: "1",
+      awayTeam: {
+        teamId: "1",
+        isWinner: true,
+          score: {
+            matchPoints: 8.5,
+            categoriesWon: 8,
+            categoriesLost: 6,
+            categoriesTied: 1,
+          },
+          playedGames: { total: 12, skaters: 10, goalies: 2 },
+          totals: {
+            goals: 10,
+            assists: 10,
+            points: 20,
+            plusMinus: 3,
+            penalties: 12,
+            shots: 80,
+            ppp: 6,
+            shp: 1,
+            hits: 30,
+            blocks: 20,
+            wins: 1,
+            saves: 50,
+            shutouts: 0,
+            gaa: 2.5,
+            savePercent: 0.91,
+          },
+        },
+      homeTeam: {
+        teamId: "999",
+        isWinner: false,
+          score: {
+            matchPoints: 6.5,
+            categoriesWon: 6,
+            categoriesLost: 8,
+            categoriesTied: 1,
+          },
+          playedGames: { total: 12, skaters: 10, goalies: 2 },
+          totals: {
+            goals: 9,
+            assists: 9,
+            points: 18,
+            plusMinus: 1,
+            penalties: 10,
+            shots: 75,
+            ppp: 5,
+            shp: 0,
+            hits: 28,
+            blocks: 18,
+            wins: 1,
+            saves: 48,
+            shutouts: 0,
+            gaa: 2.7,
+            savePercent: 0.9,
+          },
+        },
+      },
+    ]);
+    mockGetFinalsCategories.mockResolvedValue([
+      {
+        season: 2024,
+        statKey: "goals",
+        awayValue: 10,
+        homeValue: 9,
+        winnerTeamId: "1",
+      },
+      {
+        season: 2024,
+        statKey: "shp",
+        awayValue: 1,
+        homeValue: 1,
+        winnerTeamId: null,
+      },
+      {
+        season: 2024,
+        statKey: "blocks",
+        awayValue: 20,
+        homeValue: 18,
+        winnerTeamId: "404",
+      },
+      {
+        season: 1900,
+        statKey: "goals",
+        awayValue: 1,
+        homeValue: 0,
+        winnerTeamId: "1",
+      },
+    ]);
+
+    const result = await getFinalsLeaderboardData();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      season: 2024,
+      winnerTeamId: "1",
+      winnerTeamName: "Colorado Avalanche",
+      awayTeam: {
+        teamId: "1",
+        teamName: "Colorado Avalanche",
+        score: expect.any(Object),
+        playedGames: expect.any(Object),
+        totals: expect.any(Object),
+      },
+      homeTeam: {
+        teamId: "999",
+        teamName: "999",
+        score: expect.any(Object),
+        playedGames: expect.any(Object),
+        totals: expect.any(Object),
+      },
+      rates: {
+        winRate: 56.7,
+        deservedToWinRate: expect.any(Number),
+      },
+    });
+    expect(result[0].awayTeam).not.toHaveProperty("isWinner");
+    expect(result[0].homeTeam).not.toHaveProperty("isWinner");
+    expect(result[0].categories).toEqual([
+      {
+        statKey: "goals",
+        awayValue: 10,
+        homeValue: 9,
+        winnerTeamId: "1",
+      },
+      {
+        statKey: "shp",
+        awayValue: 1,
+        homeValue: 1,
+        winnerTeamId: null,
+      },
+      {
+        statKey: "blocks",
+        awayValue: 20,
+        homeValue: 18,
+        winnerTeamId: "404",
+      },
+    ]);
+  });
+
+  test("returns empty category arrays when a season has no category rows", async () => {
+    mockGetFinalsMatchups.mockResolvedValue([
+      {
+        season: 2023,
+        wonOnHomeTiebreak: false,
+        winnerTeamId: "1",
+      awayTeam: {
+        teamId: "1",
+        isWinner: true,
+          score: {
+            matchPoints: 8.5,
+            categoriesWon: 8,
+            categoriesLost: 6,
+            categoriesTied: 1,
+          },
+          playedGames: { total: 12, skaters: 10, goalies: 2 },
+          totals: {
+            goals: 10,
+            assists: 10,
+            points: 20,
+            plusMinus: 3,
+            penalties: 12,
+            shots: 80,
+            ppp: 6,
+            shp: 1,
+            hits: 30,
+            blocks: 20,
+            wins: 1,
+            saves: 50,
+            shutouts: 0,
+            gaa: 2.5,
+            savePercent: 0.91,
+          },
+        },
+      homeTeam: {
+        teamId: "2",
+        isWinner: false,
+          score: {
+            matchPoints: 6.5,
+            categoriesWon: 6,
+            categoriesLost: 8,
+            categoriesTied: 1,
+          },
+          playedGames: { total: 12, skaters: 10, goalies: 2 },
+          totals: {
+            goals: 9,
+            assists: 9,
+            points: 18,
+            plusMinus: 1,
+            penalties: 10,
+            shots: 75,
+            ppp: 5,
+            shp: 0,
+            hits: 28,
+            blocks: 18,
+            wins: 1,
+            saves: 48,
+            shutouts: 0,
+            gaa: 2.7,
+            savePercent: 0.9,
+          },
+        },
+      },
+    ]);
+    mockGetFinalsCategories.mockResolvedValue([]);
+
+    await expect(getFinalsLeaderboardData()).resolves.toEqual([
+      expect.objectContaining({
+        season: 2023,
+        categories: [],
+      }),
+    ]);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import {
   getRegularLeaderboard,
   getTransactionsLeaderboard,
 } from "./features/leaderboard/routes.js";
+import { getFinalsLeaderboard } from "./features/finals/routes.js";
 import {
   getLastModified,
   getSeasons,
@@ -73,6 +74,7 @@ const routes = [
   get("/leaderboard/playoffs", protectedRoute(getPlayoffsLeaderboard)),
   get("/leaderboard/regular", protectedRoute(getRegularLeaderboard)),
   get("/leaderboard/transactions", protectedRoute(getTransactionsLeaderboard)),
+  get("/leaderboard/finals", protectedRoute(getFinalsLeaderboard)),
   get("/openapi.json", getOpenApiSpec),
   get("/api-docs", getSwaggerUi),
   get("/*", notFound),

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -9,11 +9,18 @@ import type {
   TransactionLeaderboardEntry,
   TransactionLeaderboardSeason,
 } from "../features/leaderboard/types.js";
+import type {
+  FinalsCategoryDbEntry,
+  FinalsMatchupDbEntry,
+  FinalsTeamData,
+  FinalsTeamTotals,
+} from "../features/finals/types.js";
 import {
   formatOptionalGoalieGaa,
   formatOptionalGoalieSavePercent,
 } from "../shared/goalie-rates.js";
 import type { CsvReport } from "../shared/types/core.js";
+import { FINALS_STAT_KEYS } from "../features/finals/types.js";
 
 /** Cast DB rows to a known shape. Trust the schema — no runtime validation. */
 function castRows<T>(rows: unknown[]): T[] {
@@ -1022,5 +1029,248 @@ export const getTransactionSeasons = async (): Promise<
     trades: row.trades,
     players: row.players,
     goalies: row.goalies,
+  }));
+};
+
+type FinalsMatchupRow = {
+  season: number;
+  home_tiebreak_won: number;
+  winner_team_id: string;
+  away_team_id: string;
+  away_is_winner: number;
+  away_categories_won: number;
+  away_categories_lost: number;
+  away_categories_tied: number;
+  away_match_points: number;
+  away_played_games_total: number;
+  away_played_games_skaters: number;
+  away_played_games_goalies: number;
+  away_goals: number;
+  away_assists: number;
+  away_points: number;
+  away_plus_minus: number;
+  away_penalties: number;
+  away_shots: number;
+  away_ppp: number;
+  away_shp: number;
+  away_hits: number;
+  away_blocks: number;
+  away_wins: number;
+  away_saves: number;
+  away_shutouts: number;
+  away_gaa: number | null;
+  away_save_percent: number | null;
+  home_team_id: string;
+  home_is_winner: number;
+  home_categories_won: number;
+  home_categories_lost: number;
+  home_categories_tied: number;
+  home_match_points: number;
+  home_played_games_total: number;
+  home_played_games_skaters: number;
+  home_played_games_goalies: number;
+  home_goals: number;
+  home_assists: number;
+  home_points: number;
+  home_plus_minus: number;
+  home_penalties: number;
+  home_shots: number;
+  home_ppp: number;
+  home_shp: number;
+  home_hits: number;
+  home_blocks: number;
+  home_wins: number;
+  home_saves: number;
+  home_shutouts: number;
+  home_gaa: number | null;
+  home_save_percent: number | null;
+};
+
+const mapFinalsTeamTotals = (
+  row: FinalsMatchupRow,
+  side: "away" | "home",
+): FinalsTeamTotals =>
+  side === "away"
+    ? {
+        goals: row.away_goals,
+        assists: row.away_assists,
+        points: row.away_points,
+        plusMinus: row.away_plus_minus,
+        penalties: row.away_penalties,
+        shots: row.away_shots,
+        ppp: row.away_ppp,
+        shp: row.away_shp,
+        hits: row.away_hits,
+        blocks: row.away_blocks,
+        wins: row.away_wins,
+        saves: row.away_saves,
+        shutouts: row.away_shutouts,
+        gaa: row.away_gaa,
+        savePercent: row.away_save_percent,
+      }
+    : {
+        goals: row.home_goals,
+        assists: row.home_assists,
+        points: row.home_points,
+        plusMinus: row.home_plus_minus,
+        penalties: row.home_penalties,
+        shots: row.home_shots,
+        ppp: row.home_ppp,
+        shp: row.home_shp,
+        hits: row.home_hits,
+        blocks: row.home_blocks,
+        wins: row.home_wins,
+        saves: row.home_saves,
+        shutouts: row.home_shutouts,
+        gaa: row.home_gaa,
+        savePercent: row.home_save_percent,
+      };
+
+const mapFinalsTeam = (
+  row: FinalsMatchupRow,
+  side: "away" | "home",
+): FinalsTeamData =>
+  side === "away"
+    ? {
+        teamId: row.away_team_id,
+        isWinner: row.away_is_winner === 1,
+        score: {
+          matchPoints: row.away_match_points,
+          categoriesWon: row.away_categories_won,
+          categoriesLost: row.away_categories_lost,
+          categoriesTied: row.away_categories_tied,
+        },
+        playedGames: {
+          total: row.away_played_games_total,
+          skaters: row.away_played_games_skaters,
+          goalies: row.away_played_games_goalies,
+        },
+        totals: mapFinalsTeamTotals(row, side),
+      }
+    : {
+        teamId: row.home_team_id,
+        isWinner: row.home_is_winner === 1,
+        score: {
+          matchPoints: row.home_match_points,
+          categoriesWon: row.home_categories_won,
+          categoriesLost: row.home_categories_lost,
+          categoriesTied: row.home_categories_tied,
+        },
+        playedGames: {
+          total: row.home_played_games_total,
+          skaters: row.home_played_games_skaters,
+          goalies: row.home_played_games_goalies,
+        },
+        totals: mapFinalsTeamTotals(row, side),
+      };
+
+const mapFinalsMatchupRow = (row: FinalsMatchupRow): FinalsMatchupDbEntry => ({
+  season: row.season,
+  wonOnHomeTiebreak: row.home_tiebreak_won === 1,
+  winnerTeamId: row.winner_team_id,
+  awayTeam: mapFinalsTeam(row, "away"),
+  homeTeam: mapFinalsTeam(row, "home"),
+});
+
+type FinalsCategoryRow = {
+  season: number;
+  stat_key: FinalsCategoryDbEntry["statKey"];
+  away_value: number | null;
+  home_value: number | null;
+  winner_team_id: string | null;
+};
+
+const FINALS_STAT_ORDER_SQL = `CASE stat_key
+${FINALS_STAT_KEYS.map((statKey, index) => `  WHEN '${statKey}' THEN ${index}`).join("\n")}
+  ELSE ${FINALS_STAT_KEYS.length}
+END`;
+
+export const getFinalsMatchups = async (): Promise<FinalsMatchupDbEntry[]> => {
+  const db = getDbClient();
+  const result = await db.execute(
+    `SELECT
+       fm.season,
+       fm.home_tiebreak_won,
+       fm.winner_team_id,
+       away.team_id AS away_team_id,
+       away.is_winner AS away_is_winner,
+       away.categories_won AS away_categories_won,
+       away.categories_lost AS away_categories_lost,
+       away.categories_tied AS away_categories_tied,
+       away.match_points AS away_match_points,
+       away.played_games_total AS away_played_games_total,
+       away.played_games_skaters AS away_played_games_skaters,
+       away.played_games_goalies AS away_played_games_goalies,
+       away.goals AS away_goals,
+       away.assists AS away_assists,
+       away.points AS away_points,
+       away.plus_minus AS away_plus_minus,
+       away.penalties AS away_penalties,
+       away.shots AS away_shots,
+       away.ppp AS away_ppp,
+       away.shp AS away_shp,
+       away.hits AS away_hits,
+       away.blocks AS away_blocks,
+       away.wins AS away_wins,
+       away.saves AS away_saves,
+       away.shutouts AS away_shutouts,
+       away.gaa AS away_gaa,
+       away.save_percent AS away_save_percent,
+       home.team_id AS home_team_id,
+       home.is_winner AS home_is_winner,
+       home.categories_won AS home_categories_won,
+       home.categories_lost AS home_categories_lost,
+       home.categories_tied AS home_categories_tied,
+       home.match_points AS home_match_points,
+       home.played_games_total AS home_played_games_total,
+       home.played_games_skaters AS home_played_games_skaters,
+       home.played_games_goalies AS home_played_games_goalies,
+       home.goals AS home_goals,
+       home.assists AS home_assists,
+       home.points AS home_points,
+       home.plus_minus AS home_plus_minus,
+       home.penalties AS home_penalties,
+       home.shots AS home_shots,
+       home.ppp AS home_ppp,
+       home.shp AS home_shp,
+       home.hits AS home_hits,
+       home.blocks AS home_blocks,
+       home.wins AS home_wins,
+       home.saves AS home_saves,
+       home.shutouts AS home_shutouts,
+       home.gaa AS home_gaa,
+       home.save_percent AS home_save_percent
+     FROM finals_matchups fm
+     JOIN finals_matchup_teams away
+       ON away.season = fm.season
+      AND away.side = 'away'
+     JOIN finals_matchup_teams home
+       ON home.season = fm.season
+      AND home.side = 'home'
+     ORDER BY fm.season DESC`,
+  );
+
+  return castRows<FinalsMatchupRow>(result.rows).map(mapFinalsMatchupRow);
+};
+
+export const getFinalsCategories = async (): Promise<FinalsCategoryDbEntry[]> => {
+  const db = getDbClient();
+  const result = await db.execute(
+    `SELECT
+       season,
+       stat_key,
+       away_value,
+       home_value,
+       winner_team_id
+     FROM finals_matchup_categories
+     ORDER BY season DESC, ${FINALS_STAT_ORDER_SQL}`,
+  );
+
+  return castRows<FinalsCategoryRow>(result.rows).map((row) => ({
+    season: row.season,
+    statKey: row.stat_key,
+    awayValue: row.away_value,
+    homeValue: row.home_value,
+    winnerTeamId: row.winner_team_id,
   }));
 };

--- a/src/features/finals/routes.ts
+++ b/src/features/finals/routes.ts
@@ -1,0 +1,10 @@
+import type { RouteHandler } from "../../shared/router.js";
+import { withErrorHandlingCached } from "../../shared/route-utils.js";
+import { getFinalsLeaderboardData } from "./service.js";
+
+export const getFinalsLeaderboard: RouteHandler = async (req, res) => {
+  await withErrorHandlingCached(req, res, async () => ({
+    data: await getFinalsLeaderboardData(),
+    dataSource: "db",
+  }));
+};

--- a/src/features/finals/scoring.ts
+++ b/src/features/finals/scoring.ts
@@ -1,0 +1,283 @@
+import type {
+  FinalsMatchupDbEntry,
+  FinalsModelWeights,
+  FinalsStatKey,
+  FinalsTeamData,
+} from "./types.js";
+
+type FinalsScoringContext = {
+  plusMinusRateScale: number;
+};
+
+const MIN_GOALIE_GAMES_FOR_RATE = 2;
+const MIN_PLUS_MINUS_SCALE = 0.05;
+const EPSILON = 0.000001;
+
+export const FINALS_DESERVED_TO_WIN_WEIGHTS: FinalsModelWeights = {
+  goals: 1,
+  assists: 1,
+  points: 1,
+  plusMinus: 0.75,
+  penalties: 1,
+  shots: 1,
+  ppp: 1,
+  shp: 0.6,
+  hits: 1,
+  blocks: 1,
+  wins: 1,
+  saves: 1,
+  shutouts: 0.6,
+  gaa: 1,
+  savePercent: 1,
+};
+
+const toOneDecimal = (value: number): number => Math.round(value * 10) / 10;
+
+const erf = (x: number): number => {
+  const sign = x < 0 ? -1 : 1;
+  const absoluteX = Math.abs(x);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const t = 1 / (1 + p * absoluteX);
+  const y =
+    1 -
+    (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t *
+      Math.exp(-absoluteX * absoluteX));
+
+  return sign * y;
+};
+
+const standardNormalCdf = (value: number): number =>
+  0.5 * (1 + erf(value / Math.SQRT2));
+
+const getWinnerAndLoser = (
+  matchup: Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">,
+): { winner: FinalsTeamData; loser: FinalsTeamData } =>
+  matchup.awayTeam.isWinner
+    ? { winner: matchup.awayTeam, loser: matchup.homeTeam }
+    : { winner: matchup.homeTeam, loser: matchup.awayTeam };
+
+const getExposure = (team: FinalsTeamData, stat: FinalsStatKey): number => {
+  if (stat === "wins" || stat === "saves" || stat === "shutouts") {
+    return team.playedGames.goalies;
+  }
+
+  return team.playedGames.skaters;
+};
+
+const getRate = (value: number, exposure: number): number =>
+  exposure > 0 ? value / exposure : 0;
+
+const sampleStdDev = (values: readonly number[]): number => {
+  if (values.length <= 1) return 0;
+
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+    (values.length - 1);
+
+  return Math.sqrt(variance);
+};
+
+const hasQualifiedGoalieRates = (team: FinalsTeamData): boolean =>
+  team.playedGames.goalies >= MIN_GOALIE_GAMES_FOR_RATE;
+
+const confidenceForCountRate = (
+  winnerValue: number,
+  loserValue: number,
+  winnerExposure: number,
+  loserExposure: number,
+): number => {
+  const winnerRate = getRate(winnerValue, winnerExposure);
+  const loserRate = getRate(loserValue, loserExposure);
+  const winnerVariance = winnerExposure > 0 ? winnerRate / winnerExposure : 0;
+  const loserVariance = loserExposure > 0 ? loserRate / loserExposure : 0;
+  const standardError = Math.sqrt(winnerVariance + loserVariance);
+
+  if (standardError <= EPSILON) {
+    return 0.5;
+  }
+
+  return standardNormalCdf((winnerRate - loserRate) / standardError);
+};
+
+const confidenceForGaa = (winner: FinalsTeamData, loser: FinalsTeamData): number => {
+  const winnerQualified = hasQualifiedGoalieRates(winner);
+  const loserQualified = hasQualifiedGoalieRates(loser);
+
+  if (winnerQualified !== loserQualified) {
+    return winnerQualified ? 1 : 0;
+  }
+
+  if (!winnerQualified && !loserQualified) {
+    return 0.5;
+  }
+
+  const winnerGaa = winner.totals.gaa;
+  const loserGaa = loser.totals.gaa;
+
+  if (winnerGaa == null || loserGaa == null) {
+    return 0.5;
+  }
+
+  if (winnerGaa <= EPSILON && loserGaa <= EPSILON) {
+    return 0.5;
+  }
+
+  const winnerExposure = winner.playedGames.goalies;
+  const loserExposure = loser.playedGames.goalies;
+  const standardError = Math.sqrt(
+    (winnerGaa / winnerExposure) + (loserGaa / loserExposure),
+  );
+
+  return standardNormalCdf((loserGaa - winnerGaa) / standardError);
+};
+
+const confidenceForSavePercent = (
+  winner: FinalsTeamData,
+  loser: FinalsTeamData,
+): number => {
+  const winnerQualified = hasQualifiedGoalieRates(winner);
+  const loserQualified = hasQualifiedGoalieRates(loser);
+
+  if (winnerQualified !== loserQualified) {
+    return winnerQualified ? 1 : 0;
+  }
+
+  if (!winnerQualified && !loserQualified) {
+    return 0.5;
+  }
+
+  const winnerSavePercent = winner.totals.savePercent;
+  const loserSavePercent = loser.totals.savePercent;
+
+  if (winnerSavePercent == null || loserSavePercent == null) {
+    return 0.5;
+  }
+
+  const winnerShotsAgainst = winnerSavePercent > 0
+    ? winner.totals.saves / winnerSavePercent
+    : 0;
+  const loserShotsAgainst = loserSavePercent > 0
+    ? loser.totals.saves / loserSavePercent
+    : 0;
+
+  if (winnerShotsAgainst <= 0 || loserShotsAgainst <= 0) {
+    if (Math.abs(winnerSavePercent - loserSavePercent) < EPSILON) return 0.5;
+    return winnerSavePercent > loserSavePercent ? 1 : 0;
+  }
+
+  const pooledSavePercent =
+    (winner.totals.saves + loser.totals.saves) /
+    (winnerShotsAgainst + loserShotsAgainst);
+  if (pooledSavePercent <= EPSILON || pooledSavePercent >= 1 - EPSILON) {
+    return 0.5;
+  }
+
+  const standardError = Math.sqrt(
+    pooledSavePercent *
+      (1 - pooledSavePercent) *
+      ((1 / winnerShotsAgainst) + (1 / loserShotsAgainst)),
+  );
+
+  return standardNormalCdf(
+    (winnerSavePercent - loserSavePercent) / standardError,
+  );
+};
+
+const confidenceForPlusMinus = (
+  winner: FinalsTeamData,
+  loser: FinalsTeamData,
+  scale: number,
+): number => {
+  const winnerRate = getRate(winner.totals.plusMinus, winner.playedGames.skaters);
+  const loserRate = getRate(loser.totals.plusMinus, loser.playedGames.skaters);
+  const effectiveScale = Math.max(scale, MIN_PLUS_MINUS_SCALE);
+
+  if (Math.abs(winnerRate - loserRate) < EPSILON) {
+    return 0.5;
+  }
+
+  return standardNormalCdf((winnerRate - loserRate) / effectiveScale);
+};
+
+const confidenceForCategory = (
+  stat: FinalsStatKey,
+  winner: FinalsTeamData,
+  loser: FinalsTeamData,
+  context: FinalsScoringContext,
+): number => {
+  if (stat === "gaa") return confidenceForGaa(winner, loser);
+  if (stat === "savePercent") return confidenceForSavePercent(winner, loser);
+  if (stat === "plusMinus") {
+    return confidenceForPlusMinus(winner, loser, context.plusMinusRateScale);
+  }
+
+  return confidenceForCountRate(
+    winner.totals[stat],
+    loser.totals[stat],
+    getExposure(winner, stat),
+    getExposure(loser, stat),
+  );
+};
+
+export const buildFinalsScoringContext = (
+  matchups: ReadonlyArray<Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">>,
+): FinalsScoringContext => {
+  const plusMinusRates = matchups.flatMap(({ awayTeam, homeTeam }) => [
+    getRate(awayTeam.totals.plusMinus, awayTeam.playedGames.skaters),
+    getRate(homeTeam.totals.plusMinus, homeTeam.playedGames.skaters),
+  ]);
+
+  return {
+    plusMinusRateScale: Math.max(
+      sampleStdDev(plusMinusRates) * Math.SQRT2,
+      MIN_PLUS_MINUS_SCALE,
+    ),
+  };
+};
+
+export const calculateWinRate = (
+  matchup: Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">,
+): number => {
+  const { winner } = getWinnerAndLoser(matchup);
+  const totalCategories =
+    winner.score.categoriesWon +
+    winner.score.categoriesLost +
+    winner.score.categoriesTied;
+
+  if (totalCategories <= 0) {
+    return 50;
+  }
+
+  return toOneDecimal((winner.score.matchPoints / totalCategories) * 100);
+};
+
+export const calculateWeightedEdgeRate = (
+  matchup: Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">,
+  weights: FinalsModelWeights,
+  context: FinalsScoringContext,
+): number => {
+  const { winner, loser } = getWinnerAndLoser(matchup);
+
+  let weightedScore = 0;
+  let totalWeight = 0;
+
+  for (const stat of Object.keys(weights) as FinalsStatKey[]) {
+    const weight = weights[stat];
+    if (!weight) continue;
+
+    weightedScore += confidenceForCategory(stat, winner, loser, context) * weight;
+    totalWeight += weight;
+  }
+
+  if (totalWeight <= 0) {
+    return 50;
+  }
+
+  return toOneDecimal((weightedScore / totalWeight) * 100);
+};

--- a/src/features/finals/service.ts
+++ b/src/features/finals/service.ts
@@ -1,0 +1,99 @@
+import { TEAMS } from "../../config/index.js";
+import {
+  getFinalsCategories,
+  getFinalsMatchups,
+} from "../../db/queries.js";
+import {
+  buildFinalsScoringContext,
+  calculateWeightedEdgeRate,
+  calculateWinRate,
+  FINALS_DESERVED_TO_WIN_WEIGHTS,
+} from "./scoring.js";
+import type {
+  FinalsCategory,
+  FinalsCategoryDbEntry,
+  FinalsLeaderboardEntry,
+  FinalsMatchupDbEntry,
+  FinalsTeam,
+  FinalsTeamData,
+} from "./types.js";
+
+const getTeamName = (teamId: string): string =>
+  TEAMS.find((team) => team.id === teamId)?.presentName ?? teamId;
+
+const mapTeam = ({ isWinner: _isWinner, ...team }: FinalsTeamData): FinalsTeam => ({
+  ...team,
+  teamName: getTeamName(team.teamId),
+});
+
+const buildCategoriesBySeason = (
+  rows: readonly FinalsCategoryDbEntry[],
+): Map<number, FinalsCategory[]> => {
+  const bySeason = new Map<number, FinalsCategory[]>();
+
+  for (const row of rows) {
+    const list = bySeason.get(row.season);
+    const category: FinalsCategory = {
+      statKey: row.statKey,
+      awayValue: row.awayValue,
+      homeValue: row.homeValue,
+      winnerTeamId: row.winnerTeamId,
+    };
+
+    if (list) {
+      list.push(category);
+    } else {
+      bySeason.set(row.season, [category]);
+    }
+  }
+
+  return bySeason;
+};
+
+export const getFinalsLeaderboardData = async (): Promise<
+  FinalsLeaderboardEntry[]
+> => {
+  const [matchups, categories] = await Promise.all([
+    getFinalsMatchups(),
+    getFinalsCategories(),
+  ]);
+
+  if (matchups.length === 0) {
+    return [];
+  }
+
+  const matchupsBySeason = new Map<number, FinalsMatchupDbEntry>();
+  for (const matchup of matchups) {
+    matchupsBySeason.set(matchup.season, matchup);
+  }
+
+  const categoriesBySeason = buildCategoriesBySeason(
+    categories.filter((category) => matchupsBySeason.has(category.season)),
+  );
+  const scoringContext = buildFinalsScoringContext(matchups);
+
+  return matchups.map((matchup) => {
+    const awayTeam = mapTeam(matchup.awayTeam);
+    const homeTeam = mapTeam(matchup.homeTeam);
+    const winnerTeamName =
+      matchup.winnerTeamId === awayTeam.teamId ? awayTeam.teamName : homeTeam.teamName;
+
+    return {
+      season: matchup.season,
+      wonOnHomeTiebreak: matchup.wonOnHomeTiebreak,
+      winnerTeamId: matchup.winnerTeamId,
+      winnerTeamName,
+      awayTeam,
+      homeTeam,
+      categories: categoriesBySeason.get(matchup.season) ?? [],
+      rates: {
+        winRate: calculateWinRate(matchup),
+        deservedToWinRate: calculateWeightedEdgeRate(
+          matchup,
+          FINALS_DESERVED_TO_WIN_WEIGHTS,
+          scoringContext,
+        ),
+      },
+    };
+  });
+};

--- a/src/features/finals/types.ts
+++ b/src/features/finals/types.ts
@@ -1,0 +1,89 @@
+import { GOALIE_SCORE_FIELDS, PLAYER_SCORE_FIELDS } from "../../config/index.js";
+import type {
+  GoalieOptionalScoreField,
+  GoalieScoreField,
+  PlayerScoreField,
+} from "../stats/types.js";
+
+export type FinalsStatKey =
+  | PlayerScoreField
+  | GoalieScoreField
+  | GoalieOptionalScoreField;
+
+export type FinalsModelWeights = Record<FinalsStatKey, number>;
+
+export const FINALS_STAT_KEYS = [
+  ...PLAYER_SCORE_FIELDS,
+  ...GOALIE_SCORE_FIELDS,
+  "gaa",
+  "savePercent",
+] as const satisfies readonly FinalsStatKey[];
+
+export type FinalsTeamScore = {
+  matchPoints: number;
+  categoriesWon: number;
+  categoriesLost: number;
+  categoriesTied: number;
+};
+
+export type FinalsPlayedGames = {
+  total: number;
+  skaters: number;
+  goalies: number;
+};
+
+export type FinalsTeamTotals = Record<PlayerScoreField | GoalieScoreField, number> & {
+  gaa: number | null;
+  savePercent: number | null;
+};
+
+export type FinalsTeamData = {
+  teamId: string;
+  isWinner: boolean;
+  score: FinalsTeamScore;
+  playedGames: FinalsPlayedGames;
+  totals: FinalsTeamTotals;
+};
+
+export type FinalsTeam = Omit<FinalsTeamData, "isWinner"> & {
+  teamName: string;
+};
+
+export type FinalsCategory = {
+  statKey: FinalsStatKey;
+  awayValue: number | null;
+  homeValue: number | null;
+  winnerTeamId: string | null;
+};
+
+export type FinalsRates = {
+  winRate: number;
+  deservedToWinRate: number;
+};
+
+export type FinalsMatchupDbEntry = {
+  season: number;
+  wonOnHomeTiebreak: boolean;
+  winnerTeamId: string;
+  awayTeam: FinalsTeamData;
+  homeTeam: FinalsTeamData;
+};
+
+export type FinalsCategoryDbEntry = {
+  season: number;
+  statKey: FinalsStatKey;
+  awayValue: number | null;
+  homeValue: number | null;
+  winnerTeamId: string | null;
+};
+
+export type FinalsLeaderboardEntry = {
+  season: number;
+  wonOnHomeTiebreak: boolean;
+  winnerTeamId: string;
+  winnerTeamName: string;
+  awayTeam: FinalsTeam;
+  homeTeam: FinalsTeam;
+  categories: FinalsCategory[];
+  rates: FinalsRates;
+};


### PR DESCRIPTION
Summary:
- add `/leaderboard/finals` backed by the imported `finals_*` tables
- return one finals matchup per season with away/home totals, played games, category breakdown, and rates
- expose `score.matchPoints` instead of `rotisseriePoints`
- keep category items DB-backed with `winnerTeamId` only
- omit redundant `isWinner` flags from away/home team payloads
- add `rates.winRate` and `rates.deservedToWinRate`
- use the adjustable finals scoring model with weights:
  - `plusMinus: 0.75`
  - `shp: 0.6`
  - `shutouts: 0.6`
  - all other finals categories: `1.0`
- keep finals live from DB without snapshots
- document the endpoint and scoring model in OpenAPI, README, and `docs/SCORING.md`

Validation:
- npm run verify
