### PR TITLE
Fix: Bump current season and add draft entity generation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,11 +61,13 @@ The repository keeps its default Codex backend skills under `.agents/skills/`.
 
 ### Daily Development Loop
 
-1. **Create feature branch**
+1. **Work on a non-main branch**
 
    ```bash
-   git checkout -b feature/your-feature-name
+   git switch -c feature/your-feature-name
    ```
+
+   If you are using the shared `git-pr-workflow` skill, it should create or switch to the working branch automatically before edits begin.
 
 2. **Make changes incrementally**
    - Write failing test first (TDD approach recommended)

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -368,6 +368,30 @@ Useful options:
 - `--opening-only`
 - `--dry-run`
 
+### Generate entry-draft entity mappings from existing Fantrax entities
+
+If you want `/draft/entry` to include `playedInLeague` and `playedForDraftingTeam`, generate `entities-entry-draft.json` from the current `fantrax_entities` table before running the `--entities-only` backfill.
+
+```bash
+npm run draft:generate-entities -- --season=2026 --dry-run
+npm run draft:generate-entities -- --season=2026
+```
+
+Notes:
+
+- this reads `entry-draft-2026.json` and tries to match each player name against `fantrax_entities`
+- it writes or updates `src/playwright/.fantrax/drafts/entities-entry-draft.json`
+- existing mappings for other seasons are preserved
+- unresolved or ambiguous picks are printed to the console
+- only players already present in `fantrax_entities` can be linked automatically
+
+After generating the file, apply it to the imported draft rows:
+
+```bash
+npx tsx scripts/db-import-drafts.ts --season=2026 --entities-only --dry-run
+npx tsx scripts/db-import-drafts.ts --season=2026 --entities-only
+```
+
 ## Fantrax CSV Handling
 
 Fantrax exports often include an `Age` column and may include an `ID` column as the first data column. Stats imports treat Fantrax roster exports as sectioned CSVs (`Skaters` / `Goalies`) and preserve that raw-data shape for the importer, while transaction CSVs still parse as ordinary header-based tables.

--- a/docs/season-change.md
+++ b/docs/season-change.md
@@ -54,6 +54,7 @@ npm run playwright:sync:finals -- --year=2026
 Notes:
 
 - `playwright:sync:leagues` is the important first step because regular imports, playoff imports, and transaction downloads depend on the season-to-league mapping.
+- keep `--year=2026` on the `sync:*` commands when you only want to refresh the new active season; without it, these scripts iterate every mapped season
 - `playwright:sync:playoffs` and `playwright:sync:finals` can be deferred until those parts of the season actually exist.
 - `playwright:sync:regular` writes the local standings mapping used by regular-results imports.
 
@@ -62,40 +63,69 @@ Notes:
 For the regular-season rollover, use one of these:
 
 ```bash
-./scripts/update-season.sh 2026
+./scripts/update-season.sh
 ```
 
 or the explicit flow:
 
 ```bash
-npm run playwright:import:regular -- --year=2026
-./scripts/import-temp-csv.sh --season=2026 --report-type=regular
+npm run playwright:import:regular
+./scripts/import-temp-csv.sh --report-type=regular
 ```
 
 Important:
 
+- `playwright:import:regular` defaults to the most recent mapped season when `--year` is omitted.
 - `scripts/update-season.sh` is only a regular-season bootstrap helper. It does not replace the full season-change checklist.
 - if you use the default `csv/temp/` output, the Playwright importer already triggers the temp CSV pipeline automatically
 
 Import transactions once the new season is available:
 
 ```bash
-npm run playwright:import:transactions -- --year=2026
+npm run playwright:import:transactions
 ```
 
 Later in the season, import the remaining season-specific data as needed:
 
 ```bash
-npm run playwright:import:playoffs -- --year=2026
-npm run db:import:transactions -- --season=2026
+npm run playwright:import:playoffs
+npm run db:import:transactions
 npm run db:import:regular-results
 npm run db:import:playoff-results
 npm run db:import:finals-results
 ```
 
 Choose the commands that match the current phase of the season. Early in the year you usually only need regular-season rosters and transactions.
+Use an explicit `--year` or `--season` only when you are backfilling an older season or you want to override the default current-season target.
 
-### 5. Refresh snapshots and storage expectations
+### 5. Add the new entry draft season when it exists
+
+The FFHL entry draft does not follow the same default-current-season flow as the Fantrax imports. If the new entry draft season is missing, add it explicitly once the forum thread exists.
+
+Sync the entry draft from the public FFHL forum thread:
+
+```bash
+npm run playwright:sync:draft -- --url=https://ffhl.kld.im/threads/entry-draft-2026-varatut-pelaajat.XXXX/
+```
+
+Then import the local draft JSON into the database:
+
+```bash
+npx tsx scripts/db-import-drafts.ts --season=2026
+```
+
+Notes:
+
+- this flow is local-only until you import it; there is no automatic Fantrax-style current-season default for entry draft data
+- the scraper parses the season from the forum topic title, so make sure the thread title really says `Entry draft 2026`
+- the output file should become `src/playwright/.fantrax/drafts/entry-draft-2026.json`
+- if the `drafts/` directory does not exist yet, the sync step creates the local draft artifact through the normal output flow
+- use `--season=2026` on the import step so only the new entry-draft season is imported or refreshed
+- if you maintain draft entity mapping files such as `entities-entry-draft.json`, rerun the import after updating them so `fantrax_entity_id` links and derived API flags stay current
+
+This step is separate from the opening-draft history import. `opening-draft.json` is league-history data, while `entry-draft-2026.json` is the new season-specific file you add during rollover.
+
+### 6. Refresh snapshots and storage expectations
 
 Most imports already refresh the relevant snapshots for you:
 
@@ -117,7 +147,7 @@ npm run r2:upload:current
 npm run r2:upload:transactions -- --current-only
 ```
 
-### 6. Verify the new season behaves like the active default
+### 7. Verify the new season behaves like the active default
 
 Recommended checks:
 
@@ -139,7 +169,7 @@ If you changed runtime code such as `CURRENT_SEASON`, finish with:
 npm run verify
 ```
 
-### 7. Update contributor docs if the process changed
+### 8. Update contributor docs if the process changed
 
 If this rollover exposed a new manual step, update these docs in the same task:
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "playwright:sync:regular": "tsx src/playwright/sync-regular.ts",
     "playwright:sync:draft": "tsx src/playwright/sync-entry-draft.ts",
     "playwright:sync:opening-draft": "tsx src/playwright/sync-opening-draft.ts",
+    "draft:generate-entities": "tsx scripts/generate-draft-entities.ts",
     "preplaywright:import:regular": "npm run playwright:install",
     "playwright:import:regular": "tsx src/playwright/import-league-regular.ts",
     "preplaywright:import:playoffs": "npm run playwright:install",

--- a/scripts/generate-draft-entities.ts
+++ b/scripts/generate-draft-entities.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env tsx
+
+import dotenv from "dotenv";
+dotenv.config();
+
+if (process.env.USE_REMOTE_DB !== "true") {
+  process.env.TURSO_DATABASE_URL = "file:local.db";
+  delete process.env.TURSO_AUTH_TOKEN;
+}
+
+import fs from "fs/promises";
+import path from "path";
+
+import { getDbClient } from "../src/db/client.js";
+import { DEFAULT_ENTRY_DRAFT_OUT_DIR, type EntryDraftPick } from "../src/features/drafts/parser.js";
+import {
+  generateEntryDraftEntityMappings,
+  type EntryDraftEntityMappingRecord,
+  type FantraxEntityCandidate,
+} from "../src/features/drafts/entity-mappings.js";
+
+type ExistingMappingRow = EntryDraftEntityMappingRecord;
+
+const parseSeasonArg = (args: readonly string[]): number => {
+  const seasonArg = args.find((arg) => arg.startsWith("--season="));
+  if (!seasonArg) {
+    throw new Error("Missing required --season=YYYY argument.");
+  }
+
+  const season = Number.parseInt(seasonArg.split("=")[1], 10);
+  if (!Number.isFinite(season)) {
+    throw new Error(`Invalid --season value: ${seasonArg.split("=")[1]}`);
+  }
+
+  return season;
+};
+
+const readJsonFile = async (filePath: string): Promise<unknown> =>
+  JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readEntryDraftPicks = async (filePath: string, season: number): Promise<EntryDraftPick[]> => {
+  const payload = await readJsonFile(filePath);
+  if (!Array.isArray(payload) || payload.length === 0) {
+    throw new Error(`Entry draft file must contain a non-empty array: ${filePath}`);
+  }
+
+  const picks = payload as EntryDraftPick[];
+  const invalidSeason = picks.find((pick) => pick.season !== season);
+  if (invalidSeason) {
+    throw new Error(
+      `Entry draft file ${filePath} contains season ${invalidSeason.season} while --season=${season} was requested.`,
+    );
+  }
+
+  return picks;
+};
+
+const readExistingMappings = async (
+  filePath: string,
+): Promise<ExistingMappingRow[]> => {
+  try {
+    const payload = await readJsonFile(filePath);
+    if (!Array.isArray(payload)) {
+      throw new Error(`Draft entity mapping file must contain an array: ${filePath}`);
+    }
+
+    return payload.map((row, index) => {
+      if (!isRecord(row)) {
+        throw new Error(
+          `Draft entity mapping ${path.basename(filePath)} row ${index + 1} must be an object.`,
+        );
+      }
+
+      const season = Number(row.season);
+      const pickNumber = Number(row.pickNumber);
+      const id = Number(row.id);
+      const draftedTeamId = String(row.draftedTeamId ?? "");
+      const fantraxEntityId = String(row.fantraxEntityId ?? "");
+      const fantraxEntityName = String(row.fantraxEntityName ?? "");
+
+      if (
+        !Number.isInteger(id) ||
+        !Number.isInteger(season) ||
+        !Number.isInteger(pickNumber) ||
+        !draftedTeamId ||
+        !fantraxEntityId ||
+        !fantraxEntityName
+      ) {
+        throw new Error(
+          `Draft entity mapping ${path.basename(filePath)} row ${index + 1} is missing required values.`,
+        );
+      }
+
+      return {
+        id,
+        season,
+        pickNumber,
+        draftedTeamId,
+        fantraxEntityId,
+        fantraxEntityName,
+      };
+    });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+};
+
+const loadFantraxEntities = async (): Promise<FantraxEntityCandidate[]> => {
+  const db = getDbClient();
+  const result = await db.execute(
+    `SELECT fantrax_id, name, last_seen_season
+     FROM fantrax_entities`,
+  );
+
+  return result.rows.map((row) => ({
+    fantraxId: String(row.fantrax_id),
+    name: String(row.name),
+    lastSeenSeason: Number(row.last_seen_season),
+  }));
+};
+
+const main = async (): Promise<void> => {
+  const args = process.argv.slice(2);
+  const season = parseSeasonArg(args);
+  const dryRun = args.includes("--dry-run");
+  const draftsDirArg = args.find((arg) => arg.startsWith("--dir="));
+  const draftsDir =
+    draftsDirArg !== undefined
+      ? path.resolve(draftsDirArg.split("=")[1])
+      : DEFAULT_ENTRY_DRAFT_OUT_DIR;
+  const inputFile = path.join(draftsDir, `entry-draft-${season}.json`);
+  const outputFile = path.join(draftsDir, "entities-entry-draft.json");
+
+  const [picks, entities, existingMappings] = await Promise.all([
+    readEntryDraftPicks(inputFile, season),
+    loadFantraxEntities(),
+    readExistingMappings(outputFile),
+  ]);
+
+  const report = generateEntryDraftEntityMappings({
+    picks,
+    entities,
+  });
+
+  const preservedMappings = existingMappings.filter((mapping) => mapping.season !== season);
+  const mergedMappings = [...preservedMappings, ...report.generatedMappings]
+    .sort(
+      (left, right) =>
+        left.season - right.season ||
+        left.pickNumber - right.pickNumber ||
+        left.draftedTeamId.localeCompare(right.draftedTeamId),
+    )
+    .map((mapping, index) => ({
+      ...mapping,
+      id: index + 1,
+    }));
+
+  console.info("✅ Draft entity mapping generation complete");
+  console.info(`   Input file: ${inputFile}`);
+  console.info(`   Output file: ${outputFile}`);
+  console.info(`   Season: ${season}`);
+  console.info(`   Draft picks: ${picks.length}`);
+  console.info(`   Matched: ${report.matchedCount}`);
+  console.info(`   Ambiguous: ${report.ambiguousCount}`);
+  console.info(`   Missing: ${report.unresolvedCount}`);
+  console.info(`   Skipped null player names: ${report.skippedCount}`);
+  console.info(`   Dry run: ${dryRun}`);
+
+  const unresolved = report.results.filter(
+    (result) =>
+      result.status === "unresolved_missing_entity" ||
+      result.status === "unresolved_ambiguous_entity",
+  );
+  if (unresolved.length > 0) {
+    console.info("");
+    console.info("Unresolved picks:");
+    for (const result of unresolved) {
+      const candidateNote =
+        result.candidateNames.length > 0
+          ? ` Candidates: ${result.candidateNames.join(", ")}`
+          : "";
+      console.info(
+        `   Pick ${result.pickNumber}: ${result.playerName} [${result.status}]${candidateNote}`,
+      );
+    }
+  }
+
+  if (dryRun) {
+    return;
+  }
+
+  await fs.writeFile(outputFile, `${JSON.stringify(mergedMappings, null, 2)}\n`, "utf8");
+  console.info("");
+  console.info(`Wrote ${report.generatedMappings.length} mapping row(s) for season ${season}.`);
+};
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/src/__tests__/drafts.entity-mappings.test.ts
+++ b/src/__tests__/drafts.entity-mappings.test.ts
@@ -1,0 +1,135 @@
+import {
+  generateEntryDraftEntityMappings,
+  normalizeDraftEntityName,
+} from "../features/drafts/entity-mappings.js";
+import type { EntryDraftPick } from "../features/drafts/parser.js";
+
+const createPick = (overrides: Partial<EntryDraftPick> = {}): EntryDraftPick => ({
+  season: 2026,
+  round: 1,
+  pickNumber: 1,
+  playerName: "Gavin McKenna",
+  draftedTeam: {
+    abbreviation: "VGK",
+    teamId: "32",
+    teamName: "Vegas Golden Knights",
+  },
+  originalOwnerTeam: {
+    abbreviation: "VGK",
+    teamId: "32",
+    teamName: "Vegas Golden Knights",
+  },
+  ...overrides,
+});
+
+describe("draft entity mapping generation", () => {
+  test("normalizes accents, apostrophes, and repeated spaces", () => {
+    expect(normalizeDraftEntityName("  Viggo   Björck  ")).toBe("Viggo Bjorck");
+    expect(normalizeDraftEntityName("O'Connor")).toBe("OConnor");
+    expect(normalizeDraftEntityName("O’Connor")).toBe("OConnor");
+  });
+
+  test("matches a single exact normalized name", () => {
+    const report = generateEntryDraftEntityMappings({
+      picks: [createPick({ playerName: "Viggo Björck" })],
+      entities: [
+        {
+          fantraxId: "ftx-1",
+          name: "Viggo Bjorck",
+          lastSeenSeason: 2026,
+        },
+      ],
+    });
+
+    expect(report.matchedCount).toBe(1);
+    expect(report.generatedMappings).toEqual([
+      {
+        id: 1,
+        season: 2026,
+        pickNumber: 1,
+        draftedTeamId: "32",
+        fantraxEntityId: "ftx-1",
+        fantraxEntityName: "Viggo Bjorck",
+      },
+    ]);
+    expect(report.results[0]?.status).toBe("matched_exact_name");
+  });
+
+  test("uses the latest last-seen season when multiple names match", () => {
+    const report = generateEntryDraftEntityMappings({
+      picks: [createPick({ playerName: "Jack Smith" })],
+      entities: [
+        {
+          fantraxId: "ftx-old",
+          name: "Jack Smith",
+          lastSeenSeason: 2023,
+        },
+        {
+          fantraxId: "ftx-new",
+          name: "Jack Smith",
+          lastSeenSeason: 2026,
+        },
+      ],
+    });
+
+    expect(report.matchedCount).toBe(1);
+    expect(report.generatedMappings[0]?.fantraxEntityId).toBe("ftx-new");
+    expect(report.results[0]?.status).toBe("matched_latest_last_seen");
+  });
+
+  test("marks tied candidates as ambiguous", () => {
+    const report = generateEntryDraftEntityMappings({
+      picks: [createPick({ playerName: "Alex Lee" })],
+      entities: [
+        {
+          fantraxId: "ftx-1",
+          name: "Alex Lee",
+          lastSeenSeason: 2026,
+        },
+        {
+          fantraxId: "ftx-2",
+          name: "Alex Lee",
+          lastSeenSeason: 2026,
+        },
+      ],
+    });
+
+    expect(report.ambiguousCount).toBe(1);
+    expect(report.generatedMappings).toEqual([]);
+    expect(report.results[0]?.status).toBe("unresolved_ambiguous_entity");
+  });
+
+  test("marks missing entities as unresolved and ignores blank candidate names", () => {
+    const report = generateEntryDraftEntityMappings({
+      picks: [createPick({ playerName: "No Match Prospect" })],
+      entities: [
+        {
+          fantraxId: "ftx-blank",
+          name: "   ",
+          lastSeenSeason: 2026,
+        },
+      ],
+    });
+
+    expect(report.unresolvedCount).toBe(1);
+    expect(report.generatedMappings).toEqual([]);
+    expect(report.results[0]).toEqual(
+      expect.objectContaining({
+        status: "unresolved_missing_entity",
+        fantraxEntityId: null,
+        candidateNames: [],
+      }),
+    );
+  });
+
+  test("skips placeholder rows with null player names", () => {
+    const report = generateEntryDraftEntityMappings({
+      picks: [createPick({ playerName: null })],
+      entities: [],
+    });
+
+    expect(report.skippedCount).toBe(1);
+    expect(report.generatedMappings).toEqual([]);
+    expect(report.results[0]?.status).toBe("skipped_null_player");
+  });
+});

--- a/src/__tests__/routes.integration.goalies.ts
+++ b/src/__tests__/routes.integration.goalies.ts
@@ -237,7 +237,7 @@ export const registerGoalieRouteIntegrationTests = (): void => {
           },
           {
             teamId: "1",
-            season: 2025,
+            season: 2026,
             reportType: "regular",
             goalieId: "g-new",
             name: "Newest Goalie",

--- a/src/__tests__/routes.integration.players.ts
+++ b/src/__tests__/routes.integration.players.ts
@@ -173,7 +173,7 @@ export const registerPlayerRouteIntegrationTests = (): void => {
           },
           {
             teamId: "1",
-            season: 2025,
+            season: 2026,
             reportType: "regular",
             playerId: "p-new",
             name: "Newest Skater",

--- a/src/__tests__/routes.integration.seasons.ts
+++ b/src/__tests__/routes.integration.seasons.ts
@@ -25,7 +25,7 @@ export const registerSeasonRouteIntegrationTests = (): void => {
         expect(res.statusCode).toBe(HTTP_STATUS.OK);
         expect(res.getHeader("x-stats-data-source")).toBe("db");
         expect(body[0]).toEqual({ season: 2012, text: "2012-2013" });
-        expect(body.at(-1)).toEqual({ season: 2025, text: "2025-2026" });
+        expect(body.at(-1)).toEqual({ season: 2026, text: "2026-2027" });
         expectArraySchema("Season", body);
       } finally {
         await db.cleanup();
@@ -56,6 +56,7 @@ export const registerSeasonRouteIntegrationTests = (): void => {
           { season: 2023, text: "2023-2024" },
           { season: 2024, text: "2024-2025" },
           { season: 2025, text: "2025-2026" },
+          { season: 2026, text: "2026-2027" },
         ]);
         expectArraySchema("Season", body);
       } finally {

--- a/src/__tests__/transactions.import.test.ts
+++ b/src/__tests__/transactions.import.test.ts
@@ -11,6 +11,7 @@ import {
   parseTransactionDateToIso,
   resolveTransactionTeamId,
 } from "../../scripts/transaction-import-lib.js";
+import { CURRENT_SEASON } from "../config/index.js";
 import { createIntegrationDb } from "./integration-db.js";
 
 const getCount = async (
@@ -652,6 +653,10 @@ describe("transaction import helpers", () => {
   test("incrementally reimports only current-season rows at or after the latest watermark", async () => {
     const context = await createIntegrationDb();
     const csvDir = await fs.mkdtemp(path.join(os.tmpdir(), "ffhl-transactions-"));
+    const currentSeason = CURRENT_SEASON;
+    const currentSeasonEndYear = currentSeason + 1;
+    const currentClaimsFile = `claims-${currentSeason}-${currentSeasonEndYear}.csv`;
+    const currentTradesFile = `trades-${currentSeason}-${currentSeasonEndYear}.csv`;
 
     try {
       await context.insertPlayers([
@@ -665,7 +670,7 @@ describe("transaction import helpers", () => {
         },
         {
           teamId: "7",
-          season: 2025,
+          season: currentSeason,
           reportType: "regular",
           playerId: "p-2025-older",
           name: "Season 2025 Older Claim",
@@ -673,7 +678,7 @@ describe("transaction import helpers", () => {
         },
         {
           teamId: "7",
-          season: 2025,
+          season: currentSeason,
           reportType: "regular",
           playerId: "p-2025-latest",
           name: "Season 2025 Latest Claim",
@@ -681,7 +686,7 @@ describe("transaction import helpers", () => {
         },
         {
           teamId: "7",
-          season: 2025,
+          season: currentSeason,
           reportType: "regular",
           playerId: "p-2025-new",
           name: "Season 2025 New Claim",
@@ -689,7 +694,7 @@ describe("transaction import helpers", () => {
         },
         {
           teamId: "16",
-          season: 2025,
+          season: currentSeason,
           reportType: "regular",
           playerId: "p-2025-trade",
           name: "Trade Return",
@@ -699,7 +704,7 @@ describe("transaction import helpers", () => {
       await context.insertGoalies([
         {
           teamId: "16",
-          season: 2025,
+          season: currentSeason,
           reportType: "regular",
           goalieId: "g-2025-drop",
           name: "Trade Drop Goalie",
@@ -710,18 +715,18 @@ describe("transaction import helpers", () => {
         `"Player","Team","Position","Type","Team","Date (EDT)","Period"`,
         `"Season 2024 Claim","EDM","F","Claim","Edmonton Oilers","Mon Mar 3, 2025, 12:00PM","100"`,
       ]);
-      await writeCsv(csvDir, "claims-2025-2026.csv", [
+      await writeCsv(csvDir, currentClaimsFile, [
         `"Player","Team","Position","Type","Team","Date (EDT)","Period"`,
-        `"Season 2025 Older Claim","EDM","F","Claim","Edmonton Oilers","Wed Mar 4, 2026, 12:38PM","149"`,
-        `"Season 2025 Latest Claim","EDM","F","Claim","Edmonton Oilers","Thu Mar 5, 2026, 12:38PM","150"`,
+        `"Season 2025 Older Claim","EDM","F","Claim","Edmonton Oilers","Wed Mar 4, ${currentSeasonEndYear}, 12:38PM","149"`,
+        `"Season 2025 Latest Claim","EDM","F","Claim","Edmonton Oilers","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","150"`,
       ]);
-      await writeCsv(csvDir, "trades-2025-2026.csv", [
+      await writeCsv(csvDir, currentTradesFile, [
         `"Player","Team","Position","From","To","Date (EDT)","Period"`,
-        `"Season 2025 Older Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Wed Mar 4, 2026, 9:12AM","149"`,
-        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Wed Mar 4, 2026, 9:12AM","150"`,
-        `"Season 2025 Latest Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, 2026, 12:38PM","150"`,
-        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Thu Mar 5, 2026, 12:38PM","151"`,
-        `"Trade Drop Goalie","TBL","G","Tampa Bay Lightning","(Drop)","Thu Mar 5, 2026, 12:38PM","151"`,
+        `"Season 2025 Older Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Wed Mar 4, ${currentSeasonEndYear}, 9:12AM","149"`,
+        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Wed Mar 4, ${currentSeasonEndYear}, 9:12AM","150"`,
+        `"Season 2025 Latest Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","150"`,
+        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","151"`,
+        `"Trade Drop Goalie","TBL","G","Tampa Bay Lightning","(Drop)","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","151"`,
       ]);
 
       const firstSummary = await importTransactionsToDb({
@@ -731,37 +736,37 @@ describe("transaction import helpers", () => {
 
       expect(firstSummary).toMatchObject({
         processedFiles: 3,
-        importedSeasons: [2024, 2025],
+        importedSeasons: [2024, currentSeason],
         claimEvents: 4,
         claimItems: 4,
         tradeBlocks: 4,
         tradeItems: 4,
       });
 
-      await writeCsv(csvDir, "claims-2025-2026.csv", [
+      await writeCsv(csvDir, currentClaimsFile, [
         `"Player","Team","Position","Type","Team","Date (EDT)","Period"`,
-        `"Season 2025 New Claim","EDM","F","Claim","Edmonton Oilers","Fri Mar 6, 2026, 12:38PM","151"`,
-        `"Season 2025 Latest Claim","EDM","F","Claim","Edmonton Oilers","Thu Mar 5, 2026, 12:38PM","150"`,
-        `"Season 2025 Older Claim","EDM","F","Claim","Edmonton Oilers","Wed Mar 4, 2026, 12:38PM","149"`,
+        `"Season 2025 New Claim","EDM","F","Claim","Edmonton Oilers","Fri Mar 6, ${currentSeasonEndYear}, 12:38PM","151"`,
+        `"Season 2025 Latest Claim","EDM","F","Claim","Edmonton Oilers","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","150"`,
+        `"Season 2025 Older Claim","EDM","F","Claim","Edmonton Oilers","Wed Mar 4, ${currentSeasonEndYear}, 12:38PM","149"`,
       ]);
-      await writeCsv(csvDir, "trades-2025-2026.csv", [
+      await writeCsv(csvDir, currentTradesFile, [
         `"Player","Team","Position","From","To","Date (EDT)","Period"`,
-        `"Season 2025 Older Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Wed Mar 4, 2026, 9:12AM","149"`,
-        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Wed Mar 4, 2026, 9:12AM","150"`,
-        `"Season 2025 Latest Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, 2026, 12:38PM","150"`,
-        `"2026 Draft Pick, Round 3 (Buffalo Sabres)","","","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, 2026, 12:38PM","150"`,
-        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Thu Mar 5, 2026, 12:38PM","151"`,
-        `"Trade Drop Goalie","TBL","G","Tampa Bay Lightning","(Drop)","Thu Mar 5, 2026, 12:38PM","151"`,
+        `"Season 2025 Older Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Wed Mar 4, ${currentSeasonEndYear}, 9:12AM","149"`,
+        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Wed Mar 4, ${currentSeasonEndYear}, 9:12AM","150"`,
+        `"Season 2025 Latest Claim","EDM","F","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","150"`,
+        `"${currentSeasonEndYear} Draft Pick, Round 3 (Buffalo Sabres)","","","Edmonton Oilers","Tampa Bay Lightning","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","150"`,
+        `"Trade Return","TBL","D","Tampa Bay Lightning","Edmonton Oilers","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","151"`,
+        `"Trade Drop Goalie","TBL","G","Tampa Bay Lightning","(Drop)","Thu Mar 5, ${currentSeasonEndYear}, 12:38PM","151"`,
       ]);
 
       const secondSummary = await importTransactionsToDb({
         db: context.db,
         csvDir,
-        seasons: [2025],
+        seasons: [currentSeason],
         incremental: true,
       });
 
-      expect(secondSummary.importedSeasons).toEqual([2025]);
+      expect(secondSummary.importedSeasons).toEqual([currentSeason]);
       expect(
         await getCount(
           context.db,
@@ -771,73 +776,73 @@ describe("transaction import helpers", () => {
       expect(
         await getCount(
           context.db,
-          "SELECT COUNT(*) AS count FROM claim_events WHERE season = 2025",
+          `SELECT COUNT(*) AS count FROM claim_events WHERE season = ${currentSeason}`,
         ),
       ).toBe(4);
       expect(
         await getCount(
           context.db,
-          "SELECT COUNT(*) AS count FROM trade_source_blocks WHERE season = 2025",
+          `SELECT COUNT(*) AS count FROM trade_source_blocks WHERE season = ${currentSeason}`,
         ),
       ).toBe(4);
       expect(
         await getCount(
           context.db,
-          "SELECT COUNT(*) AS count FROM trade_block_items WHERE trade_source_block_id IN (SELECT id FROM trade_source_blocks WHERE season = 2025)",
+          `SELECT COUNT(*) AS count FROM trade_block_items WHERE trade_source_block_id IN (SELECT id FROM trade_source_blocks WHERE season = ${currentSeason})`,
         ),
       ).toBe(5);
 
       const currentClaimRows = await context.db.execute(
         `SELECT source_file, source_group_index, occurred_at
          FROM claim_events
-         WHERE season = 2025
+         WHERE season = ${currentSeason}
          ORDER BY source_file ASC, source_group_index ASC`,
       );
       expect(currentClaimRows.rows).toEqual([
         {
-          source_file: "claims-2025-2026.csv",
+          source_file: currentClaimsFile,
           source_group_index: 0,
-          occurred_at: "2026-03-04T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-04T16:38:00.000Z`,
         },
         {
-          source_file: "claims-2025-2026.csv",
+          source_file: currentClaimsFile,
           source_group_index: 1,
-          occurred_at: "2026-03-06T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-06T16:38:00.000Z`,
         },
         {
-          source_file: "claims-2025-2026.csv",
+          source_file: currentClaimsFile,
           source_group_index: 2,
-          occurred_at: "2026-03-05T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-05T16:38:00.000Z`,
         },
         {
-          source_file: "trades-2025-2026.csv",
+          source_file: currentTradesFile,
           source_group_index: 0,
-          occurred_at: "2026-03-05T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-05T16:38:00.000Z`,
         },
       ]);
 
       const tradeRows = await context.db.execute(
         `SELECT source_block_index, occurred_at
          FROM trade_source_blocks
-         WHERE season = 2025
+         WHERE season = ${currentSeason}
          ORDER BY source_block_index ASC`,
       );
       expect(tradeRows.rows).toEqual([
         {
           source_block_index: 0,
-          occurred_at: "2026-03-04T13:12:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-04T13:12:00.000Z`,
         },
         {
           source_block_index: 1,
-          occurred_at: "2026-03-04T13:12:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-04T13:12:00.000Z`,
         },
         {
           source_block_index: 2,
-          occurred_at: "2026-03-05T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-05T16:38:00.000Z`,
         },
         {
           source_block_index: 3,
-          occurred_at: "2026-03-05T16:38:00.000Z",
+          occurred_at: `${currentSeasonEndYear}-03-05T16:38:00.000Z`,
         },
       ]);
     } finally {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -8,7 +8,7 @@ import type {
 import type { Report, Team } from "../shared/types/core.js";
 
 export const START_SEASON = 2012;
-export const CURRENT_SEASON = 2025;
+export const CURRENT_SEASON = 2026;
 
 export const REPORT_TYPES = [
   "playoffs",

--- a/src/features/drafts/entity-mappings.ts
+++ b/src/features/drafts/entity-mappings.ts
@@ -1,0 +1,187 @@
+import type { EntryDraftPick } from "./parser.js";
+
+export type FantraxEntityCandidate = {
+  fantraxId: string;
+  name: string;
+  lastSeenSeason: number;
+};
+
+export type EntryDraftEntityMappingRecord = {
+  id: number;
+  season: number;
+  pickNumber: number;
+  draftedTeamId: string;
+  fantraxEntityId: string;
+  fantraxEntityName: string;
+};
+
+export type DraftEntityMatchStatus =
+  | "matched_exact_name"
+  | "matched_latest_last_seen"
+  | "unresolved_missing_entity"
+  | "unresolved_ambiguous_entity"
+  | "skipped_null_player";
+
+export type DraftEntityMatchResult = {
+  season: number;
+  pickNumber: number;
+  draftedTeamId: string;
+  playerName: string | null;
+  status: DraftEntityMatchStatus;
+  fantraxEntityId: string | null;
+  fantraxEntityName: string | null;
+  candidateNames: string[];
+};
+
+export type EntryDraftEntityGenerationReport = {
+  generatedMappings: EntryDraftEntityMappingRecord[];
+  results: DraftEntityMatchResult[];
+  matchedCount: number;
+  unresolvedCount: number;
+  ambiguousCount: number;
+  skippedCount: number;
+};
+
+/** @internal Test-only export for draft entity name normalization coverage. */
+export const normalizeDraftEntityName = (value: string): string =>
+  value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .replace(/['’]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+const buildCandidateLookup = (
+  entities: readonly FantraxEntityCandidate[],
+): ReadonlyMap<string, FantraxEntityCandidate[]> => {
+  const byName = new Map<string, FantraxEntityCandidate[]>();
+
+  for (const entity of entities) {
+    const normalizedName = normalizeDraftEntityName(entity.name);
+    if (!normalizedName) {
+      continue;
+    }
+
+    const existing = byName.get(normalizedName);
+    if (existing) {
+      existing.push(entity);
+    } else {
+      byName.set(normalizedName, [entity]);
+    }
+  }
+
+  return byName;
+};
+
+const compareCandidates = (
+  left: FantraxEntityCandidate,
+  right: FantraxEntityCandidate,
+): number =>
+  right.lastSeenSeason - left.lastSeenSeason ||
+  left.name.localeCompare(right.name) ||
+  left.fantraxId.localeCompare(right.fantraxId);
+
+const chooseCandidate = (
+  candidates: readonly FantraxEntityCandidate[],
+):
+  | { status: "matched_exact_name" | "matched_latest_last_seen"; candidate: FantraxEntityCandidate }
+  | { status: "unresolved_missing_entity" | "unresolved_ambiguous_entity"; candidate: null } => {
+  if (candidates.length === 0) {
+    return { status: "unresolved_missing_entity", candidate: null };
+  }
+
+  const sorted = [...candidates].sort(compareCandidates);
+  if (sorted.length === 1) {
+    return { status: "matched_exact_name", candidate: sorted[0] };
+  }
+
+  const latest = sorted[0];
+  const next = sorted[1];
+
+  if (latest.lastSeenSeason > next.lastSeenSeason) {
+    return { status: "matched_latest_last_seen", candidate: latest };
+  }
+
+  return { status: "unresolved_ambiguous_entity", candidate: null };
+};
+
+export const generateEntryDraftEntityMappings = (args: {
+  picks: readonly EntryDraftPick[];
+  entities: readonly FantraxEntityCandidate[];
+}): EntryDraftEntityGenerationReport => {
+  const candidatesByName = buildCandidateLookup(args.entities);
+  const results: DraftEntityMatchResult[] = [];
+  const generatedMappings: EntryDraftEntityMappingRecord[] = [];
+  let matchedCount = 0;
+  let unresolvedCount = 0;
+  let ambiguousCount = 0;
+  let skippedCount = 0;
+
+  for (const pick of args.picks) {
+    const baseResult = {
+      season: pick.season,
+      pickNumber: pick.pickNumber,
+      draftedTeamId: pick.draftedTeam.teamId,
+      playerName: pick.playerName,
+    };
+
+    if (pick.playerName === null) {
+      skippedCount += 1;
+      results.push({
+        ...baseResult,
+        status: "skipped_null_player",
+        fantraxEntityId: null,
+        fantraxEntityName: null,
+        candidateNames: [],
+      });
+      continue;
+    }
+
+    const normalizedName = normalizeDraftEntityName(pick.playerName);
+    const candidates = candidatesByName.get(normalizedName) ?? [];
+    const resolution = chooseCandidate(candidates);
+
+    if (resolution.candidate) {
+      matchedCount += 1;
+      generatedMappings.push({
+        id: generatedMappings.length + 1,
+        season: pick.season,
+        pickNumber: pick.pickNumber,
+        draftedTeamId: pick.draftedTeam.teamId,
+        fantraxEntityId: resolution.candidate.fantraxId,
+        fantraxEntityName: resolution.candidate.name,
+      });
+      results.push({
+        ...baseResult,
+        status: resolution.status,
+        fantraxEntityId: resolution.candidate.fantraxId,
+        fantraxEntityName: resolution.candidate.name,
+        candidateNames: candidates.map((candidate) => candidate.name),
+      });
+      continue;
+    }
+
+    if (resolution.status === "unresolved_ambiguous_entity") {
+      ambiguousCount += 1;
+    } else {
+      unresolvedCount += 1;
+    }
+
+    results.push({
+      ...baseResult,
+      status: resolution.status,
+      fantraxEntityId: null,
+      fantraxEntityName: null,
+      candidateNames: candidates.map((candidate) => candidate.name),
+    });
+  }
+
+  return {
+    generatedMappings,
+    results,
+    matchedCount,
+    unresolvedCount,
+    ambiguousCount,
+    skippedCount,
+  };
+};


### PR DESCRIPTION
Summary
- Update `CURRENT_SEASON` to 2026 and align season-sensitive route and transaction tests with the new current-season behavior.
- Refresh season rollover and importing docs so current-season commands use defaults where appropriate and entry-draft handling is documented more clearly.
- Add `draft:generate-entities` plus draft entity matching logic and tests so `entities-entry-draft.json` can be generated from existing `fantrax_entities` with unresolved picks reported.

Verification
- `npm run verify`