### PR TITLE
Docs: Add shared workflow skills and trim duplicated AGENTS guidance

### DIFF
--- a/.agents/skills/git-pr-workflow/SKILL.md
+++ b/.agents/skills/git-pr-workflow/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: git-pr-workflow
+description: Use when a task should follow a consistent working-branch, review, verify, commit, push, and PR-handoff flow across repositories. Helps enforce branch hygiene before edits, use repo-aware branch naming, pause for user review before the final verification gate, commit in coherent batches with consistent prefixes, and finish with pushed changes plus copy-pasteable PR notes.
+---
+
+# Git PR Workflow
+
+## Overview
+
+Use this skill when the repository should follow a predictable Git and handoff workflow instead of re-explaining the same steps in every `AGENTS.md`.
+
+The goal is to keep delivery flow consistent across repositories:
+
+- do not work on `main`
+- use a sensible working branch with repo-appropriate naming
+- implement in coherent batches
+- pause for user review before the final verification gate
+- run the real verification gate after acceptance
+- commit with consistent prefixes
+- push the ready branch
+- finish with copy-pasteable PR notes
+
+Read [references/workflow-checklist.md](./references/workflow-checklist.md) when deciding branch naming, docs-only verification exceptions, or the expected PR-notes shape.
+
+## Core Rules
+
+- Repo-specific workflow rules still win when they are stricter or more specific.
+- Explicit user instructions in chat override the default workflow.
+- Before editing, confirm the current branch is not `main`.
+- If the repo documents branch naming conventions, follow them.
+- If no repo convention exists, use a clear branch name with a conventional prefix.
+- Use targeted checks while implementing, but reserve the final verification gate for after user review and acceptance.
+- Commit in reasonable, coherent batches. A single PR may contain multiple commits.
+- Use capitalized conventional commit prefixes such as `Feature:`, `Fix:`, `Docs:`, `Chore:`, `Refactor:`, or `Test:`.
+- After acceptance, verification, and commit, push the branch unless the user explicitly wants to stop before push.
+- End with copy-pasteable PR notes in a single fenced code block unless the branch is intentionally not PR-ready.
+
+## Token Discipline
+
+- Do not narrate every Git command.
+- Report only:
+  - branch state and branch choice when relevant
+  - review pause status
+  - final verification result
+  - commits created
+  - whether the branch was pushed
+  - PR notes or the reason they were intentionally omitted
+- Expand only when branch hygiene, verification exceptions, or push readiness is non-obvious.
+
+## Workflow
+
+### 1. Start from branch hygiene
+
+Before implementation:
+
+- inspect the current branch
+- if on `main`, create or switch to a working branch before editing
+- if the repo already defines branch naming rules, follow them
+
+Prefer short, descriptive branch names such as:
+
+- `feature/player-card-charts`
+- `bugfix/search-empty-state`
+- `docs/api-readme-refresh`
+- `chore/update-tooling`
+
+For repositories that already standardize on prefixes like `feature/`, `bugfix/`, `chore/`, `docs/`, `refactor/`, or `test/`, preserve that convention.
+
+### 2. Implement in coherent batches
+
+Keep work grouped into meaningful units:
+
+- one feature slice
+- one bug fix
+- one docs refresh
+- one test batch
+- one refactor concern
+
+Do not wait until the very end to think about commit boundaries.
+
+### 3. Use iterative checks while working
+
+While implementing, run only the checks needed to stay honest:
+
+- focused tests
+- typecheck
+- lint
+- targeted verification for the touched behavior
+
+These are implementation checks, not the final gate.
+
+### 4. Pause for user review before the final gate
+
+After the batch is ready:
+
+- summarize the implemented change briefly
+- ask the user to review
+- do not run the final `verify` gate yet unless the user has already accepted the batch
+- if review feedback arrives, iterate and return to the review pause as needed
+
+This review pause is part of the workflow, not an optional courtesy.
+
+### 5. Run the final verification gate after acceptance
+
+After the user explicitly accepts the batch:
+
+- run the repo's real verification gate, usually `npm run verify`
+- if it fails, fix the issue and rerun the necessary checks until it passes
+
+Docs-only changes may skip the full gate only when the touched files are limited to docs or workflow text and the repo treats that as a valid exception.
+
+Read [references/workflow-checklist.md](./references/workflow-checklist.md) for the usual docs-only and repo-config exception boundaries.
+
+### 6. Commit in ready batches
+
+Once the accepted batch is verified, commit it unless the user explicitly wants to hold commits.
+
+Use commit messages like:
+
+- `Feature: Add park visit summary cards`
+- `Fix: Correct goalie playoff ranking sort`
+- `Docs: Refresh local setup notes`
+- `Chore: Tighten verify script inputs`
+
+Use sentence-style capitalization after the colon.
+
+### 7. Push and prepare handoff
+
+When the branch is accepted, verified, and committed:
+
+- push the branch
+- if more implementation is still planned on the same branch, say so clearly
+- if the branch is PR-ready, provide copy-pasteable PR notes
+
+PR notes should usually include:
+
+- `Title`
+- `Summary`
+- `Verification`
+
+Wrap the notes in one fenced code block so they are easy to copy.
+
+## Anti-Patterns
+
+- starting implementation on `main`
+- inventing a one-off branch name when the repo already has a convention
+- treating targeted tests as a substitute for the final verify gate
+- running final verify before the user has reviewed the batch
+- building one giant end-of-task commit when the work had obvious batch boundaries
+- skipping push or PR notes without saying why
+- mixing docs-only exceptions into runtime-code changes without calling out the difference
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Check branch state before editing.
+2. Use a repo-appropriate working branch.
+3. Implement in coherent batches with iterative checks.
+4. Pause for user review before the final verification gate.
+5. After acceptance, run the real verification gate.
+6. Commit with consistent prefixes.
+7. Push the branch and provide fenced PR notes when ready.

--- a/.agents/skills/git-pr-workflow/agents/openai.yaml
+++ b/.agents/skills/git-pr-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git PR Workflow"
+  short_description: "Use a consistent branch, verify, commit, and PR handoff flow"
+  default_prompt: "Use $git-pr-workflow for this task so the work follows the standard branch, review, verify, commit, push, and PR-notes workflow."

--- a/.agents/skills/git-pr-workflow/references/workflow-checklist.md
+++ b/.agents/skills/git-pr-workflow/references/workflow-checklist.md
@@ -1,0 +1,117 @@
+# Git PR Workflow Checklist
+
+Use this reference when a repo should follow the same task-delivery flow without repeating it in every `AGENTS.md`.
+
+## Pre-Work Branch Check
+
+Before editing:
+
+- inspect the current branch
+- if on `main`, create or switch to a working branch first
+- check whether the repo already defines branch naming conventions
+- keep unrelated user changes intact
+
+## Branch Naming
+
+If the repo already documents a branch naming scheme, follow it.
+
+Good common prefixes:
+
+- `feature/`
+- `bugfix/`
+- `chore/`
+- `docs/`
+- `refactor/`
+- `test/`
+
+Good examples:
+
+- `feature/park-visit-form`
+- `bugfix/random-record-empty-state`
+- `docs/testing-guide-refresh`
+- `chore/verify-script-cleanup`
+
+Choose the prefix from the dominant concern of the batch, not from every small side effect.
+
+## Review Pause
+
+Before the final verification gate:
+
+- finish the current implementation batch
+- summarize what changed
+- pause for user review
+- wait for explicit acceptance
+
+If the user requests changes, iterate and return to the same review pause.
+
+## Verification Gate
+
+After acceptance:
+
+- run the repo's final gate, usually `npm run verify`
+- treat targeted checks as support for implementation, not as the final gate
+- if the gate fails, fix the issue and rerun until it passes
+
+Common exception:
+
+- docs-only or workflow-only changes may skip the full gate when the touched files are limited to documentation or repo workflow text and the repo treats that as safe
+
+Use the repo's stricter rule if it defines one.
+
+## Commit Strategy
+
+Commit in coherent batches when they are ready.
+
+Typical commit prefixes:
+
+- `Feature:`
+- `Fix:`
+- `Docs:`
+- `Chore:`
+- `Refactor:`
+- `Test:`
+
+Message style:
+
+- capitalize the first word after the colon
+- keep the rest in normal sentence style
+- avoid vague messages like `Fix stuff`
+
+## Push And Handoff
+
+When the batch is accepted, verified, and committed:
+
+- push the branch
+- state clearly if more work is still planned before PR
+- if PR-ready, provide notes in one fenced code block
+
+Suggested PR-notes shape:
+
+```md
+Title
+- Short PR title
+
+Summary
+- Main change
+- Important follow-up detail
+
+Verification
+- `npm run verify`
+- Any scoped checks worth mentioning
+```
+
+## Lean AGENTS.md Pattern
+
+To avoid repeating this workflow in every repo, keep `AGENTS.md` short:
+
+- point to the shared workflow skill
+- keep only repo-specific overrides in the repo
+- document local branch naming quirks, verify exceptions, or push constraints only when they differ from the shared default
+
+Good candidates to keep repo-local:
+
+- required branch prefixes unique to the repo
+- exact verify command if it is not `npm run verify`
+- generated-file rules
+- deployment or push constraints
+- exceptions around docs-only, E2E-only, or plan-only changes

--- a/.agents/skills/project-documentation/SKILL.md
+++ b/.agents/skills/project-documentation/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: project-documentation
+description: Use when creating, restructuring, or updating repository documentation so README, docs pages, contributor guidance, commands, environment setup, testing expectations, architecture notes, and deployment or operations docs stay concise, project-specific, and aligned with actual frontend, backend, mobile, or split-repo workflows.
+---
+
+# Project Documentation
+
+## Overview
+
+Use this skill when a repository needs documentation that stays useful during normal engineering work instead of becoming a separate maintenance burden.
+
+The goal is to keep project docs:
+
+- easy to enter through one clear starting point
+- specific to the actual repository, not generic framework teaching
+- honest about commands, environments, architecture, and verification
+- updated in the same change when behavior or workflow changes
+- shaped appropriately for frontend, backend, mobile, or paired UI/API repos
+
+Read [references/documentation-checklist.md](./references/documentation-checklist.md) when deciding which docs belong in a repo or which files must be updated for a given change.
+
+## Core Rules
+
+- Prefer one clear documentation entrypoint before adding more files.
+- Keep README focused on orientation, setup, core commands, and where deeper docs live.
+- Put detailed workflows in `docs/` once they become too large or too specific for README.
+- Document repository-specific truths, not generic React, Angular, Expo, Node, or framework tutorials.
+- Keep commands, environment variables, ports, URLs, and deployment details concrete.
+- When a repo depends on a sibling repo, name that relationship explicitly.
+- Update docs in the same task when code changes affect behavior, commands, contracts, testing, deployment, or contributor workflow.
+- Prefer concise sections and strong cross-links over long duplicated explanations.
+- If a fact is enforced by code, config, or scripts, document the rule without drifting from the real source of truth.
+- Call out known local exceptions, shortcuts, and operational caveats that would otherwise slow the next contributor down.
+
+## Token Discipline
+
+- Do not rewrite an entire documentation set when only one workflow changed.
+- Summarize repeated patterns once, then link to the deeper file.
+- Keep change reports short:
+  - entrypoints updated
+  - workflow or command drift fixed
+  - new docs added only if they close a real gap
+  - any remaining documentation debt
+- Expand only when structure, rollout, or migration impact is non-obvious.
+
+## Workflow
+
+### 1. Identify the documentation surfaces
+
+Map the current documentation entrypoints:
+
+- `README.md`
+- `docs/README.md` if present
+- topic guides under `docs/`
+- `AGENTS.md`, `CLAUDE.md`, or project-local skill docs
+- generated API docs such as OpenAPI or Swagger
+
+Find where contributors are expected to start and whether that path is still obvious.
+
+### 2. Identify the repo type and audience
+
+Determine what this repository actually is:
+
+- web frontend
+- mobile app
+- backend or API
+- data/import pipeline
+- paired UI or API repo in a multi-repo system
+
+Also identify the main readers:
+
+- maintainers
+- new contributors
+- AI coding agents
+- deployers or operators
+- consumers of the API or app
+
+The docs should optimize for the real readers, not for an imaginary generic audience.
+
+### 3. Keep README as the orientation layer
+
+A strong README usually answers:
+
+- what this project is
+- what it connects to
+- how to run it locally
+- which commands matter most
+- where the detailed docs live
+
+README should help someone become oriented quickly. It should not become a dumping ground for every implementation detail.
+
+### 4. Move depth into focused docs
+
+When the project has enough complexity, split topic-specific guidance into focused files such as:
+
+- development workflow
+- testing and verification
+- architecture or project structure
+- deployment and operations
+- importing or data sync workflows
+- accessibility, design system, or UI conventions
+- agent or contributor workflow
+
+Each deeper doc should have a clear reason to exist and a stable link from the main entrypoint.
+
+### 5. Match the doc set to the repository type
+
+Different repos need different depth:
+
+- frontend and mobile repos often need setup, UI conventions, testing, accessibility, theming, and API-integration notes
+- backend repos often need runtime overview, environment variables, migrations, import jobs, API shape, auth, deployment, and operations notes
+- split UI/API projects should cross-link each other and clearly describe the boundary between them
+
+Use [references/documentation-checklist.md](./references/documentation-checklist.md) to choose the smallest honest doc set.
+
+### 6. Update docs when code changes create drift
+
+Documentation updates are required when changes affect:
+
+- commands
+- ports, URLs, or environment variables
+- repo structure or important directories
+- API contracts or generated type workflows
+- test strategy, coverage gates, or verification commands
+- deployment, auth, caching, or data import behavior
+- accessibility, theming, navigation, or other contributor-facing UI rules
+
+Do not leave docs behind and call it follow-up work unless the user explicitly chooses that tradeoff.
+
+### 7. Keep docs concrete and skimmable
+
+Prefer:
+
+- real commands
+- real file paths
+- real ports and URLs
+- short sections with descriptive headings
+- explicit links between related docs
+
+Avoid vague phrases like "configure as needed" when the repository already knows what is needed.
+
+### 8. Close the loop before finishing
+
+Before considering the work done:
+
+- check that README still points to the right deeper docs
+- remove or fix stale command examples
+- ensure new files are linked from an obvious entrypoint
+- make sure frontend/backend counterpart links still work
+- report any remaining documentation gap explicitly
+
+## Anti-Patterns
+
+- README that tries to explain the entire codebase with no deeper structure
+- many docs files with no obvious starting point
+- generic framework tutorials copied into repo docs
+- command lists that no longer match `package.json` or scripts
+- environment variable sections that omit required values or local defaults
+- frontend docs that hide the backend dependency
+- backend docs that never explain auth, contracts, data sources, or operational flows
+- documenting desired architecture instead of the current one
+- leaving docs stale after changing workflows because "the code is obvious"
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Find the real docs entrypoints and repo type.
+2. Keep README as the fast orientation layer.
+3. Move complexity into focused docs only when it earns its own file.
+4. Update docs in the same change whenever workflow or behavior drift appears.
+5. Keep instructions concrete, project-specific, and cross-linked.

--- a/.agents/skills/project-documentation/agents/openai.yaml
+++ b/.agents/skills/project-documentation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Project Documentation"
+  short_description: "Keep repo docs concise, current, and project-specific"
+  default_prompt: "Use $project-documentation to create or update this repository's README and docs so they stay aligned with the real frontend, backend, or mobile workflow."

--- a/.agents/skills/project-documentation/references/documentation-checklist.md
+++ b/.agents/skills/project-documentation/references/documentation-checklist.md
@@ -1,0 +1,150 @@
+# Project Documentation Checklist
+
+Use this checklist to decide which documentation files belong in a repository and which existing docs must be updated after a change.
+
+## Core Principles
+
+- README is the entrypoint, not the whole knowledge base.
+- Prefer a small doc set that is current over a large doc set that drifts.
+- Keep docs project-specific and operationally useful.
+- Cross-link related docs instead of duplicating the same instructions.
+- If a repo has a sibling UI/API/mobile/backend repository, state the relationship clearly.
+
+## README Baseline
+
+Most repos should keep these in `README.md`:
+
+- project purpose and scope
+- linked sibling repo or live deployment if one matters
+- quick local start or setup
+- most important commands
+- doc index for deeper topics
+- concise technology or architecture summary when useful
+
+README can also include:
+
+- feature summary for product-facing apps
+- API overview for backend repos
+- environment overview when setup is otherwise confusing
+- contributor expectations if they are short and central
+
+Move detailed command explanations, long architecture notes, or operational runbooks into `docs/`.
+
+## Docs Directory Baseline
+
+Add topic docs only when the topic is substantial enough to deserve its own stable link.
+
+Common files:
+
+- `docs/README.md`
+  Use when `docs/` contains enough files that contributors need a docs index.
+- `docs/development.md` or `docs/DEVELOPMENT.md`
+  Local setup, workflow, commands, conventions, project structure.
+- `docs/testing.md` or `docs/TESTING.md`
+  Test strategy, verification expectations, fixture or mock rules, coverage gates.
+- `docs/deployment.md` or `docs/DEPLOYMENT.md`
+  Hosting, secrets, environments, rollout, operational checks.
+- `docs/architecture.md`
+  Only when the project has enough moving parts that structure and boundaries are otherwise hard to infer.
+- `docs/accessibility.md`
+  Useful when accessibility rules are central to UI work.
+- `docs/versioning.md`
+  Useful for Expo/mobile release flow, app version policy, or API versioning.
+- `docs/importing.md`
+  Useful for scrapers, import pipelines, seed data, or sync workflows.
+- `docs/agent_skills.md` or `docs/AGENT_SKILLS.md`
+  Useful when the repo relies on project-local skills or explicit AI workflow rules.
+
+Keep topic docs narrowly scoped. If two files explain nearly the same workflow, combine them.
+
+## Frontend and Web UI Repos
+
+Usually document:
+
+- backend dependency and base URL expectations
+- environment variables
+- core dev, build, test, and verify commands
+- route or feature overview when product scope is not obvious
+- testing strategy
+- accessibility or design-system rules when they materially affect contributions
+- API type generation or contract-sync workflow when typed clients are generated
+- deployment or hosting notes if the frontend proxies auth or API traffic
+
+Good deeper docs for frontend repos often include:
+
+- development workflow
+- testing
+- styling or theming guide
+- accessibility guide
+- architecture or project overview
+
+## Mobile Repos
+
+Usually document:
+
+- simulator or device assumptions
+- Expo or native tooling prerequisites
+- environment variable flow for local and cloud builds
+- API dependency and generated type workflow
+- versioning and release/update flow
+- platform-specific debugging notes when they are recurring
+
+## Backend and API Repos
+
+Usually document:
+
+- runtime purpose and data sources
+- quick start, migrations, and import/bootstrap flow
+- required and optional environment variables
+- auth expectations
+- key routes or where the generated API docs live
+- verification commands and test strategy
+- deployment/runtime target
+- cache, snapshot, import, or operations workflow when applicable
+
+Good deeper docs for backend repos often include:
+
+- development
+- testing
+- deployment
+- importing or sync workflows
+- snapshots, caching, or data-pipeline notes
+
+## Paired UI and API Repos
+
+When frontend and backend live separately:
+
+- link each repo from the other
+- explain the contract boundary
+- describe how local URLs and auth work between them
+- document generated client/type workflows from the backend contract
+- state clearly which repo is the source of truth for API shape
+
+## Documentation Update Triggers
+
+Update docs when a change affects:
+
+- local startup steps
+- commands or scripts
+- environment variables
+- API routes, auth, or contract generation
+- project structure that contributors rely on
+- test strategy or quality gates
+- deployment configuration
+- data import or sync flow
+- accessibility, theming, navigation, or major UX conventions
+- sibling-repo integration points
+
+If the change only affects internal implementation and no contributor-facing workflow or behavior changed, docs may not need updates.
+
+## Review Questions
+
+Before finishing documentation work, ask:
+
+- Can a new contributor find the right starting point quickly?
+- Does README explain what the repo is and how it fits into the system?
+- Are the most important commands accurate?
+- Are required environment variables concrete and current?
+- Do docs still match the actual test and deployment workflow?
+- Is there duplication that will drift?
+- Are deeper docs linked from an obvious place?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,38 +3,36 @@
 ## Startup Checklist
 1. Read [README.md](README.md) for project overview, quick start, and the documentation map.
 2. Read [package.json](package.json) for available npm scripts.
-3. Follow all development standards in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
-4. Follow all testing standards in [docs/TESTING.md](docs/TESTING.md).
+3. Follow [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+4. Follow [docs/TESTING.md](docs/TESTING.md).
 5. Follow [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) for the project's default Codex skill workflow.
 6. Read the relevant topic doc when the task touches that area:
-   - [docs/IMPORTING.md](docs/IMPORTING.md) for Fantrax and FFHL draft import workflows
-   - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Vercel, Turso, R2, auth, and caching
-   - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md) for snapshot generation and storage
-   - [docs/SCORING.md](docs/SCORING.md) for player and goalie scoring behavior
-   - [docs/RATING.md](docs/RATING.md) for finals leaderboard rate behavior
+   - [docs/IMPORTING.md](docs/IMPORTING.md)
+   - [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)
+   - [docs/SNAPSHOTS.md](docs/SNAPSHOTS.md)
+   - [docs/SCORING.md](docs/SCORING.md)
+   - [docs/RATING.md](docs/RATING.md)
+
+## Shared Skills
+- Use `$project-documentation` when updating `README.md`, `docs/**`, contributor guidance, or repository workflow docs.
+- Use `$git-pr-workflow` for the standard branch, review, final-verify, commit, push, and PR-notes flow.
+- Keep the detailed project skill workflow in [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) instead of re-explaining it here.
 
 ## Documentation Rules
-- Keep [README.md](README.md) and docs updated after every task.
+- Keep [README.md](README.md) and docs updated after every task when needed.
 - Keep [README.md](README.md) concise as the front door: overview, quick start, API doc entrypoints, and links to deeper docs.
-- Put deep operational detail into focused docs under `docs/` instead of rebuilding a 1,000-line README.
+- Put deep operational detail into focused docs under `docs/` instead of rebuilding a large README.
 - Avoid duplicating the same long runbook across [README.md](README.md), [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md), and topic docs.
-- Keep detailed Codex skill workflow in [docs/AGENT_SKILLS.md](docs/AGENT_SKILLS.md) and link to it instead of re-explaining the same skill rules in multiple files.
-- If current documentation has clearly weak decisions, challenge them and propose better alternatives.
-- User decides whether documentation guidelines are changed.
+- If current documentation has clearly weak decisions, challenge them and propose better alternatives. User decides whether documentation guidelines are changed.
 
-## Git Workflow Rules
-- Default workflow is a user-created branch (not `main`).
-- If currently on `main`, ask user to create a branch before implementing task changes.
-- If considering `git worktree`, always ask explicitly first and explain why worktree would help.
-- Before any non-docs commit, `npm run verify` must pass. Docs-only changes do not require the full verification gate. Targeted tests are not a substitute for the full verification gate when runtime code changes.
-- Commit message prefixes should use capitalized conventional labels.
-- New features must use the prefix `Feature: `.
-- Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.
-- Use sentence-style capitalization after the colon: capitalize the first word, but do not title-case the whole message unless normal capitalization requires it. Example: `Feature: Add career player and goalie listings`.
-
-## Task Completion and Handoff
-- You may commit independently on the working branch.
+## Repo-Specific Workflow Overrides
+- Before any non-docs commit, `npm run verify` must pass. Docs-only changes do not require the full verification gate.
+- Targeted tests are not a substitute for the full verification gate when runtime code changes.
 - After finishing implementation, ask the user to review.
-- After user accepts changes, complete a commit phase on the current branch before offering PR notes.
-- After the commit phase, offer PR notes as a copy-pasteable code block.
+- After user acceptance, complete a commit phase on the current branch before offering PR notes.
 - User handles final PR flow.
+
+## Commit Message Style
+- New features must use the prefix `Feature: `.
+- Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, and similar conventional labels.
+- Use sentence-style capitalization after the colon: capitalize the first word, but do not title-case the whole message unless normal capitalization requires it.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -7,6 +7,12 @@
       "skillPath": "skills/api-contract-sync/SKILL.md",
       "computedHash": "5a84737d3a58e6f43228303570f7997ee1a644e75f4aaf592d0bf33a70d220ca"
     },
+    "git-pr-workflow": {
+      "source": "maestor/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/git-pr-workflow/SKILL.md",
+      "computedHash": "40e64ee3cd04130db176d353aae532da37da659b33736ccd2a7a1b9aec235ca4"
+    },
     "intelligence-testing": {
       "source": "maestor/agent-skills",
       "sourceType": "github",
@@ -18,6 +24,12 @@
       "sourceType": "github",
       "skillPath": "skills/local-first-verification/SKILL.md",
       "computedHash": "faf7380a5e2c35402ff699534a1d84948ec3c230b71e79d8a5472105aa3afa12"
+    },
+    "project-documentation": {
+      "source": "maestor/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/project-documentation/SKILL.md",
+      "computedHash": "6045f59b9b299ff3e7223f5dea726d78817e9937573a48324fd0d50ab86b6d03"
     }
   }
 }


### PR DESCRIPTION
Summary
- Install the shared `$project-documentation` and `$git-pr-workflow` skills for this repo
- Update `AGENTS.md` to reference those shared skills instead of repeating the same Git, review, verify, commit, push, and PR-notes workflow in full
- Keep repo-specific overrides in `AGENTS.md`, such as branch naming conventions, docs-only verify exceptions, local dev-server rules, and project-specific coding or testing constraints
- Reduce repeated maintenance across related repos by moving the common workflow into reusable shared skills

Verification
- Docs-only change
- `npm run verify` intentionally not run because the PR changes only workflow and agent documentation files
