### PR TITLE
Fix: Use year-to-date Fantrax regular stats

### DIFF
--- a/src/__tests__/fantrax.roster-url.test.ts
+++ b/src/__tests__/fantrax.roster-url.test.ts
@@ -1,0 +1,30 @@
+import { buildRosterUrlForSeason } from "../features/fantrax/roster-url.js";
+
+describe("Fantrax roster URL builder", () => {
+  test("builds the regular roster-by-date URL without season projection override by default", () => {
+    expect(
+      buildRosterUrlForSeason({
+        leagueId: "league 1",
+        rosterTeamId: "team/2",
+        startDate: "2025-10-07",
+        endDate: "2026-03-15",
+      }),
+    ).toBe(
+      "https://www.fantrax.com/fantasy/league/league%201/team/roster;teamId=team%2F2;timeframeTypeCode=BY_DATE;startDate=2025-10-07;endDate=2026-03-15;statsType=3",
+    );
+  });
+
+  test("adds year-to-date season selection for current regular season imports", () => {
+    expect(
+      buildRosterUrlForSeason({
+        leagueId: "league 1",
+        rosterTeamId: "team/2",
+        startDate: "2026-10-07",
+        endDate: "2027-03-15",
+        includeYearToDateSeason: true,
+      }),
+    ).toBe(
+      "https://www.fantrax.com/fantasy/league/league%201/team/roster;teamId=team%2F2;timeframeTypeCode=BY_DATE;startDate=2026-10-07;endDate=2027-03-15;seasonOrProjection=SEASON_31n_YEAR_TO_DATE;statsType=3",
+    );
+  });
+});

--- a/src/features/fantrax/roster-url.ts
+++ b/src/features/fantrax/roster-url.ts
@@ -1,0 +1,19 @@
+import { FANTRAX_URLS } from "../../config/index.js";
+
+export const buildRosterUrlForSeason = (args: {
+  leagueId: string;
+  rosterTeamId: string;
+  startDate: string;
+  endDate: string;
+  includeYearToDateSeason?: boolean;
+}): string => {
+  const leagueId = encodeURIComponent(args.leagueId);
+  const rosterTeamId = encodeURIComponent(args.rosterTeamId);
+  const startDate = encodeURIComponent(args.startDate);
+  const endDate = encodeURIComponent(args.endDate);
+  const seasonOrProjection = args.includeYearToDateSeason
+    ? ";seasonOrProjection=SEASON_31n_YEAR_TO_DATE"
+    : "";
+
+  return `${FANTRAX_URLS.league}/${leagueId}/team/roster;teamId=${rosterTeamId};timeframeTypeCode=BY_DATE;startDate=${startDate};endDate=${endDate}${seasonOrProjection};statsType=3`;
+};

--- a/src/playwright/helpers.ts
+++ b/src/playwright/helpers.ts
@@ -5,6 +5,7 @@ import path from "path";
 import type { BrowserContext, Locator, Page } from "playwright";
 
 import { DEFAULT_CSV_OUT_DIR, FANTRAX_URLS } from "../config/index.js";
+export { buildRosterUrlForSeason } from "../features/fantrax/roster-url.js";
 import type { Team } from "../shared/types/index.js";
 
 export type RoundWindow = { startDate: string; endDate: string; label: string };
@@ -1008,20 +1009,6 @@ export const getRosterTeamIdFromStandingsByNames = async (
       lastClickError,
     )}`,
   );
-};
-
-export const buildRosterUrlForSeason = (args: {
-  leagueId: string;
-  rosterTeamId: string;
-  startDate: string;
-  endDate: string;
-}): string => {
-  const leagueId = encodeURIComponent(args.leagueId);
-  const rosterTeamId = encodeURIComponent(args.rosterTeamId);
-  const startDate = encodeURIComponent(args.startDate);
-  const endDate = encodeURIComponent(args.endDate);
-
-  return `${FANTRAX_URLS.league}/${leagueId}/team/roster;teamId=${rosterTeamId};timeframeTypeCode=BY_DATE;startDate=${startDate};endDate=${endDate};statsType=3`;
 };
 
 export type RosterCsvKind = "regular" | "playoffs";

--- a/src/playwright/import-league-regular.ts
+++ b/src/playwright/import-league-regular.ts
@@ -2,7 +2,7 @@ import { chromium, type Browser } from "playwright";
 import { existsSync, mkdirSync } from "fs";
 import path from "path";
 
-import { TEAMS } from "../config/index.js";
+import { CURRENT_SEASON, TEAMS } from "../config/index.js";
 import {
   AUTH_STATE_PATH,
   buildRosterCsvFileName,
@@ -175,6 +175,7 @@ const main = async (): Promise<void> => {
         rosterTeamId,
         startDate: options.startDate,
         endDate: options.endDate,
+        includeYearToDateSeason: options.year === CURRENT_SEASON,
       });
 
       console.info(`[${team.name}] goto ${rosterUrl}`);


### PR DESCRIPTION
## Summary
- add a dedicated Fantrax roster URL builder for regular-season imports
- include `seasonOrProjection=SEASON_31n_YEAR_TO_DATE` only for current regular season imports
- keep non-current seasons and other import flows unchanged
- add focused tests for the roster URL behavior

## Verification
- `npm run verify`

## Notes
- this fixes current regular-season parsing when Fantrax defaults the page to projected stats
- playoffs and historical regular seasons are unaffected