### PR TITLE
Fix: Return finals rates as fractions

### DIFF
--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -88,8 +88,14 @@ Each weight is a decimal between `0` and `1`. Lowering a weight reduces that sta
 
 `/leaderboard/finals` returns a `rates` object for each imported finals season:
 
-- `winRate`: the champion's raw finals match-points share, `winnerMatchPoints / totalCategories * 100`
+- `winRate`: the champion's raw finals match-points share, `winnerMatchPoints / totalCategories`
 - `deservedToWinRate`: a games-adjusted finals strength model that compares the actual winner against the loser category by category
+
+Both rates follow the API's normal percentage convention:
+
+- values are returned as fractions between `0` and `1`
+- values are rounded to three decimals
+- example: `0.567` means `56.7%`
 
 The finals model:
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1686,10 +1686,10 @@ components:
       properties:
         winRate:
           type: number
-          description: The actual finals scoreboard share for the champion, equivalent to raw match-points share.
+          description: "The actual finals scoreboard share for the champion as a fraction between 0 and 1, rounded to three decimals. Example: `0.567` means `56.7%`."
         deservedToWinRate:
           type: number
-          description: A weighted, games-adjusted finals strength model that downweights plusMinus, SHP, and shutouts.
+          description: "A weighted, games-adjusted finals strength model returned as a fraction between 0 and 1, rounded to three decimals."
 
 security:
   - apiKey: []

--- a/src/__tests__/finals.scoring.test.ts
+++ b/src/__tests__/finals.scoring.test.ts
@@ -107,8 +107,8 @@ describe("finals scoring", () => {
     });
   });
 
-  test("calculates winRate from match points and falls back to 50 with no categories", () => {
-    expect(calculateWinRate(createMatchup())).toBe(56.7);
+  test("calculates winRate from match points and falls back to 0.5 with no categories", () => {
+    expect(calculateWinRate(createMatchup())).toBe(0.567);
 
     expect(
       calculateWinRate(
@@ -123,10 +123,10 @@ describe("finals scoring", () => {
           },
         }),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
   });
 
-  test("returns 50 when the finalists are identical", () => {
+  test("returns 0.5 when the finalists are identical", () => {
     const matchup = createMatchup({
       awayTeam: {
         score: {
@@ -152,7 +152,7 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([matchup]),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
   });
 
   test("returns neutral when both finalists have zero skater exposure", () => {
@@ -205,7 +205,7 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([matchup]),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
   });
 
   test("favors better per-game pace even when the raw total is lower", () => {
@@ -258,7 +258,7 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([matchup]),
       ),
-    ).toBeGreaterThan(50);
+    ).toBeGreaterThan(0.5);
   });
 
   test("downweights plus-minus, SHP, and shutouts in the deserved rate", () => {
@@ -484,29 +484,29 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([qualifiedWinner]),
       ),
-    ).toBeGreaterThan(50);
+    ).toBeGreaterThan(0.5);
     expect(
       calculateWeightedEdgeRate(
         disqualifiedWinner,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([disqualifiedWinner]),
       ),
-    ).toBeLessThan(50);
+    ).toBeLessThan(0.5);
     expect(
       calculateWeightedEdgeRate(
         bothUnqualified,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([bothUnqualified]),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
     expect(
       calculateWeightedEdgeRate(
         nullRatesDespiteQualification,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([nullRatesDespiteQualification]),
       ),
-    ).toBe(50);
-    expect(zeroWeightRate).toBe(50);
+    ).toBe(0.5);
+    expect(zeroWeightRate).toBe(0.5);
   });
 
   test("handles zero-shot save percentage comparisons without blowing up", () => {
@@ -557,7 +557,7 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([matchup]),
       ),
-    ).toBeGreaterThan(50);
+    ).toBeGreaterThan(0.5);
   });
 
   test("treats tied zero-shot save percentage cases as neutral and can penalize the winner", () => {
@@ -648,14 +648,14 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([tiedZeroShotMatchup]),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
     expect(
       calculateWeightedEdgeRate(
         loserBetterZeroShotMatchup,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([loserBetterZeroShotMatchup]),
       ),
-    ).toBeLessThan(50);
+    ).toBeLessThan(0.5);
   });
 
   test("treats identical perfect qualified goalie rates as neutral", () => {
@@ -706,6 +706,6 @@ describe("finals scoring", () => {
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([matchup]),
       ),
-    ).toBe(50);
+    ).toBe(0.5);
   });
 });

--- a/src/__tests__/routes.integration.finals.ts
+++ b/src/__tests__/routes.integration.finals.ts
@@ -153,7 +153,7 @@ export const registerFinalsRouteIntegrationTests = (): void => {
             teamName: "Montreal Canadiens",
           },
           rates: {
-            winRate: 76.7,
+            winRate: 0.767,
             deservedToWinRate: expect.any(Number),
           },
         });

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -506,8 +506,8 @@ describe("routes", () => {
             },
           ],
           rates: {
-            winRate: 56.7,
-            deservedToWinRate: 60.4,
+            winRate: 0.567,
+            deservedToWinRate: 0.604,
           },
         },
       ];

--- a/src/__tests__/services.finals.test.ts
+++ b/src/__tests__/services.finals.test.ts
@@ -140,7 +140,7 @@ describe("finals service", () => {
         totals: expect.any(Object),
       },
       rates: {
-        winRate: 56.7,
+        winRate: 0.567,
         deservedToWinRate: expect.any(Number),
       },
     });

--- a/src/features/finals/scoring.ts
+++ b/src/features/finals/scoring.ts
@@ -31,7 +31,8 @@ export const FINALS_DESERVED_TO_WIN_WEIGHTS: FinalsModelWeights = {
   savePercent: 1,
 };
 
-const toOneDecimal = (value: number): number => Math.round(value * 10) / 10;
+const toThreeDecimals = (value: number): number =>
+  Math.round(value * 1000) / 1000;
 
 const erf = (x: number): number => {
   const sign = x < 0 ? -1 : 1;
@@ -251,10 +252,10 @@ export const calculateWinRate = (
     winner.score.categoriesTied;
 
   if (totalCategories <= 0) {
-    return 50;
+    return 0.5;
   }
 
-  return toOneDecimal((winner.score.matchPoints / totalCategories) * 100);
+  return toThreeDecimals(winner.score.matchPoints / totalCategories);
 };
 
 export const calculateWeightedEdgeRate = (
@@ -276,8 +277,8 @@ export const calculateWeightedEdgeRate = (
   }
 
   if (totalWeight <= 0) {
-    return 50;
+    return 0.5;
   }
 
-  return toOneDecimal((weightedScore / totalWeight) * 100);
+  return toThreeDecimals(weightedScore / totalWeight);
 };


### PR DESCRIPTION
Summary:
- change finals `winRate` and `deservedToWinRate` to follow the API’s normal percentage convention
- return both rates as fractions between `0` and `1`, rounded to three decimals
- keep frontend-friendly semantics so `0.567` represents `56.7%`
- update finals scoring tests and route/service expectations
- update OpenAPI and scoring docs to describe the fraction-based contract

Validation:
- npm run verify
