### PR TITLE
Docs: Agents skill in use

### DIFF
--- a/.agents/skills/api-contract-sync/SKILL.md
+++ b/.agents/skills/api-contract-sync/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: api-contract-sync
+description: Use when backend and frontend or mobile clients share an API contract that must stay in sync. Helps treat the contract as a source of truth, update schemas or OpenAPI before consumer code drifts, regenerate typed clients safely, coordinate breaking and additive changes, and verify that runtime responses, generated types, and consuming code still agree.
+---
+
+# API Contract Sync
+
+## Overview
+
+Use this skill when API changes affect more than one codebase or layer.
+
+The goal is to keep:
+
+- the contract source of truth
+- generated types or clients
+- backend behavior
+- frontend or mobile consumers
+
+in sync at the same time.
+
+This skill is especially useful for TypeScript stacks that use OpenAPI, JSON Schema, Zod-derived schemas, generated types, or shared DTO packages.
+
+## Core Rules
+
+- Identify the contract source of truth first.
+- Change the source of truth before changing consumers that depend on it.
+- Do not hand-edit generated artifacts.
+- Prefer additive contract changes when possible.
+- Treat breaking changes as deliberate decisions, not incidental refactors.
+- Update all affected consumers in the same task when practical.
+- Verify runtime behavior, not just generated TypeScript.
+- Remove stale fields, params, and client assumptions once the new contract is in place.
+
+## Token Discipline
+
+- Keep reporting short by default.
+- Report only:
+  - source of truth changed
+  - consumers updated
+  - generation or validation performed
+  - remaining compatibility risk
+- Expand only when the contract change is breaking, cross-repo, or operationally risky.
+
+## Workflow
+
+### 1. Find the source of truth
+
+Determine which artifact defines the contract:
+
+- OpenAPI document
+- schema definitions
+- shared DTO package
+- route-level contract builders
+
+If the repo has both generated files and handwritten types, prefer the upstream source and treat generated output as disposable.
+
+### 2. Map the consumers
+
+Identify all consumers that depend on the contract:
+
+- web frontend
+- mobile app
+- other backend services
+- tests, fixtures, mocks, or fake servers
+- generated types or SDKs
+
+Read [references/contract-change-checklist.md](./references/contract-change-checklist.md) when the change is cross-repo or potentially breaking.
+
+### 3. Change the contract at the source
+
+Update the source-of-truth contract first.
+
+Typical changes:
+
+- add or remove fields
+- change nullability or optionality
+- change enum values
+- add or remove query or path params
+- split or rename endpoints
+- tighten validation rules
+
+Prefer the smallest contract change that solves the actual product need.
+
+### 4. Regenerate and reconcile consumers
+
+After the source changes:
+
+- regenerate typed clients or types
+- update consuming code
+- fix mocks, fixtures, and tests that model the contract
+- remove outdated assumptions and compatibility shims that are no longer needed
+
+Do not keep drift alive by patching consumer-side handwritten types to imitate the new contract temporarily.
+
+### 5. Verify both compile-time and runtime agreement
+
+Check both:
+
+- compile-time agreement: generated types, app builds, typecheck
+- runtime agreement: real route responses, integration tests, behavior tests, or schema validation
+
+Type generation passing is not enough if the actual response shape is still wrong.
+
+### 6. Handle breaking changes explicitly
+
+When a change is breaking:
+
+- name it clearly
+- update all in-repo consumers in the same batch when possible
+- document migration assumptions briefly if external consumers may exist
+- avoid silent partial compatibility unless the project truly needs a migration window
+
+### 7. Close drift immediately
+
+Before finishing:
+
+- remove dead fields and deprecated consumer logic that no longer matches the contract
+- update fixtures and mocks to the real shape
+- make sure future generation checks will catch drift again
+
+## Anti-Patterns
+
+- Editing generated files directly
+- Changing frontend types without updating the backend contract
+- Shipping a contract change without updating fixtures or mocks
+- Treating typecheck success as proof of runtime correctness
+- Keeping compatibility branches "just in case" without a real migration plan
+- Letting additive and breaking changes blend together without calling out the risk
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Identify the contract source of truth.
+2. Change the contract there first.
+3. Regenerate or refresh dependent artifacts.
+4. Update all affected consumers.
+5. Verify both runtime and type-level agreement.
+6. Report any remaining compatibility risk briefly.

--- a/.agents/skills/api-contract-sync/agents/openai.yaml
+++ b/.agents/skills/api-contract-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "API Contract Sync"
+  short_description: "Keep backend and client API contracts in sync"
+  default_prompt: "Use $api-contract-sync to update this API contract and keep all consumers aligned."

--- a/.agents/skills/api-contract-sync/references/contract-change-checklist.md
+++ b/.agents/skills/api-contract-sync/references/contract-change-checklist.md
@@ -1,0 +1,55 @@
+# Contract Change Checklist
+
+Use this checklist when an API contract change touches more than one layer or repository.
+
+## Change Types
+
+### Usually additive
+
+- adding an optional field
+- adding a new endpoint
+- adding a new optional query param
+- adding a new enum value only when every consumer is already resilient to unknown values
+
+Even additive changes still require fixture, mock, and generated-type updates where relevant.
+
+### Potentially breaking
+
+- removing a field
+- renaming a field
+- changing a field type
+- changing nullability or requiredness
+- changing enum semantics
+- changing route paths or query param names
+- changing pagination, filtering, sorting, or auth expectations
+
+Treat these as explicit compatibility decisions.
+
+## Consumer Checklist
+
+- backend implementation updated
+- source-of-truth contract updated
+- generated types or SDK regenerated
+- web frontend updated
+- mobile app updated
+- tests updated
+- mocks or fake servers updated
+- fixtures updated
+- docs or examples updated if they are user-facing or operationally important
+
+## Verification Checklist
+
+- typecheck passes in changed repos
+- build or verify passes where appropriate
+- integration or route tests prove the live response shape
+- behavior tests still pass in consumers
+- no stale consumer-side handwritten type overrides remain
+
+## Drift Warnings
+
+Pause if any of these appear:
+
+- generated files changed unexpectedly far beyond the intended contract edit
+- frontend or mobile starts casting around the contract instead of updating usage properly
+- fixtures pass but runtime responses no longer match them
+- the change seems additive in TypeScript but changes real user-visible behavior

--- a/.agents/skills/intelligence-testing/SKILL.md
+++ b/.agents/skills/intelligence-testing/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: intelligence-testing
+description: "Use when working on application code that should be built with behavior-first TDD: define the real usage story, write the highest-signal failing test first, implement the smallest change to pass it, and refactor only after behavior is protected. Helps choose the right test layer, cover realistic user, API, mobile, and operator scenarios, avoid mock-heavy duplication, and remove speculative defensive branches or fallback logic that cannot be exercised by real usage."
+---
+
+# Intelligence Testing
+
+## Overview
+
+Use this skill when the goal is not just "add tests", but to drive implementation through realistic behavior first.
+
+This skill uses behavior-first TDD:
+
+- Write the real usage story first
+- Turn that story into the best failing test first
+- Implement the smallest production change that makes the test pass
+- Refactor only after the behavior is protected
+
+The default bias is:
+
+- Start from real behavior, not internal functions
+- Prefer the highest-signal failing test that still keeps failures understandable
+- Cover realistic scenarios completely
+- Delete unreachable or speculative logic instead of defending it with artificial tests
+
+If the repository already has project-specific testing rules, follow those rules first and apply this skill as the decision-making lens behind them.
+
+## Core Rules
+
+- Define the real actor first: browser user, mobile user, API consumer, admin, importer operator, scraper run, scheduled job.
+- Describe the task as a usage flow before writing code or tests.
+- Write the failing test before implementation unless the user explicitly asks for another workflow.
+- Test visible behavior, returned API behavior, persisted data behavior, or operator-visible outcomes.
+- Do not add branches for imagined futures unless the product explicitly needs them now.
+- Do not keep fallback logic that no real scenario can trigger.
+- Do not add helper-only tests just to justify dead code.
+- Prefer one strong integration or behavior test over several thin mock-wiring tests.
+- Keep pure unit tests for deterministic logic that is reused or too awkward to reach through behavior tests.
+- Refactor only after the failing test has gone green.
+
+## Token Discipline
+
+- Keep the workflow strict, but keep narration short.
+- Do not narrate every TDD step unless the user asks for that level of detail.
+- Do not dump full scenario lists in routine updates.
+- Report only the essentials by default:
+  - chosen test layer
+  - behavior proved
+  - remaining risk or verification gap
+- Expand reasoning only when the risk is non-obvious, the user asks for depth, or a product decision needs clarification.
+
+## Workflow
+
+### 1. Frame the usage story
+
+Before editing, write the smallest realistic story that proves the task:
+
+- Who is doing the action?
+- What do they do?
+- What should they observe?
+- What can realistically go wrong?
+
+Good examples:
+
+- "User opens the player table, changes season, and sees rows update."
+- "API consumer requests a record detail with an invalid id and gets a clear `400` or `404`."
+- "Importer runs against partially stale upstream data and preserves good local data until the sync succeeds."
+
+### 2. Pick the first failing test
+
+Choose the thinnest test layer that still proves the real behavior, then write that test first.
+
+Behavior-first TDD does not mean unit-test-first by default. It means the first test should live at the most realistic layer for the behavior under change.
+
+Use this bias:
+
+- UI rendering, labels, interaction, loading, empty, and error states: behavior tests with Testing Library first
+- Cross-page flows, browser routing, responsive behavior, keyboard flows, or shared shell behavior: E2E tests first
+- Endpoint + service + database composition: integration tests through the real HTTP boundary and real temporary DB or realistic fixtures first
+- Pure scoring, parsing, mapping, normalization, and reducer logic: focused unit tests first
+- Scraping/import pipelines: realistic input fixtures plus integration-style verification of normalized output, stored records, or operator-visible summaries first
+
+Read [references/scenario-matrix.md](./references/scenario-matrix.md) when the task spans multiple layers or includes UI, API, and import behavior together.
+
+### 3. Go red on realistic behavior
+
+Make the first test fail for the right reason.
+
+- The failure should prove the requested behavior does not exist yet or is currently wrong.
+- The test should describe the user, caller, or operator-visible outcome.
+- Avoid starting with internal helper assertions unless the logic is genuinely pure and isolated.
+- Keep the initial failing test narrow enough to guide implementation, but real enough to matter.
+
+### 4. Go green with the smallest change
+
+Implement the smallest production change that makes the failing test pass.
+
+- Prefer simpler production code over defensive indirection
+- Add only the logic justified by the failing scenario
+- Resist adding future-facing branches while the first behavior is still being proven
+- If the implementation exposes dead parameters, impossible states, or duplicate paths, simplify them instead of preserving them
+
+### 5. Expand to the realistic scenario set
+
+After the first test is green, add the remaining realistic scenarios for the task.
+
+Cover only scenarios that a real user or system can actually hit, but cover those thoroughly.
+
+Default checklist:
+
+- Success path
+- Loading or in-progress state when visible
+- Empty state when valid
+- Invalid input that users or callers can really send
+- Upstream/API/DB/network failure that the product intentionally handles
+- Persistence/cache/reload behavior when the feature depends on it
+- Accessibility behavior for interactive UI
+- Navigation, deep link, or parameter behavior when routing is involved
+
+Do not invent branches only because "something might happen someday." If a branch cannot be described as a realistic path, simplify or delete it.
+
+### 6. Refactor after protection exists
+
+Once the behavior is protected:
+
+- Remove dead parameters, impossible unions, and unused fallbacks
+- Collapse duplicated logic once a single real flow proves behavior
+- Improve naming, structure, and extraction without changing protected behavior
+- Keep the test suite focused on observable outcomes, not new internals created during refactor
+
+### 7. Verify at the right depth
+
+After implementation:
+
+- Run the repo's normal quality gate when practical
+- Run the most relevant high-signal test layer for the touched behavior
+- Report any unverified risk clearly if environment limits block full validation
+
+## Anti-Patterns
+
+- Testing component methods instead of user-visible behavior
+- Mocking most of the stack and then claiming integration confidence
+- Preserving unreachable branches and covering them with isolated tests
+- Adding "just in case" fallbacks without a concrete scenario
+- Duplicating the same happy path in unit, integration, and E2E suites
+- Using TDD as an excuse to start from internal helper tests when the behavior belongs at UI, route, or integration level
+- Hiding product uncertainty inside defensive logic instead of clarifying the expected behavior
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. State the primary real usage flow being protected.
+2. Choose the highest-signal first failing test intentionally.
+3. Implement only enough production code to make that test pass.
+4. Add the remaining realistic scenarios that must be covered.
+5. Refactor only after protection exists.
+6. Prefer simplifying code over defending imaginary cases.
+7. Finish by reporting what real behavior was verified and what remains unverified.

--- a/.agents/skills/intelligence-testing/agents/openai.yaml
+++ b/.agents/skills/intelligence-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Intelligence Testing"
+  short_description: "Drive software work with behavior-first TDD"
+  default_prompt: "Use $intelligence-testing to drive this task with behavior-first TDD and realistic test scenarios."

--- a/.agents/skills/intelligence-testing/references/scenario-matrix.md
+++ b/.agents/skills/intelligence-testing/references/scenario-matrix.md
@@ -1,0 +1,116 @@
+# Scenario Matrix
+
+Use this file when a task needs a more concrete behavior-first TDD checklist.
+
+For each area below:
+
+- Start with the highest-signal failing test for the requested behavior
+- Make it pass with the smallest implementation
+- Then add the rest of the realistic scenarios
+
+## Web UI
+
+Prefer behavior tests for local component/page work and E2E when the behavior depends on routing, browser layout, shared shell state, or full-page interactions.
+
+Best first failing tests:
+
+- A user-visible behavior test for a single screen interaction
+- An E2E test first only when the behavior genuinely depends on routing, layout, or full browser flow
+
+Typical realistic scenarios:
+
+- First render shows the expected title, controls, and initial data state
+- Loading indicator appears only while data is unresolved
+- Empty state is clear and not confused with an error
+- Error state explains failure and leaves the screen usable
+- Search, filters, sort, tabs, dialogs, and drawers work through visible controls
+- URL params, deep links, and back/forward navigation keep the right state
+- Keyboard focus, labels, and roles still support the main flow
+- Refresh, cache reuse, or retry behavior works if the feature depends on it
+
+Avoid:
+
+- Testing private methods
+- Driving branches through CSS selectors when accessible queries exist
+- Mocking core state services if the user flow can exercise the real ones
+
+## Mobile App
+
+Prefer React Native Testing Library behavior tests for screen logic and route-level tests for Expo Router wiring. Use device-level or end-to-end checks only when touch, platform, or navigation integration truly matters.
+
+Best first failing tests:
+
+- A screen-level behavior test for the visible user action
+- A route-level test first when params or navigation wiring are the real behavior under change
+
+Typical realistic scenarios:
+
+- Screen loads with API data and keeps visible state stable through refresh
+- Empty/error/loading states are distinct and understandable
+- Search, filters, and sort react to real text entry and presses
+- Detail routes reject invalid params cleanly
+- Required accessibility labels and roles exist for navigation and alerts
+- Secrets stay out of URLs, rendered UI, logs, and cache keys
+
+Avoid:
+
+- Snapshot-heavy tests with little behavioral meaning
+- Hardcoded locale strings when shared translation helpers already define the output shape
+- Keeping optional branches that no actual route or screen can reach
+
+## Backend API
+
+Prefer integration tests through the HTTP boundary when behavior spans routing, services, queries, persistence, auth, caching, or schema validation.
+
+Best first failing tests:
+
+- A route/integration test first when the contract depends on multiple layers
+- A focused unit test first only when the changed logic is truly pure
+
+Typical realistic scenarios:
+
+- Happy path returns the expected response shape and status
+- Invalid params return the intended `400` or `404`
+- Auth-protected routes reject missing or invalid credentials
+- Empty datasets return stable response shapes
+- Cache headers, ETags, or pagination behave consistently when part of the contract
+- Data imported to the database is the data the route later returns
+- OpenAPI or response-schema expectations still match live responses
+
+Avoid:
+
+- Mocking the database for flows that are really route-plus-data behavior
+- Duplicating the same happy path in route, service, and query tests
+- Writing tests that only prove parameter forwarding or internal delegation
+
+## Importers, Scrapers, And Sync Jobs
+
+Treat these like operator-facing product features, not just scripts.
+
+Best first failing tests:
+
+- A realistic fixture or integration-style test for the observable sync/import outcome
+- A pure parser/mapping unit test first only after extracting deterministic logic out of the CLI or browser shell
+
+Typical realistic scenarios:
+
+- Valid upstream input normalizes into the expected stored or emitted output
+- Partial bad input fails clearly without corrupting already good data
+- Re-runs are idempotent when the workflow expects repeat execution
+- Logs or summaries expose the outcome an operator actually needs
+- Retry or backoff logic is covered only when the tool really uses it in production
+- Pure parsing rules are extracted into testable modules when the Playwright or CLI shell itself is not the right unit-test surface
+
+Avoid:
+
+- Pulling CLI entrypoints directly into unit suites when extracted pure logic would be cleaner
+- Adding broad fallback parsing branches for shapes that have never been observed
+- Marking a sync as "safe" without proving what happens to existing data on failure
+
+## Cross-Cutting Heuristics
+
+- If a branch cannot be tied to a realistic scenario, remove it.
+- If a test does not describe observable behavior, question whether it belongs.
+- If a unit test and an integration test prove the same thing, keep the one with better signal.
+- If coverage pressure encourages fake scenarios, simplify the code instead.
+- If the task changes behavior across UI and API, make sure both the user-visible result and the server contract are validated.

--- a/.agents/skills/local-first-verification/SKILL.md
+++ b/.agents/skills/local-first-verification/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: local-first-verification
+description: Use when deciding how to verify a change locally before handoff, review, or commit. Helps choose the cheapest meaningful checks that still prove the touched behavior, coordinate local environment assumptions, avoid both under-testing and wasteful over-testing, keep fixtures and mocks honest, and report only real residual risk.
+---
+
+# Local First Verification
+
+## Overview
+
+Use this skill when a change needs verification, but not every task needs the heaviest possible check immediately.
+
+The goal is to verify changes locally in the cheapest order that still provides honest confidence:
+
+- start with the most relevant low-cost checks
+- escalate only when risk or uncertainty requires it
+- do not confuse speed with shallow verification
+- do not confuse expensive verification with meaningful verification
+
+## Core Rules
+
+- Match verification depth to the behavior changed.
+- Prefer the cheapest check that can actually fail for the right reason.
+- Escalate when the cheaper check cannot prove the real behavior.
+- Verify user-visible behavior with user-visible checks.
+- Verify integration boundaries with integration checks.
+- Keep mocks and fixtures aligned with current runtime behavior.
+- Coordinate with local services, ports, credentials, and background processes before expensive runs.
+- Report only what was truly verified, not what was merely assumed.
+
+## Token Discipline
+
+- Do not narrate every command or every check.
+- Summarize only:
+  - checks run
+  - behavior covered
+  - gaps or blocked verification
+- Expand only when a failure, environment issue, or hidden risk needs explanation.
+
+## Workflow
+
+### 1. Identify the touched surface
+
+Classify the change:
+
+- pure logic
+- UI behavior
+- routing or navigation
+- API contract
+- persistence or caching
+- environment or config
+- styling or accessibility
+- cross-layer integration
+
+Read [references/verification-matrix.md](./references/verification-matrix.md) when the right check depth is not obvious.
+
+### 2. Choose the first meaningful check
+
+Good starting points:
+
+- typecheck or lint for type-level or structural edits
+- focused unit or behavior tests for isolated logic or local UI changes
+- integration tests for API, DB, caching, or multi-layer flows
+- browser or device verification for visual, responsive, or interaction-sensitive changes
+
+Start with a check that is cheap and relevant, not merely familiar.
+
+### 3. Confirm local assumptions
+
+Before heavier verification, confirm what the run depends on:
+
+- required local servers
+- ports already in use
+- environment variables or credentials
+- fixture or mock mode versus live mode
+- generated artifacts already up to date
+
+Do not burn time debugging a failing verification flow that was invalid before it started.
+
+### 4. Escalate only when needed
+
+Escalate when:
+
+- the first check cannot observe the changed behavior
+- the change crosses boundaries
+- production risk is higher than local signal so far
+- the repo's standard quality gate is required before finishing
+
+Examples:
+
+- from unit test to integration test
+- from behavior test to E2E
+- from local mock mode to live local backend
+- from targeted test to full verify
+
+### 5. Keep fixtures and mocks honest
+
+When a change touches contract, routing, request shape, or serialized output:
+
+- update fixtures
+- update mocks
+- verify they still represent real runtime behavior
+
+Do not let passing local tests hide drift between mock mode and live mode.
+
+### 6. Stop when confidence is sufficient and honest
+
+The goal is not maximal command count. Stop when:
+
+- the changed behavior has been proved at the right depth
+- the repo's required gate has passed, if applicable
+- remaining uncertainty is minor and explicitly reported
+
+## Anti-Patterns
+
+- Running only cheap checks that cannot observe the actual change
+- Jumping straight to the heaviest check for every small edit
+- Treating fixture mode as enough when the contract or runtime behavior changed
+- Claiming full confidence after typecheck only
+- Re-running large verification commands repeatedly without learning from the first failure
+- Hiding blocked verification behind vague language
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Identify what changed and what kind of signal it needs.
+2. Run the cheapest meaningful verification first.
+3. Escalate only when the cheaper check is insufficient.
+4. Keep local assumptions, fixtures, and mocks honest.
+5. Report verified behavior and any real gaps briefly.

--- a/.agents/skills/local-first-verification/agents/openai.yaml
+++ b/.agents/skills/local-first-verification/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Local First Verification"
+  short_description: "Choose the cheapest honest local verification path"
+  default_prompt: "Use $local-first-verification to choose and run the right local verification depth for this task."

--- a/.agents/skills/local-first-verification/references/verification-matrix.md
+++ b/.agents/skills/local-first-verification/references/verification-matrix.md
@@ -1,0 +1,58 @@
+# Verification Matrix
+
+Use this matrix to choose the first meaningful local check.
+
+## Change Type To First Check
+
+### Pure logic or utility code
+
+- start with focused unit tests
+- add typecheck if signatures or generics changed
+
+### UI behavior inside one screen or component
+
+- start with behavior tests
+- escalate to browser or device checks only if layout, focus, routing, or visual state matters
+
+### Styling only
+
+- start with browser or device verification
+- add visual or behavior tests only when styles affect interaction states
+
+### Route, navigation, or deep-link behavior
+
+- start with route-level behavior or integration tests
+- escalate to E2E if the full shell or browser history matters
+
+### Backend route, cache, DB, or auth behavior
+
+- start with integration tests through the real boundary
+- add unit tests only for extracted pure logic
+
+### API contract or generated client changes
+
+- start with contract regeneration or validation plus integration verification
+- then verify at least one affected consumer path
+
+### Build, config, or environment changes
+
+- start with the narrowest command that proves the config works
+- escalate to the standard project gate if the config affects the full app
+
+## Escalation Signals
+
+Escalate when:
+
+- the changed behavior is not visible to the current test layer
+- mocks or fixtures may have drifted from runtime
+- multiple layers changed together
+- accessibility or visual behavior is part of the outcome
+- the repo requires a full gate before completion
+
+## Reporting Pattern
+
+Keep the final summary short:
+
+- what was verified
+- at what layer
+- what was not verified and why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Default workflow is a user-created branch (not `main`).
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
-- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Before any non-docs commit, `npm run verify` must pass. Docs-only changes do not require the full verification gate. Targeted tests are not a substitute for the full verification gate when runtime code changes.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
 - Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 2. Read [package.json](package.json) for available npm scripts.
 3. Follow all development standards in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 4. Follow all testing standards in [docs/TESTING.md](docs/TESTING.md).
-5. Read the relevant topic doc when the task touches that area:
+5. Follow [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) for the project's default Codex skill workflow.
+6. Read the relevant topic doc when the task touches that area:
    - [docs/IMPORTING.md](docs/IMPORTING.md) for Fantrax and FFHL draft import workflows
    - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Vercel, Turso, R2, auth, and caching
    - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md) for snapshot generation and storage
@@ -17,6 +18,7 @@
 - Keep [README.md](README.md) concise as the front door: overview, quick start, API doc entrypoints, and links to deeper docs.
 - Put deep operational detail into focused docs under `docs/` instead of rebuilding a 1,000-line README.
 - Avoid duplicating the same long runbook across [README.md](README.md), [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md), and topic docs.
+- Keep detailed Codex skill workflow in [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) and link to it instead of re-explaining the same skill rules in multiple files.
 - If current documentation has clearly weak decisions, challenge them and propose better alternatives.
 - User decides whether documentation guidelines are changed.
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,13 @@ npm run test:integration
 npm run snapshot:generate
 ```
 
+## Agent Workflow
+
+Codex work in this repository defaults to the backend/basic skill set from `maestor/agent-skills`: `intelligence-testing`, `api-contract-sync`, and `local-first-verification`. Those skills live in this repo under `.agents/skills/`. `mutation-testing` is intentionally not part of this project. See [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) for the project-local install command and automatic usage rules.
+
 ## Documentation
 
+- [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) - default Codex skill set, project-local install flow, and when to apply each backend skill
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - development workflow, code standards, project structure, OpenAPI maintenance
 - [docs/TESTING.md](docs/TESTING.md) - test strategy, coverage expectations, integration testing rules
 - [docs/IMPORTING.md](docs/IMPORTING.md) - Fantrax sync/import workflows, FFHL draft sync, draft entity linking/backfill, CSV normalization

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -1,0 +1,28 @@
+# Agent Skills Workflow
+
+## Default Skill Set
+
+This project uses the backend/basic Codex skill set from [`maestor/agent-skills`](https://github.com/maestor/agent-skills):
+
+- `intelligence-testing`
+- `api-contract-sync`
+- `local-first-verification`
+
+## Automatic Usage Rules
+
+Use these skills by default during future development work:
+
+- `intelligence-testing`: every time work involves testing, test coverage scope, or deciding the right test layer. Start from a real usage story, write the highest-signal failing test first, and prefer behavior or integration coverage over duplicated mock wiring when the changed behavior crosses boundaries.
+- `api-contract-sync`: every time a task changes route shapes, request or response contracts, OpenAPI, generated types, shared DTOs, fixtures, or client expectations. Treat the contract source of truth as the first edit.
+- `local-first-verification`: every time a task needs verification planning before handoff, review, or commit. Start with the cheapest meaningful local check, escalate only when needed, and still finish with `npm run verify` before every commit because that is a repository rule.
+
+When project-specific instructions conflict with a generic skill, follow this repository's docs first and use the skill as the decision-making lens behind them.
+
+## Documentation Ownership
+
+Keep the detailed skill workflow in this file.
+
+- `README.md` should only mention that these skills are part of the default workflow and link here.
+- `docs/DEVELOPMENT.md` should reference this file for day-to-day AI-assisted workflow expectations.
+- `docs/TESTING.md` should reference this file while keeping repository-specific testing rules here in-repo.
+- `AGENTS.md` should point sessions here so future Codex work picks up the same defaults automatically.

--- a/docs/AGENT_SKILLS.md
+++ b/docs/AGENT_SKILLS.md
@@ -14,7 +14,7 @@ Use these skills by default during future development work:
 
 - `intelligence-testing`: every time work involves testing, test coverage scope, or deciding the right test layer. Start from a real usage story, write the highest-signal failing test first, and prefer behavior or integration coverage over duplicated mock wiring when the changed behavior crosses boundaries.
 - `api-contract-sync`: every time a task changes route shapes, request or response contracts, OpenAPI, generated types, shared DTOs, fixtures, or client expectations. Treat the contract source of truth as the first edit.
-- `local-first-verification`: every time a task needs verification planning before handoff, review, or commit. Start with the cheapest meaningful local check, escalate only when needed, and still finish with `npm run verify` before every commit because that is a repository rule.
+- `local-first-verification`: every time a task needs verification planning before handoff, review, or commit. Start with the cheapest meaningful local check, escalate only when needed, and finish with `npm run verify` for non-docs changes because that is the repository rule.
 
 When project-specific instructions conflict with a generic skill, follow this repository's docs first and use the skill as the decision-making lens behind them.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -77,7 +77,7 @@ Keep the detailed workflow in [AGENT_SKILLS.md](AGENT_SKILLS.md). This file stay
 3. **Before committing**
 
    ```bash
-   npm run verify  # Must pass - runs all quality gates
+   npm run verify  # Required for non-docs changes; docs-only commits can skip it
    ```
 
 4. **Commit with descriptive message**
@@ -105,7 +105,7 @@ npm run verify
 4. `npm run build` - Production build (outputs to lib/)
 5. `npm run test:coverage` - Full test suite with coverage gates
 
-**Must pass before every commit.** No exceptions.
+**Must pass before every non-docs commit.** Docs-only commits can skip the full verification gate.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,6 +35,7 @@ This should:
 ## Documentation Map
 
 - [../README.md](../README.md) - project overview, quick start, API doc links, grouped endpoint examples
+- [AGENT_SKILLS.md](AGENT_SKILLS.md) - default Codex skill set and project-local install/usage rules
 - [TESTING.md](TESTING.md) - testing strategy and coverage rules
 - [IMPORTING.md](IMPORTING.md) - Fantrax and FFHL draft import runbooks, CSV handling
 - [DEPLOYMENT.md](DEPLOYMENT.md) - Vercel, Turso, R2, auth, caching
@@ -43,6 +44,18 @@ This should:
 - [RATING.md](RATING.md) - finals leaderboard rate behavior
 
 Keep the README concise. Put deep operational detail in the topic docs above instead of growing the top-level readme again.
+
+---
+
+## Agent Skills Workflow
+
+The repository keeps its default Codex backend skills under `.agents/skills/`.
+
+- Use `intelligence-testing` whenever work changes tests or needs a decision about test coverage scope.
+- Use `api-contract-sync` whenever route shapes, OpenAPI, generated types, fixtures, or consumer expectations change.
+- Use `local-first-verification` whenever choosing local checks before review, handoff, or commit.
+
+Keep the detailed workflow in [AGENT_SKILLS.md](AGENT_SKILLS.md). This file stays focused on repository development rules instead of repeating the full skill playbook.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,17 @@
 # 🧪 Testing Requirements
 
+## Default Testing Skill
+
+`intelligence-testing` is the default skill for all testing work in this repository, including deciding test coverage scope.
+
+- Start from the real usage story before choosing a test.
+- Prefer the highest-signal failing test first at the right layer.
+- Prefer behavior and integration coverage over duplicated mock wiring when the changed behavior crosses boundaries.
+
+Use [AGENT_SKILLS.md](AGENT_SKILLS.md) for the shared skill workflow, and use this document for the repository-specific rules and coverage expectations that refine it.
+
+---
+
 ## Coverage Gates ✅
 
 All new code **must maintain 100% test coverage:**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -21,7 +21,7 @@ All new code **must maintain 100% test coverage:**
 - **100% function coverage**
 - **100% line coverage**
 
-**Enforcement:** `npm run verify` must pass before any commit.
+**Enforcement:** `npm run verify` must pass before non-docs commits. Docs-only commits can skip it.
 
 **Excluded from coverage:**
 
@@ -225,7 +225,7 @@ Keep this directory updated whenever a new module or integration boundary is add
 
 - [ ] All new code has test coverage
 - [ ] `npm run unused` passes or intentional test-only exports are marked `@internal`
-- [ ] `npm run verify` passes (lint + typecheck + build + coverage)
+- [ ] `npm run verify` passes for non-docs changes (lint + typecheck + build + coverage)
 - [ ] No coverage thresholds lowered
 - [ ] Test names clearly describe what's being tested
 - [ ] Edge cases and error conditions tested

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "api-contract-sync": {
+      "source": "maestor/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/api-contract-sync/SKILL.md",
+      "computedHash": "5a84737d3a58e6f43228303570f7997ee1a644e75f4aaf592d0bf33a70d220ca"
+    },
+    "intelligence-testing": {
+      "source": "maestor/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/intelligence-testing/SKILL.md",
+      "computedHash": "a82c5d9827487b84c319e624d5c30632c8e1e1d3129248400a418d229eb49d3d"
+    },
+    "local-first-verification": {
+      "source": "maestor/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/local-first-verification/SKILL.md",
+      "computedHash": "faf7380a5e2c35402ff699534a1d84948ec3c230b71e79d8a5472105aa3afa12"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the project-local backend Codex skill workflow to this repository and updates the docs so future development uses those skills by default.

## What changed

- Installed the backend/basic `maestor/agent-skills` set into this repo under `.agents/skills/`:
  - `intelligence-testing`
  - `api-contract-sync`
  - `local-first-verification`
- Added `skills-lock.json` so the installed skill sources are tracked in-repo.
- Added `docs/AGENT_SKILLS.md` as the source of truth for how these skills should be used in this project.
- Updated `README.md`, `AGENTS.md`, `docs/DEVELOPMENT.md`, and `docs/TESTING.md` to reference the new skill workflow and reduce duplicated guidance.
- Changed the verification policy so `npm run verify` is required for non-docs changes, while docs-only commits can skip the full verification gate.

## Verification

- `npm run verify` passed for the branch changes before the docs-only verify-rule follow-up.
- The follow-up commit only changed documentation policy text and intentionally did not rerun `npm run verify`, matching the new docs-only exemption.
