### PR TITLE
Feature: Add finals matchup factors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
    - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Vercel, Turso, R2, auth, and caching
    - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md) for snapshot generation and storage
    - [docs/SCORING.md](docs/SCORING.md) for player and goalie scoring behavior
+   - [docs/RATING.md](docs/RATING.md) for finals leaderboard rate behavior
 
 ## Documentation Rules
 - Keep [README.md](README.md) and docs updated after every task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ See @README.md for project overview, quick start, and the documentation map, and
 - Use @docs/DEPLOYMENT.md for Vercel, Turso, R2, auth, and caching
 - Use @docs/SNAPSHOTS.md for snapshot generation and storage
 - Use @docs/SCORING.md for player and goalie scoring details
+- Use @docs/RATING.md for finals leaderboard rating details
 
 Keep @README.md and project documentation updated after every task.
 Keep @README.md concise as the front door and move deep operational detail into focused docs under @docs/.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm run snapshot:generate
 - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) - Vercel, Turso, R2, API auth, caching, operational commands
 - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md) - snapshot-backed endpoints, generation rules, R2 snapshot storage
 - [docs/SCORING.md](docs/SCORING.md) - player and goalie scoring model details
+- [docs/RATING.md](docs/RATING.md) - finals leaderboard rate model details
 
 ## Technology
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,6 +40,7 @@ This should:
 - [DEPLOYMENT.md](DEPLOYMENT.md) - Vercel, Turso, R2, auth, caching
 - [SNAPSHOTS.md](SNAPSHOTS.md) - snapshot-backed endpoints and generation rules
 - [SCORING.md](SCORING.md) - player and goalie scoring behavior
+- [RATING.md](RATING.md) - finals leaderboard rate behavior
 
 Keep the README concise. Put deep operational detail in the topic docs above instead of growing the top-level readme again.
 

--- a/docs/RATING.md
+++ b/docs/RATING.md
@@ -1,0 +1,232 @@
+# Rating Models
+
+This document covers rating-style models that are related to FFHL results analysis but are not part of the player/goalie `score` and `scoreAdjustedByGames` model described in [SCORING.md](SCORING.md).
+
+## Finals Rates
+
+`/leaderboard/finals` returns a `rates` object for each imported finals season:
+
+- `winRate`
+- `deservedToWinRate`
+
+Both values follow the API's normal percentage convention:
+
+- values are returned as fractions between `0` and `1`
+- values are rounded to three decimals
+- example: `0.567` means `56.7%`
+
+## What Each Rate Means
+
+### `winRate`
+
+`winRate` reflects the actual finals scoreboard result for the champion.
+
+Formula:
+
+```text
+winnerMatchPoints / totalCategories
+```
+
+Where:
+
+- `winnerMatchPoints` comes from the imported finals result
+- `totalCategories = categoriesWon + categoriesLost + categoriesTied`
+- if `totalCategories <= 0`, the API falls back to `0.5`
+
+Example:
+
+- champion match points: `8.5`
+- total categories: `15`
+- `winRate = 8.5 / 15 = 0.567`
+
+This rate answers: "How much of the actual finals scoreboard did the winner capture?"
+
+### `deservedToWinRate`
+
+`deservedToWinRate` is a games-adjusted strength model for the actual finals winner. Instead of looking only at the raw category scoreboard, it asks whether the winner's underlying category performance looked stronger than the loser's once differing skater and goalie game counts are taken into account, while also accounting for a couple of structural finals advantages.
+
+This rate answers: "Given the category totals and the number of games each finalist actually used, how convincing was the winner's underlying performance?"
+
+## Input Data Used By The Model
+
+The finals model compares the imported away and home finalists using:
+
+- skater counting totals: `goals`, `assists`, `points`, `plusMinus`, `penalties`, `shots`, `ppp`, `shp`, `hits`, `blocks`
+- goalie counting totals: `wins`, `saves`, `shutouts`
+- goalie rate stats when qualified: `gaa`, `savePercent`
+- played-game counts:
+  - `playedGames.skaters`
+  - `playedGames.goalies`
+
+Exposure is stat-specific:
+
+- skater stats are compared per skater game
+- `wins`, `saves`, and `shutouts` are compared per goalie game
+- `gaa` and `savePercent` use their own rate-specific confidence logic
+
+## Category Confidence Model
+
+For each stat, the model estimates how strongly the actual winner outperformed the loser in rate terms. Each category produces a confidence value between `0` and `1`:
+
+- near `1.0`: strong evidence the winner was better in that category
+- near `0.5`: effectively neutral
+- near `0.0`: evidence the loser was better in that category
+
+The final `deservedToWinRate` is the weighted average of those category confidences.
+
+### Counting stats
+
+For most stats, the model:
+
+1. Converts totals to rates using the relevant exposure.
+2. Estimates variance from those rates and exposures.
+3. Converts the winner-vs-loser edge into a normal-CDF confidence.
+
+In simplified form:
+
+```text
+winnerRate = winnerValue / winnerExposure
+loserRate = loserValue / loserExposure
+
+winnerVariance = winnerRate / winnerExposure
+loserVariance = loserRate / loserExposure
+standardError = sqrt(winnerVariance + loserVariance)
+confidence = NormalCDF((winnerRate - loserRate) / standardError)
+```
+
+If the standard error collapses to zero, the model returns a neutral `0.5`.
+
+This behavior is why a finalist can have a lower raw total but still improve `deservedToWinRate` if that total came from materially fewer games.
+
+### `plusMinus`
+
+`plusMinus` is treated differently because it can be negative and tends to swing more noisily than pure counting totals.
+
+The model:
+
+- compares plus-minus on a per-skater-game basis
+- measures the leaguewide finals spread from all imported finalists
+- builds a shared scale from the sample standard deviation of those rates
+- enforces a floor of `0.05` so the model never becomes unrealistically certain in tiny samples
+
+If the winner and loser have effectively identical plus-minus rates, the result is neutral `0.5`.
+
+### `gaa`
+
+`gaa` is only meaningful when a team qualifies for goalie rate stats.
+
+Qualification rule:
+
+- a finalist must have at least `2` goalie games
+
+Comparison rules:
+
+- if only the winner qualifies, the category confidence is `0.65`
+- if only the loser qualifies, the category confidence is `0.35`
+- if neither qualifies, the category confidence is `0.5`
+- if both qualify but either `gaa` value is missing, the category confidence is `0.5`
+- lower `gaa` is better
+
+When both teams qualify with usable values, the model compares them through a standard-error calculation based on goalie-game exposure. If both GAAs are effectively zero, the result is neutral `0.5`.
+
+The `0.65` / `0.35` split is intentional: qualifying for goalie-rate categories is a real edge, but not full proof that the qualified team had stronger underlying goalie play.
+
+### `savePercent`
+
+`savePercent` follows the same qualification gate as `gaa`:
+
+- minimum `2` goalie games
+
+Comparison rules:
+
+- if only the winner qualifies, the category confidence is `0.65`
+- if only the loser qualifies, the category confidence is `0.35`
+- if neither qualifies, the category confidence is `0.5`
+- if both qualify but either save percentage is missing, the category confidence is `0.5`
+- higher `savePercent` is better
+
+When both teams qualify, the model reconstructs shots against from:
+
+```text
+shotsAgainst = saves / savePercent
+```
+
+It then uses a pooled-proportion standard error to estimate confidence.
+
+Special handling keeps edge cases stable:
+
+- if reconstructed shots against are non-positive, the model falls back to direct save-percentage comparison
+- if both sides are effectively identical in that zero-shot scenario, the result is `0.5`
+- if the pooled save percentage is effectively `0` or `1`, the result is `0.5`
+
+As with `gaa`, one-sided qualification is treated as a meaningful but softened edge instead of an automatic full-confidence win.
+
+## Structural Finals Edges
+
+The model also accounts for structural advantages that are not the same thing as underlying finals dominance.
+
+### Home-team tiebreak
+
+If the champion won specifically on the home-team tiebreak after a level finals scoreboard, `deservedToWinRate` applies a small negative adjustment to the winner.
+
+That adjustment exists because:
+
+- the winner benefited from a pre-finals edge earned in the regular season
+- winning via that edge is not as strong a finals-only signal as winning outright on the category scoreboard
+
+Current tiebreak adjustment:
+
+- winner confidence contribution: `0.25`
+- weight: `1.5`
+
+In practice, this means a perfectly even finals that the home team wins on tiebreak will land slightly below neutral in `deservedToWinRate`.
+
+## Weights
+
+The weighted finals model uses the following category weights:
+
+- `plusMinus`: `0.75`
+- `shp`: `0.6`
+- `shutouts`: `0.6`
+- every other finals category: `1.0`
+
+This means the model intentionally downweights only three noisier swing categories while keeping the rest of the finals categories at full strength.
+
+In particular:
+
+- `hits` and `blocks` stay at full weight
+- goalie rate categories are included at full weight when qualification allows them to participate meaningfully
+
+If every category weight were set to `0`, the model would return the neutral fallback `0.5`.
+
+## Final Aggregation
+
+After calculating each category confidence, the API computes:
+
+```text
+sum(confidence(stat) * weight(stat)) / sum(weight(stat))
+```
+
+The result is then rounded to three decimals and returned as `deservedToWinRate`.
+
+Interpretation:
+
+- above `0.5`: the winner's underlying finals profile looks stronger than neutral
+- near `0.5`: the matchup looks essentially even after game-count adjustment
+- below `0.5`: the loser may have had the stronger underlying profile despite losing the actual finals scoreboard
+
+Because the rate is always evaluated from the actual winner's perspective, values below `0.5` indicate a possible "won the matchup, but not the underlying profile" result.
+
+## Relationship To The Returned Finals Payload
+
+Each `/leaderboard/finals` item contains:
+
+- `awayTeam` and `homeTeam` raw imported totals
+- `categories`, showing the actual category-by-category finals scoreboard
+- `rates.winRate`, which reflects the actual result
+- `rates.deservedToWinRate`, which reflects the games-adjusted weighted model
+
+Those two rates are intentionally complementary:
+
+- `winRate` describes what happened on the scoreboard
+- `deservedToWinRate` describes how strong the winner's underlying finals performance looked after adjusting for games played

--- a/docs/RATING.md
+++ b/docs/RATING.md
@@ -230,3 +230,143 @@ Those two rates are intentionally complementary:
 
 - `winRate` describes what happened on the scoreboard
 - `deservedToWinRate` describes how strong the winner's underlying finals performance looked after adjusting for games played
+
+## Finals Factors
+
+`/leaderboard/finals` also returns a `factors` object at the matchup root:
+
+```json
+{
+  "factors": {
+    "awayTeam": {
+      "offence": 0.54,
+      "physical": 0.46,
+      "goalies": 0.61
+    },
+    "homeTeam": {
+      "offence": 0.46,
+      "physical": 0.54,
+      "goalies": 0.39
+    }
+  }
+}
+```
+
+All factor values:
+
+- be returned as fractions between `0` and `1`
+- be rounded to three decimals
+- be interpreted as matchup-share style percentages
+
+For each factor:
+
+- `awayTeam.factor + homeTeam.factor = 1`
+
+### `offence`
+
+`offence` is a weighted share of the finalists' combined offensive counting production.
+
+Included stats:
+
+- `goals`
+- `assists`
+- `shots`
+- `ppp`
+- `shp`
+
+`points` should be excluded so the group does not double count `goals` and `assists`.
+
+Base formula:
+
+```text
+teamOffence / (awayOffence + homeOffence)
+```
+
+### `physical`
+
+`physical` is a weighted share of the finalists' combined physical-category production.
+
+Included stats:
+
+- `hits`
+- `blocks`
+- `penalties`
+
+Base formula:
+
+```text
+teamPhysical / (awayPhysical + homePhysical)
+```
+
+### `goalies`
+
+`goalies` is a hybrid percentage, not a pure production share.
+
+It should blend:
+
+- goalie volume share
+- goalie efficiency share
+
+#### Goalie volume share
+
+Goalie volume share uses the count-based goalie stats:
+
+- `wins`
+- `saves`
+- `shutouts`
+
+Base formula:
+
+```text
+teamGoalieVolume / (awayGoalieVolume + homeGoalieVolume)
+```
+
+#### Goalie efficiency share
+
+Goalie efficiency share should use:
+
+- `gaa`
+- `savePercent`
+
+`savePercent` is turned into a matchup share directly when both finalists qualify:
+
+```text
+awaySavePercentShare = awaySavePercent / (awaySavePercent + homeSavePercent)
+homeSavePercentShare = 1 - awaySavePercentShare
+```
+
+Because lower `gaa` is better, `gaa` is first converted into strength via its inverse:
+
+```text
+awayGaaStrength = 1 / awayGaa
+homeGaaStrength = 1 / homeGaa
+
+awayGaaShare = awayGaaStrength / (awayGaaStrength + homeGaaStrength)
+homeGaaShare = 1 - awayGaaShare
+```
+
+Then:
+
+```text
+goalieEfficiencyShare = average(gaaShare, savePercentShare)
+```
+
+If only one finalist qualifies for goalie rate stats, the qualified team receives the full goalie-efficiency share for that component.
+
+If neither finalist qualifies, goalie-efficiency share falls back to `0.5` / `0.5`.
+
+#### Final goalie factor
+
+The final `goalies` factor blends goalie volume share and goalie efficiency share with equal weight:
+
+```text
+goalies = 0.5 * goalieVolumeShare + 0.5 * goalieEfficiencyShare
+```
+
+## Intended Usage
+
+These matchup factors are meant to complement, not replace, `rates.winRate` and `rates.deservedToWinRate`.
+
+- `winRate` answers how much of the actual finals scoreboard the winner captured
+- `deservedToWinRate` answers how strong the winner's underlying profile looked
+- `factors` answer how the finalists split offensive, physical, and goalie influence inside the matchup

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -84,33 +84,12 @@ Weights live in `src/config/settings.ts`:
 
 Each weight is a decimal between `0` and `1`. Lowering a weight reduces that stat's influence without changing the overall `0-100` scale.
 
-## Finals Rates
+## Related Rating Docs
 
-`/leaderboard/finals` returns a `rates` object for each imported finals season:
+Finals leaderboard rates are documented separately in [RATING.md](RATING.md).
 
-- `winRate`: the champion's raw finals match-points share, `winnerMatchPoints / totalCategories`
-- `deservedToWinRate`: a games-adjusted finals strength model that compares the actual winner against the loser category by category
+Use that document for:
 
-Both rates follow the API's normal percentage convention:
-
-- values are returned as fractions between `0` and `1`
-- values are rounded to three decimals
-- example: `0.567` means `56.7%`
-
-The finals model:
-
-- uses skater games for skater counting stats and goalie games for goalie counting stats
-- keeps `hits` and `blocks` at full weight
-- only downweights three noisier swing categories
-
-Current finals weights:
-
-- `plusMinus`: `0.75`
-- `shp`: `0.6`
-- `shutouts`: `0.6`
-- every other finals category: `1.0`
-
-Goalie qualification behavior matches the imported finals data:
-
-- `wins`, `saves`, and `shutouts` always stay numeric
-- `gaa` and `savePercent` become `null` when a finalist misses the two-goalie-game minimum
+- `/leaderboard/finals` `winRate`
+- `/leaderboard/finals` `deservedToWinRate`
+- finals weighting and goalie-rate qualification rules

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1516,6 +1516,7 @@ components:
         - homeTeam
         - categories
         - rates
+        - factors
       properties:
         season:
           type: integer
@@ -1535,6 +1536,8 @@ components:
             $ref: "#/components/schemas/FinalsLeaderboardCategory"
         rates:
           $ref: "#/components/schemas/FinalsLeaderboardRates"
+        factors:
+          $ref: "#/components/schemas/FinalsLeaderboardFactors"
 
     FinalsLeaderboardTeam:
       type: object
@@ -1690,6 +1693,34 @@ components:
         deservedToWinRate:
           type: number
           description: "A weighted, games-adjusted finals strength model returned as a fraction between 0 and 1, rounded to three decimals."
+
+    FinalsLeaderboardFactors:
+      type: object
+      required:
+        - awayTeam
+        - homeTeam
+      properties:
+        awayTeam:
+          $ref: "#/components/schemas/FinalsLeaderboardFactorSet"
+        homeTeam:
+          $ref: "#/components/schemas/FinalsLeaderboardFactorSet"
+
+    FinalsLeaderboardFactorSet:
+      type: object
+      required:
+        - offence
+        - physical
+        - goalies
+      properties:
+        offence:
+          type: number
+          description: "Share of combined offensive category production (`goals`, `assists`, `shots`, `ppp`, `shp`) as a fraction between 0 and 1, rounded to three decimals."
+        physical:
+          type: number
+          description: "Share of combined physical category production (`hits`, `blocks`, `penalties`) as a fraction between 0 and 1, rounded to three decimals."
+        goalies:
+          type: number
+          description: "Hybrid goalie matchup share returned as a fraction between 0 and 1, rounded to three decimals. Blends count-stat volume (`wins`, `saves`, `shutouts`) with goalie-rate efficiency (`gaa`, `savePercent`)."
 
 security:
   - apiKey: []
@@ -2224,8 +2255,9 @@ paths:
       summary: Finals matchup leaderboard
       description: |
         Returns one finals matchup summary per imported season, including away/home team details,
-        category results, and a `rates` object with both the actual win share and a modeled
-        deserved-to-win percentage.
+        category results, a `rates` object with both the actual win share and a modeled
+        deserved-to-win percentage, plus `factors` that split matchup influence into offence,
+        physical play, and goaltending.
       responses:
         "200":
           description: Finals matchup summaries.

--- a/src/__tests__/finals.scoring.test.ts
+++ b/src/__tests__/finals.scoring.test.ts
@@ -1,8 +1,10 @@
 import {
+  calculateFinalsFactors,
   buildFinalsScoringContext,
   calculateWeightedEdgeRate,
   calculateWinRate,
   FINALS_DESERVED_TO_WIN_WEIGHTS,
+  testOnlyToFactorPair,
 } from "../features/finals/scoring.js";
 import type {
   FinalsMatchupDbEntry,
@@ -654,6 +656,417 @@ describe("finals scoring", () => {
         buildFinalsScoringContext([matchup]),
       ),
     ).toBeGreaterThan(0.5);
+  });
+
+  test("calculates offence, physical, and goalie factors as matchup shares", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 13,
+          assists: 13,
+          points: 26,
+          plusMinus: 5,
+          penalties: 14,
+          shots: 135,
+          ppp: 9,
+          shp: 0,
+          hits: 62,
+          blocks: 34,
+          wins: 0,
+          saves: 17,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 9, goalies: 3 },
+        totals: {
+          goals: 8,
+          assists: 18,
+          points: 26,
+          plusMinus: -8,
+          penalties: 28,
+          shots: 148,
+          ppp: 9,
+          shp: 0,
+          hits: 73,
+          blocks: 40,
+          wins: 1,
+          saves: 107,
+          shutouts: 1,
+          gaa: 3.23,
+          savePercent: 0.907,
+        },
+      },
+    });
+
+    expect(calculateFinalsFactors(matchup)).toEqual({
+      awayTeam: {
+        offence: 0.482,
+        physical: 0.438,
+        goalies: 0.067,
+      },
+      homeTeam: {
+        offence: 0.518,
+        physical: 0.562,
+        goalies: 0.933,
+      },
+    });
+  });
+
+  test("uses neutral factor shares when both finalists have no production or goalie qualification", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        playedGames: { total: 0, skaters: 0, goalies: 0 },
+        totals: {
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 0,
+          hits: 0,
+          blocks: 0,
+          wins: 0,
+          saves: 0,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 0, skaters: 0, goalies: 0 },
+        totals: {
+          goals: 0,
+          assists: 0,
+          points: 0,
+          plusMinus: 0,
+          penalties: 0,
+          shots: 0,
+          ppp: 0,
+          shp: 0,
+          hits: 0,
+          blocks: 0,
+          wins: 0,
+          saves: 0,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+    });
+
+    expect(calculateFinalsFactors(matchup)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+    });
+  });
+
+  test("treats perfect GAA and one-sided goalie qualification as full factor-share edges", () => {
+    const matchup = createMatchup({
+      awayTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 0,
+          savePercent: 0.92,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 30,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+    });
+
+    expect(calculateFinalsFactors(matchup)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.811,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.189,
+      },
+    });
+  });
+
+  test("falls back to neutral goalie-efficiency shares for missing or tied qualified rate stats", () => {
+    const nullQualifiedRates = createMatchup({
+      awayTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+    });
+    const tiedPerfectGaa = createMatchup({
+      awayTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 0,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 0,
+          savePercent: 0.91,
+        },
+      },
+    });
+
+    expect(calculateFinalsFactors(nullQualifiedRates)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+    });
+    expect(calculateFinalsFactors(tiedPerfectGaa)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.5,
+      },
+    });
+  });
+
+  test("normalizes factor-share edge values and handles single perfect qualified GAA edges", () => {
+    expect(testOnlyToFactorPair(Number.POSITIVE_INFINITY)).toEqual({
+      away: 0.5,
+      home: 0.5,
+    });
+    expect(testOnlyToFactorPair(-1)).toEqual({
+      away: 0,
+      home: 1,
+    });
+    expect(testOnlyToFactorPair(2)).toEqual({
+      away: 1,
+      home: 0,
+    });
+
+    const awayPerfectGaa = createMatchup({
+      awayTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 0,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+    });
+    const homePerfectGaa = createMatchup({
+      awayTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 2.5,
+          savePercent: 0.91,
+        },
+      },
+      homeTeam: {
+        playedGames: { total: 12, skaters: 10, goalies: 2 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: 0,
+          savePercent: 0.91,
+        },
+      },
+    });
+
+    expect(calculateFinalsFactors(awayPerfectGaa)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.625,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.375,
+      },
+    });
+    expect(calculateFinalsFactors(homePerfectGaa)).toEqual({
+      awayTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.375,
+      },
+      homeTeam: {
+        offence: 0.5,
+        physical: 0.5,
+        goalies: 0.625,
+      },
+    });
   });
 
   test("treats tied zero-shot save percentage cases as neutral and can penalize the winner", () => {

--- a/src/__tests__/finals.scoring.test.ts
+++ b/src/__tests__/finals.scoring.test.ts
@@ -155,6 +155,39 @@ describe("finals scoring", () => {
     ).toBe(0.5);
   });
 
+  test("slightly penalizes winners that needed the home tiebreak", () => {
+    const matchup = createMatchup({
+      wonOnHomeTiebreak: true,
+      awayTeam: {
+        isWinner: false,
+        score: {
+          matchPoints: 7.5,
+          categoriesWon: 7,
+          categoriesLost: 7,
+          categoriesTied: 1,
+        },
+      },
+      homeTeam: {
+        isWinner: true,
+        score: {
+          matchPoints: 7.5,
+          categoriesWon: 7,
+          categoriesLost: 7,
+          categoriesTied: 1,
+        },
+      },
+      winnerTeamId: "2",
+    });
+
+    expect(
+      calculateWeightedEdgeRate(
+        matchup,
+        FINALS_DESERVED_TO_WIN_WEIGHTS,
+        buildFinalsScoringContext([matchup]),
+      ),
+    ).toBe(0.476);
+  });
+
   test("returns neutral when both finalists have zero skater exposure", () => {
     const matchup = createMatchup({
       awayTeam: {
@@ -313,6 +346,62 @@ describe("finals scoring", () => {
   });
 
   test("respects goalie-rate qualification, null rate values, and zero-weight fallbacks", () => {
+    const goalieRateOnlyWeights: FinalsModelWeights = {
+      goals: 0,
+      assists: 0,
+      points: 0,
+      plusMinus: 0,
+      penalties: 0,
+      shots: 0,
+      ppp: 0,
+      shp: 0,
+      hits: 0,
+      blocks: 0,
+      wins: 0,
+      saves: 0,
+      shutouts: 0,
+      gaa: 1,
+      savePercent: 1,
+    };
+    const qualifiedEdgeOnly = createMatchup({
+      winnerTeamId: "2",
+      awayTeam: {
+        isWinner: false,
+        score: {
+          matchPoints: 6.5,
+          categoriesWon: 6,
+          categoriesLost: 8,
+          categoriesTied: 1,
+        },
+        playedGames: { total: 11, skaters: 10, goalies: 1 },
+        totals: {
+          goals: 10,
+          assists: 10,
+          points: 20,
+          plusMinus: 2,
+          penalties: 12,
+          shots: 80,
+          ppp: 6,
+          shp: 1,
+          hits: 30,
+          blocks: 20,
+          wins: 1,
+          saves: 50,
+          shutouts: 0,
+          gaa: null,
+          savePercent: null,
+        },
+      },
+      homeTeam: {
+        isWinner: true,
+        score: {
+          matchPoints: 8.5,
+          categoriesWon: 8,
+          categoriesLost: 6,
+          categoriesTied: 1,
+        },
+      },
+    });
     const qualifiedWinner = createMatchup({
       winnerTeamId: "2",
       awayTeam: {
@@ -480,18 +569,25 @@ describe("finals scoring", () => {
 
     expect(
       calculateWeightedEdgeRate(
+        qualifiedEdgeOnly,
+        goalieRateOnlyWeights,
+        buildFinalsScoringContext([qualifiedEdgeOnly]),
+      ),
+    ).toBe(0.65);
+    expect(
+      calculateWeightedEdgeRate(
         qualifiedWinner,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([qualifiedWinner]),
       ),
-    ).toBeGreaterThan(0.5);
+    ).toBe(0.489);
     expect(
       calculateWeightedEdgeRate(
         disqualifiedWinner,
         FINALS_DESERVED_TO_WIN_WEIGHTS,
         buildFinalsScoringContext([disqualifiedWinner]),
       ),
-    ).toBeLessThan(0.5);
+    ).toBe(0.511);
     expect(
       calculateWeightedEdgeRate(
         bothUnqualified,

--- a/src/__tests__/routes.integration.finals.ts
+++ b/src/__tests__/routes.integration.finals.ts
@@ -157,6 +157,18 @@ export const registerFinalsRouteIntegrationTests = (): void => {
             winRate: 0.767,
             deservedToWinRate: expect.any(Number),
           },
+          factors: {
+            awayTeam: {
+              offence: 0.482,
+              physical: 0.438,
+              goalies: 0.067,
+            },
+            homeTeam: {
+              offence: 0.518,
+              physical: 0.562,
+              goalies: 0.933,
+            },
+          },
         });
         expect(body[0].awayTeam).not.toHaveProperty("isWinner");
         expect(body[0].homeTeam).not.toHaveProperty("isWinner");

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -509,6 +509,18 @@ describe("routes", () => {
             winRate: 0.567,
             deservedToWinRate: 0.604,
           },
+          factors: {
+            awayTeam: {
+              offence: 0.482,
+              physical: 0.438,
+              goalies: 0.067,
+            },
+            homeTeam: {
+              offence: 0.518,
+              physical: 0.562,
+              goalies: 0.933,
+            },
+          },
         },
       ];
       (getFinalsLeaderboardData as jest.Mock).mockResolvedValue(payload);

--- a/src/__tests__/services.finals.test.ts
+++ b/src/__tests__/services.finals.test.ts
@@ -143,6 +143,18 @@ describe("finals service", () => {
         winRate: 0.567,
         deservedToWinRate: expect.any(Number),
       },
+      factors: {
+        awayTeam: {
+          offence: 0.522,
+          physical: 0.525,
+          goalies: 0.51,
+        },
+        homeTeam: {
+          offence: 0.478,
+          physical: 0.475,
+          goalies: 0.49,
+        },
+      },
     });
     expect(result[0].awayTeam).not.toHaveProperty("isWinner");
     expect(result[0].homeTeam).not.toHaveProperty("isWinner");
@@ -243,6 +255,7 @@ describe("finals service", () => {
       expect.objectContaining({
         season: 2023,
         categories: [],
+        factors: expect.any(Object),
       }),
     ]);
   });

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -217,6 +217,17 @@ export const GOALIE_SAVE_PERCENT_BASELINE = 0.85; // .850
 // Minimum games required for games-adjusted scoring (players and goalies)
 export const MIN_GAMES_FOR_ADJUSTED_SCORE = 1;
 
+// Finals deserved-to-win model tuning.
+// One-sided goalie-rate qualification is a meaningful edge, but not a full
+// proof that the qualified team "deserved" those categories on underlying play.
+export const FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE = 0.65;
+
+// If a champion wins specifically via the home-team tiebreak, the deserved model
+// applies a small penalty because the winner benefited from a structural edge
+// earned before the finals started.
+export const FINALS_HOME_TIEBREAK_WINNER_CONFIDENCE = 0.25;
+export const FINALS_HOME_TIEBREAK_WEIGHT = 1.5;
+
 // Games-adjusted scores use stabilized per-game pace. Higher values pull short
 // samples more strongly toward the pool-average rate for that category.
 export const PLAYER_ADJUSTED_SCORE_PRIOR_GAMES: Record<

--- a/src/features/finals/scoring.ts
+++ b/src/features/finals/scoring.ts
@@ -4,6 +4,8 @@ import {
   FINALS_HOME_TIEBREAK_WINNER_CONFIDENCE,
 } from "../../config/settings.js";
 import type {
+  FinalsFactors,
+  FinalsFactorSet,
   FinalsMatchupDbEntry,
   FinalsModelWeights,
   FinalsStatKey,
@@ -17,6 +19,9 @@ type FinalsScoringContext = {
 const MIN_GOALIE_GAMES_FOR_RATE = 2;
 const MIN_PLUS_MINUS_SCALE = 0.05;
 const EPSILON = 0.000001;
+const OFFENCE_FACTOR_KEYS = ["goals", "assists", "shots", "ppp", "shp"] as const;
+const PHYSICAL_FACTOR_KEYS = ["hits", "blocks", "penalties"] as const;
+const GOALIE_VOLUME_FACTOR_KEYS = ["wins", "saves", "shutouts"] as const;
 
 export const FINALS_DESERVED_TO_WIN_WEIGHTS: FinalsModelWeights = {
   goals: 1,
@@ -38,6 +43,21 @@ export const FINALS_DESERVED_TO_WIN_WEIGHTS: FinalsModelWeights = {
 
 const toThreeDecimals = (value: number): number =>
   Math.round(value * 1000) / 1000;
+
+const clampShare = (value: number): number => {
+  if (!Number.isFinite(value)) return 0.5;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+};
+
+const toFactorPair = (awayShare: number): { away: number; home: number } => {
+  const away = toThreeDecimals(clampShare(awayShare));
+  return {
+    away,
+    home: toThreeDecimals(1 - away),
+  };
+};
 
 const erf = (x: number): number => {
   const sign = x < 0 ? -1 : 1;
@@ -96,6 +116,127 @@ const qualificationConfidence = (qualified: boolean): number =>
   qualified
     ? FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE
     : 1 - FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE;
+
+const sumFactorTotals = (
+  team: FinalsTeamData,
+  keys: readonly ("goals" | "assists" | "shots" | "ppp" | "shp" | "hits" | "blocks" | "penalties" | "wins" | "saves" | "shutouts")[],
+): number => keys.reduce((sum, key) => sum + team.totals[key], 0);
+
+const calculateShare = (awayValue: number, homeValue: number): number => {
+  const total = awayValue + homeValue;
+  if (total <= 0) return 0.5;
+  return awayValue / total;
+};
+
+const bothTeamsQualifiedForGoalieRates = (
+  awayTeam: FinalsTeamData,
+  homeTeam: FinalsTeamData,
+): boolean => hasQualifiedGoalieRates(awayTeam) && hasQualifiedGoalieRates(homeTeam);
+
+const calculateSavePercentShare = (
+  awayTeam: FinalsTeamData,
+  homeTeam: FinalsTeamData,
+): number => {
+  const awayQualified = hasQualifiedGoalieRates(awayTeam);
+  const homeQualified = hasQualifiedGoalieRates(homeTeam);
+
+  if (awayQualified !== homeQualified) {
+    return awayQualified ? 1 : 0;
+  }
+
+  if (!bothTeamsQualifiedForGoalieRates(awayTeam, homeTeam)) {
+    return 0.5;
+  }
+
+  const awaySavePercent = awayTeam.totals.savePercent;
+  const homeSavePercent = homeTeam.totals.savePercent;
+
+  if (awaySavePercent == null || homeSavePercent == null) {
+    return 0.5;
+  }
+
+  return calculateShare(awaySavePercent, homeSavePercent);
+};
+
+const calculateGaaShare = (
+  awayTeam: FinalsTeamData,
+  homeTeam: FinalsTeamData,
+): number => {
+  const awayQualified = hasQualifiedGoalieRates(awayTeam);
+  const homeQualified = hasQualifiedGoalieRates(homeTeam);
+
+  if (awayQualified !== homeQualified) {
+    return awayQualified ? 1 : 0;
+  }
+
+  if (!bothTeamsQualifiedForGoalieRates(awayTeam, homeTeam)) {
+    return 0.5;
+  }
+
+  const awayGaa = awayTeam.totals.gaa;
+  const homeGaa = homeTeam.totals.gaa;
+
+  if (awayGaa == null || homeGaa == null) {
+    return 0.5;
+  }
+
+  if (awayGaa <= EPSILON && homeGaa <= EPSILON) {
+    return 0.5;
+  }
+
+  if (awayGaa <= EPSILON) return 1;
+  if (homeGaa <= EPSILON) return 0;
+
+  return calculateShare(1 / awayGaa, 1 / homeGaa);
+};
+
+const calculateGoalieEfficiencyShare = (
+  awayTeam: FinalsTeamData,
+  homeTeam: FinalsTeamData,
+): number =>
+  (calculateGaaShare(awayTeam, homeTeam) +
+    calculateSavePercentShare(awayTeam, homeTeam)) /
+  2;
+
+const buildFactorSetPair = (
+  awayTeam: FinalsTeamData,
+  homeTeam: FinalsTeamData,
+): FinalsFactors => {
+  const offence = toFactorPair(
+    calculateShare(
+      sumFactorTotals(awayTeam, OFFENCE_FACTOR_KEYS),
+      sumFactorTotals(homeTeam, OFFENCE_FACTOR_KEYS),
+    ),
+  );
+  const physical = toFactorPair(
+    calculateShare(
+      sumFactorTotals(awayTeam, PHYSICAL_FACTOR_KEYS),
+      sumFactorTotals(homeTeam, PHYSICAL_FACTOR_KEYS),
+    ),
+  );
+  const goalieVolume = calculateShare(
+    sumFactorTotals(awayTeam, GOALIE_VOLUME_FACTOR_KEYS),
+    sumFactorTotals(homeTeam, GOALIE_VOLUME_FACTOR_KEYS),
+  );
+  const goalieEfficiency = calculateGoalieEfficiencyShare(awayTeam, homeTeam);
+  const goalies = toFactorPair((goalieVolume + goalieEfficiency) / 2);
+
+  const awayTeamFactors: FinalsFactorSet = {
+    offence: offence.away,
+    physical: physical.away,
+    goalies: goalies.away,
+  };
+  const homeTeamFactors: FinalsFactorSet = {
+    offence: offence.home,
+    physical: physical.home,
+    goalies: goalies.home,
+  };
+
+  return {
+    awayTeam: awayTeamFactors,
+    homeTeam: homeTeamFactors,
+  };
+};
 
 const confidenceForCountRate = (
   winnerValue: number,
@@ -301,3 +442,10 @@ export const calculateWeightedEdgeRate = (
 
   return toThreeDecimals(weightedScore / totalWeight);
 };
+
+export const calculateFinalsFactors = (
+  matchup: Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">,
+): FinalsFactors => buildFactorSetPair(matchup.awayTeam, matchup.homeTeam);
+
+/** @internal */
+export const testOnlyToFactorPair = toFactorPair;

--- a/src/features/finals/scoring.ts
+++ b/src/features/finals/scoring.ts
@@ -1,3 +1,8 @@
+import {
+  FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE,
+  FINALS_HOME_TIEBREAK_WEIGHT,
+  FINALS_HOME_TIEBREAK_WINNER_CONFIDENCE,
+} from "../../config/settings.js";
 import type {
   FinalsMatchupDbEntry,
   FinalsModelWeights,
@@ -87,6 +92,11 @@ const sampleStdDev = (values: readonly number[]): number => {
 const hasQualifiedGoalieRates = (team: FinalsTeamData): boolean =>
   team.playedGames.goalies >= MIN_GOALIE_GAMES_FOR_RATE;
 
+const qualificationConfidence = (qualified: boolean): number =>
+  qualified
+    ? FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE
+    : 1 - FINALS_GOALIE_RATE_QUALIFICATION_CONFIDENCE;
+
 const confidenceForCountRate = (
   winnerValue: number,
   loserValue: number,
@@ -111,7 +121,7 @@ const confidenceForGaa = (winner: FinalsTeamData, loser: FinalsTeamData): number
   const loserQualified = hasQualifiedGoalieRates(loser);
 
   if (winnerQualified !== loserQualified) {
-    return winnerQualified ? 1 : 0;
+    return qualificationConfidence(winnerQualified);
   }
 
   if (!winnerQualified && !loserQualified) {
@@ -146,7 +156,7 @@ const confidenceForSavePercent = (
   const loserQualified = hasQualifiedGoalieRates(loser);
 
   if (winnerQualified !== loserQualified) {
-    return winnerQualified ? 1 : 0;
+    return qualificationConfidence(winnerQualified);
   }
 
   if (!winnerQualified && !loserQualified) {
@@ -259,7 +269,10 @@ export const calculateWinRate = (
 };
 
 export const calculateWeightedEdgeRate = (
-  matchup: Pick<FinalsMatchupDbEntry, "awayTeam" | "homeTeam">,
+  matchup: Pick<
+    FinalsMatchupDbEntry,
+    "awayTeam" | "homeTeam" | "wonOnHomeTiebreak"
+  >,
   weights: FinalsModelWeights,
   context: FinalsScoringContext,
 ): number => {
@@ -274,6 +287,12 @@ export const calculateWeightedEdgeRate = (
 
     weightedScore += confidenceForCategory(stat, winner, loser, context) * weight;
     totalWeight += weight;
+  }
+
+  if (matchup.wonOnHomeTiebreak) {
+    weightedScore +=
+      FINALS_HOME_TIEBREAK_WINNER_CONFIDENCE * FINALS_HOME_TIEBREAK_WEIGHT;
+    totalWeight += FINALS_HOME_TIEBREAK_WEIGHT;
   }
 
   if (totalWeight <= 0) {

--- a/src/features/finals/service.ts
+++ b/src/features/finals/service.ts
@@ -4,6 +4,7 @@ import {
   getFinalsMatchups,
 } from "../../db/queries.js";
 import {
+  calculateFinalsFactors,
   buildFinalsScoringContext,
   calculateWeightedEdgeRate,
   calculateWinRate,
@@ -94,6 +95,7 @@ export const getFinalsLeaderboardData = async (): Promise<
           scoringContext,
         ),
       },
+      factors: calculateFinalsFactors(matchup),
     };
   });
 };

--- a/src/features/finals/types.ts
+++ b/src/features/finals/types.ts
@@ -63,6 +63,17 @@ export type FinalsRates = {
   deservedToWinRate: number;
 };
 
+export type FinalsFactorSet = {
+  offence: number;
+  physical: number;
+  goalies: number;
+};
+
+export type FinalsFactors = {
+  awayTeam: FinalsFactorSet;
+  homeTeam: FinalsFactorSet;
+};
+
 export type FinalsMatchupDbEntry = {
   season: number;
   wonOnHomeTiebreak: boolean;
@@ -88,4 +99,5 @@ export type FinalsLeaderboardEntry = {
   homeTeam: FinalsTeam;
   categories: FinalsCategory[];
   rates: FinalsRates;
+  factors: FinalsFactors;
 };


### PR DESCRIPTION
## Summary
- refine the finals deserved-to-win model to handle structural edges more realistically
- add matchup-level finals factors for offence, physical play, and goaltending
- document the finals rating API and model behavior in more detail

## Included commits
- Feature: Refine finals deserved-to-win model
- Feature: Add finals matchup factors

## What changed
- soften one-sided goalie-rate qualification in `deservedToWinRate` so qualifying for `gaa` and `savePercent` is a meaningful edge, but not automatic full credit
- apply a small `deservedToWinRate` penalty when the champion wins on the home-team tiebreak
- add a new `factors` object to `/leaderboard/finals` with per-finalist values for:
  - `offence`
  - `physical`
  - `goalies`
- calculate `offence` from matchup-share production in `goals`, `assists`, `shots`, `ppp`, and `shp`
- calculate `physical` from matchup-share production in `hits`, `blocks`, and `penalties`
- calculate `goalies` as a 50/50 blend of:
  - goalie volume share from `wins`, `saves`, and `shutouts`
  - goalie efficiency share from `gaa` and `savePercent`
- update the OpenAPI schema for the finals leaderboard response
- add focused and integration test coverage for the new finals model behavior and `factors`
- add and expand `docs/RATING.md`, and keep `docs/SCORING.md` focused on player/goalie scoring only

## Verification
- npm run verify
